### PR TITLE
calling `searchIndex` twice causes the process to hang, so check to see if the index has already been "opened" before opening it again.

### DIFF
--- a/src/store/blockstore-level.ts
+++ b/src/store/blockstore-level.ts
@@ -10,7 +10,7 @@ import type { Blockstore } from 'interface-blockstore';
 //  and Chrome for Android.
 export class BlockstoreLevel implements Blockstore {
   db: Level<string, Uint8Array>;
-
+  status: 'opening' | 'closing' | 'open';
   /**
    * @param location - must be a directory path (relative or absolute) where LevelDB will store its
    * files, or in browsers, the name of
@@ -19,6 +19,7 @@ export class BlockstoreLevel implements Blockstore {
    */
   constructor(location: string) {
     this.db = new Level(location, { keyEncoding: 'utf8', valueEncoding: 'binary' });
+    this.status = this.db.status;
   }
 
   async open(): Promise<void> {

--- a/src/store/message-store-level.ts
+++ b/src/store/message-store-level.ts
@@ -47,6 +47,8 @@ export class MessageStoreLevel implements MessageStore {
     // TODO: parameterize `name`
     // calling `searchIndex` twice causes the process to hang, so check to see if the index
     // has already been "opened" before opening it again.
+    if(this.db.status === 'open' || this.db.status === 'opening') return;
+
     if (!this.index) {
       this.index = await searchIndex({ name: this.config.indexLocation });
     }


### PR DESCRIPTION
This is a PR addressing the above comment that is under the TODOs. I've attached a field to blockstore-level that allows access to the instance db status, and a simple check on that status to determine `open()` logic. Please let me know if adjustments are needed!