### PR TITLE
jose updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Code Coverage
 
-![Statements](https://img.shields.io/badge/statements-71.96%25-red.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-62.31%25-red.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-65.11%25-red.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-73.72%25-red.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-72.18%25-red.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-62.31%25-red.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-65.11%25-red.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-73.92%25-red.svg?style=flat)
 
 
 

--- a/src/interfaces/permissions/permissions-request.ts
+++ b/src/interfaces/permissions/permissions-request.ts
@@ -1,7 +1,6 @@
 import { DIDResolver } from '../../did/did-resolver';
 
 import type { Ability, Conditions } from './permission';
-import type { JwsFlattened } from '../../jose/jws';
 import type { MessageStore } from '../../store/message-store';
 
 /**
@@ -20,7 +19,7 @@ export async function handlePermissionsRequest(
 
 export type PermissionsRequestMessage = {
   descriptor: PermissionsRequestDescriptor,
-  attestation: JwsFlattened
+  attestation: string
 };
 
 export type PermissionsRequestDescriptor = {

--- a/src/jose/algorithms/ed25519.ts
+++ b/src/jose/algorithms/ed25519.ts
@@ -1,12 +1,17 @@
+import type { Jwk } from '../types';
+
 import * as ed25519 from '@noble/ed25519';
 import { base64url } from 'multiformats/bases/base64';
 
 /**
  * An Ed25519 public key in JWK format.
  */
-export type JwkEd25519Public = {
-  kty: 'OKP';
+export type JwkEd25519Public = Jwk & {
+  alg: 'EdDSA'
   crv: 'Ed25519';
+  kid: string;
+  kty: 'OKP';
+  use: 'sig';
   x: string;
 };
 
@@ -22,7 +27,7 @@ export type JwkEd25519Private = JwkEd25519Public & {
  * Generates ED25519 public-private key pair.
  * @returns Public and private ED25519 keys in JWK format.
  */
-export async function generateKeyPair (): Promise<{
+export async function generateKeyPair (kid: string): Promise<{
   publicKeyJwk: JwkEd25519Public,
   privateKeyJwk: JwkEd25519Private
 }> {
@@ -32,7 +37,14 @@ export async function generateKeyPair (): Promise<{
   const d = base64url.baseEncode(privateKeyBytes);
   const x = base64url.baseEncode(publicKeyBytes);
 
-  const publicKeyJwk: JwkEd25519Public = { kty: 'OKP', crv: 'Ed25519', x };
+  const publicKeyJwk: JwkEd25519Public = {
+    alg : 'EdDSA',
+    crv : 'Ed25519',
+    kid,
+    kty : 'OKP',
+    use : 'sig',
+    x
+  };
   const privateKeyJwk: Required<JwkEd25519Private> = { ...publicKeyJwk, d };
 
   return { publicKeyJwk, privateKeyJwk };

--- a/src/jose/algorithms/secp256k1.ts
+++ b/src/jose/algorithms/secp256k1.ts
@@ -1,3 +1,5 @@
+import type { Jwk } from '../types';
+
 import * as secp256k1 from '@noble/secp256k1';
 
 import { base64url } from 'multiformats/bases/base64';
@@ -9,9 +11,12 @@ import { sha256 } from 'multiformats/hashes/sha2';
  * https://www.iana.org/assignments/jose/jose.xhtml#web-key-elliptic-curve
  * https://datatracker.ietf.org/doc/html/draft-ietf-cose-webauthn-algorithms-06#section-3.1
  */
-export type JwkSecp256k1Public = {
-  kty: 'EC';
+export type JwkSecp256k1Public = Jwk & {
+  alg: 'ES256K';
   crv: 'secp256k1';
+  kid: string;
+  kty: 'EC';
+  use: 'sig';
   x: string;
   y: string;
 };
@@ -27,7 +32,7 @@ export type JwkSecp256k1Private = JwkSecp256k1Public & {
  * generates a random keypair
  * @returns the public and private keys as JWKs
  */
-export async function generateKeyPair(): Promise<{publicKeyJwk: JwkSecp256k1Public, privateKeyJwk: JwkSecp256k1Private}> {
+export async function generateKeyPair(kid: string): Promise<{publicKeyJwk: JwkSecp256k1Public, privateKeyJwk: JwkSecp256k1Private}> {
   const privateKeyBytes = secp256k1.utils.randomPrivateKey();
   // the public key is uncompressed which means that it contains both the x and y values.
   // the first byte is a header that indicates whether the key is uncompressed (0x04 if uncompressed).
@@ -40,7 +45,15 @@ export async function generateKeyPair(): Promise<{publicKeyJwk: JwkSecp256k1Publ
   const x = base64url.baseEncode(publicKeyBytes.subarray(1, 33));
   const y = base64url.baseEncode(publicKeyBytes.subarray(33, 65));
 
-  const publicKeyJwk: JwkSecp256k1Public = { kty: 'EC', crv: 'secp256k1', x, y };
+  const publicKeyJwk: JwkSecp256k1Public = {
+    alg : 'ES256K',
+    kid,
+    kty : 'EC',
+    use : 'sig',
+    crv : 'secp256k1',
+    x,
+    y
+  };
   const privateKeyJwk: Required<JwkSecp256k1Private> = { ...publicKeyJwk, d };
 
   return { publicKeyJwk, privateKeyJwk };

--- a/src/jose/types.ts
+++ b/src/jose/types.ts
@@ -1,0 +1,7 @@
+export interface Jwk {
+  alg: string;
+  crv: string;
+  kid: string;
+  kty: string;
+  use: string;
+}

--- a/src/message.ts
+++ b/src/message.ts
@@ -71,10 +71,12 @@ export async function verifyMessageSignature(message: Message, didResolver: DIDR
   const { descriptor, attestation } = message;
   let providedCID: CID;
 
+  const [protectedHeader, payload] = attestation.split('.');
+
   // check to ensure that attestation payload is a valid CID
   try {
     // `baseDecode` throws SyntaxError: Unexpected end of data if payload is not base64
-    const payloadBytes = base64url.baseDecode(attestation.payload);
+    const payloadBytes = base64url.baseDecode(payload);
 
     // `decode` throws `Error` if the bytes provided do not contain a valid binary representation
     //  of a CID.
@@ -109,7 +111,7 @@ export async function verifyMessageSignature(message: Message, didResolver: DIDR
   //  - use public key to verify signature
 
   // `baseDecode` throws SyntaxError: Unexpected end of data if paylod is not base64
-  const protectedBytes = base64url.baseDecode(attestation.protected);
+  const protectedBytes = base64url.baseDecode(protectedHeader);
   const protectedJson = new TextDecoder().decode(protectedBytes);
 
   const { kid } = JSON.parse(protectedJson);

--- a/tests/jose/jws.spec.ts
+++ b/tests/jose/jws.spec.ts
@@ -9,23 +9,21 @@ chai.use(chaiAsPromised);
 
 describe('Jws', () => {
   it('should sign and verify secp256k1 signature using a key vector correctly',  async () => {
-    const { publicKeyJwk, privateKeyJwk } = await generateSecp256k1Jwk();
+    const { publicKeyJwk, privateKeyJwk } = await generateSecp256k1Jwk('did:jank:alice');
 
-    const protectedHeader = { alg: 'ES256K', anyHeader: 'anyHeaderValue' };
     const payloadBytes = new TextEncoder().encode('anyPayloadValue');
-    const jwsObject = await jws.sign(protectedHeader, payloadBytes, privateKeyJwk);
+    const jwsCompact = await jws.sign(payloadBytes, privateKeyJwk);
 
-    const verificationResult = await jws.verify(jwsObject, publicKeyJwk);
+    const verificationResult = await jws.verify(jwsCompact, publicKeyJwk);
 
     expect(verificationResult).to.be.true;
   });
 
   it('should sign and verify ed25519 signature using an appropriate keypair', async () => {
-    const { publicKeyJwk, privateKeyJwk } = await generateEd25519Jwk();
-
-    const protectedHeader = { anyHeader: 'anyHeaderValue' };
+    const { publicKeyJwk, privateKeyJwk } = await generateEd25519Jwk('did:jank:alice');;
     const payloadBytes = new TextEncoder().encode('anyPayloadValue');
-    const jwsObject = await jws.sign(protectedHeader, payloadBytes, privateKeyJwk);
+
+    const jwsObject = await jws.sign(payloadBytes, privateKeyJwk);
 
     const verificationResult = await jws.verify(jwsObject, publicKeyJwk);
 
@@ -33,13 +31,12 @@ describe('Jws', () => {
   });
 
   it('should throw error if attempting to sign using an unsupported JWK',  async () => {
-    const { privateKeyJwk } = await generateEd25519Jwk();
+    const { privateKeyJwk } = await generateEd25519Jwk('did:jank:alice');
     const unsupportedJwk = { randomUnsupportedProperty: 'anyValue', ...privateKeyJwk as any }; // Clone private key.
     unsupportedJwk.crv = 'derp';
 
-    const protectedHeader = { anyHeader: 'anyHeaderValue' };
     const payloadBytes = new TextEncoder().encode('anyPayloadValue');
-    const signingPromise = jws.sign(protectedHeader, payloadBytes, unsupportedJwk);
+    const signingPromise = jws.sign(payloadBytes, unsupportedJwk);
 
     await expect(signingPromise).to.be.rejectedWith('unsupported crv');
   });

--- a/tests/message.spec.ts
+++ b/tests/message.spec.ts
@@ -8,7 +8,6 @@ import * as jws from '../src/jose/jws';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 
-import { base64url } from 'multiformats/bases/base64';
 import { CID } from 'multiformats/cid';
 import { generateEd25519Jwk, generateSecp256k1Jwk } from '../src/jose/jwk';
 import { verifyMessageSignature } from '../src/message';

--- a/tests/store/message-store.spec.ts
+++ b/tests/store/message-store.spec.ts
@@ -76,11 +76,7 @@ describe('MessageStoreLevel Tests', () => {
           'objectId'  : '03754d75-c6b9-4fdd-891f-7eb2ad4bbd21',
           'requester' : 'did:jank:alice'
         },
-        'attestation': {
-          'payload'   : 'farts',
-          'protected' : 'farts',
-          'signature' : 'farts'
-        }
+        'attestation': 'doodoodoo'
       };
 
       await messageStore.put(msg);
@@ -106,11 +102,7 @@ describe('MessageStoreLevel Tests', () => {
           'objectId'  : '03754d75-c6b9-4fdd-891f-7eb2ad4bbd21',
           'requester' : 'did:jank:alice'
         },
-        'attestation': {
-          'payload'   : 'farts',
-          'protected' : 'farts',
-          'signature' : 'farts'
-        }
+        'attestation': 'doodoodoo'
       };
 
       await messageStore.put(msg);


### PR DESCRIPTION
* `jws.sign` now produces a compact JWS instead of a flattened JWS
* ensure that `alg`, `kid`, `kty`, and `crv` exist on all JWKs. This was done so that we can set `alg` and `kid` in the protected header of a JWS when signing