### PR TITLE
refactored entire codebase to use encoder.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Code Coverage
 
-![Statements](https://img.shields.io/badge/statements-79.5%25-red.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-86.98%25-yellow.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-80.68%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-79.5%25-red.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-79.55%25-red.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-86.94%25-yellow.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-81.37%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-79.55%25-red.svg?style=flat)
 
 
 ## Introduction

--- a/src/did/did-key-resolver.ts
+++ b/src/did/did-key-resolver.ts
@@ -2,7 +2,7 @@ import type { DidMethodResolver, DidResolutionResult, DIDDocument } from './did-
 
 import varint from 'varint';
 import { base58btc } from 'multiformats/bases/base58';
-import { base64url } from 'multiformats/bases/base64';
+import * as encoder from '../utils/encoder';
 import { Did } from './did';
 import { ed25519 } from '../../src/jose/algorithms/signing/ed25519';
 import { PrivateJwk, PublicJwk } from '../jose/types';
@@ -117,7 +117,7 @@ export class DidKeyResolver implements DidMethodResolver {
 
     // multicodec code for Ed25519 public keys
     const ed25519Multicodec = varint.encode(0xed);
-    const publicKeyBytes = base64url.baseDecode(publicJwk.x);
+    const publicKeyBytes = encoder.base64urlToBytes(publicJwk.x);
     const idBytes = new Uint8Array(ed25519Multicodec.length + publicKeyBytes.byteLength);
     idBytes.set(ed25519Multicodec, 0);
     idBytes.set(publicKeyBytes, ed25519Multicodec.length);

--- a/src/interfaces/collections/handlers/collections-write.ts
+++ b/src/interfaces/collections/handlers/collections-write.ts
@@ -1,7 +1,6 @@
 import type { CollectionsWriteMessage } from '../types';
 import type { MethodHandler } from '../../types';
-
-import { base64url } from 'multiformats/bases/base64';
+import * as encoder from '../../../utils/encoder';
 import { CollectionsWrite } from '../messages/collections-write';
 import { getDagCid } from '../../../utils/data';
 import { MessageReply } from '../../../core';
@@ -15,7 +14,7 @@ export const handleCollectionsWrite: MethodHandler = async (
     // verify dataCid matches given data
     const incomingMessage = message as CollectionsWriteMessage;
     if (incomingMessage.encodedData !== undefined) {
-      const rawData = base64url.baseDecode(incomingMessage.encodedData);
+      const rawData = encoder.base64urlToBytes(incomingMessage.encodedData);
       const actualDataCid = (await getDagCid(rawData)).toString();
 
       if (actualDataCid !== incomingMessage.descriptor.dataCid) {

--- a/src/interfaces/collections/messages/collections-write.ts
+++ b/src/interfaces/collections/messages/collections-write.ts
@@ -1,7 +1,7 @@
 import type { AuthCreateOptions, Authorizable, AuthVerificationResult } from '../../../core/types';
 import type { CollectionsWriteDescriptor, CollectionsWriteMessage } from '../types';
 import { authenticate, authorize, validateSchema } from '../../../core/auth';
-import { base64url } from 'multiformats/bases/base64';
+import * as encoder from '../../../utils/encoder';
 import { DidResolver } from '../../../did/did-resolver';
 import { getDagCid } from '../../../utils/data';
 import { Jws } from '../../../jose/jws/jws';
@@ -58,7 +58,7 @@ export class CollectionsWrite extends Message implements Authorizable {
     const messageType = descriptor.method;
     validate(messageType, { descriptor, authorization: {} });
 
-    const encodedData = base64url.baseEncode(options.data);
+    const encodedData = encoder.bytesToBase64Url(options.data);
     const authorization = await Jws.sign({ descriptor }, options.signatureInput);
     const message = { descriptor, authorization, encodedData };
 

--- a/src/jose/algorithms/signing/ed25519.ts
+++ b/src/jose/algorithms/signing/ed25519.ts
@@ -1,6 +1,5 @@
 import * as Ed25519 from '@noble/ed25519';
-import { base64url } from 'multiformats/bases/base64';
-
+import * as encoder from '../../../utils/encoder';
 import type { PrivateJwk, PublicJwk, Signer } from '../../types';
 
 function validateKey(jwk: PrivateJwk | PublicJwk): void {
@@ -10,7 +9,7 @@ function validateKey(jwk: PrivateJwk | PublicJwk): void {
 }
 
 function publicKeyToJwk(publicKeyBytes: Uint8Array): PublicJwk {
-  const x = base64url.baseEncode(publicKeyBytes);
+  const x = encoder.bytesToBase64Url(publicKeyBytes);
 
   const publicJwk: PublicJwk = {
     alg : 'EdDSA',
@@ -26,14 +25,14 @@ export const ed25519: Signer = {
   sign: (content: Uint8Array, privateJwk: PrivateJwk): Promise<Uint8Array> => {
     validateKey(privateJwk);
 
-    const privateKeyBytes = base64url.baseDecode(privateJwk.d);
+    const privateKeyBytes = encoder.base64urlToBytes(privateJwk.d);
 
     return Ed25519.sign(content, privateKeyBytes);
   },
 
   verify: (content: Uint8Array, signature: Uint8Array, publicJwk: PublicJwk): Promise<boolean> => {
     validateKey(publicJwk);
-    const publicKeyBytes = base64url.baseDecode(publicJwk.x);
+    const publicKeyBytes = encoder.base64urlToBytes(publicJwk.x);
 
     return Ed25519.verify(signature, content, publicKeyBytes);
   },
@@ -42,7 +41,7 @@ export const ed25519: Signer = {
     const privateKeyBytes = Ed25519.utils.randomPrivateKey();
     const publicKeyBytes = await Ed25519.getPublicKey(privateKeyBytes);
 
-    const d = base64url.baseEncode(privateKeyBytes);
+    const d = encoder.bytesToBase64Url(privateKeyBytes);
 
     const publicJwk = publicKeyToJwk(publicKeyBytes);
     const privateJwk: PrivateJwk = { ...publicJwk, d };

--- a/src/jose/algorithms/signing/secp256k1.ts
+++ b/src/jose/algorithms/signing/secp256k1.ts
@@ -1,6 +1,5 @@
 import * as Secp256k1 from '@noble/secp256k1';
-
-import { base64url } from 'multiformats/bases/base64';
+import * as encoder from '../../../utils/encoder';
 import { sha256 } from 'multiformats/hashes/sha2';
 
 import type { PublicJwk, PrivateJwk, Signer } from '../../types';
@@ -28,8 +27,8 @@ function publicKeyToJwk(publicKeyBytes: Uint8Array): PublicJwk {
   // bytes 33 - 64 represent Y
 
   // skip the first byte because it's used as a header to indicate whether the key is uncompressed
-  const x = base64url.baseEncode(uncompressedPublicKeyBytes.subarray(1, 33));
-  const y = base64url.baseEncode(uncompressedPublicKeyBytes.subarray(33, 65));
+  const x = encoder.bytesToBase64Url(uncompressedPublicKeyBytes.subarray(1, 33));
+  const y = encoder.bytesToBase64Url(uncompressedPublicKeyBytes.subarray(33, 65));
 
   const publicJwk: PublicJwk = {
     alg : 'ES256K',
@@ -49,7 +48,7 @@ export const secp256k1: Signer = {
     // the underlying lib expects us to hash the content ourselves:
     // https://github.com/paulmillr/noble-secp256k1/blob/97aa518b9c12563544ea87eba471b32ecf179916/index.ts#L1160
     const hashedContent = await sha256.encode(content);
-    const privateKeyBytes = base64url.baseDecode(privateJwk.d);
+    const privateKeyBytes = encoder.base64urlToBytes(privateJwk.d);
 
     return await Secp256k1.sign(hashedContent, privateKeyBytes, { der: false });
   },
@@ -57,8 +56,8 @@ export const secp256k1: Signer = {
   verify: async (content: Uint8Array, signature: Uint8Array, publicJwk: PublicJwk): Promise<boolean> => {
     validateKey(publicJwk);
 
-    const xBytes = base64url.baseDecode(publicJwk.x);
-    const yBytes = base64url.baseDecode(publicJwk.y);
+    const xBytes = encoder.base64urlToBytes(publicJwk.x);
+    const yBytes = encoder.base64urlToBytes(publicJwk.y);
 
     const publicKeyBytes = new Uint8Array(xBytes.length + yBytes.length + 1);
 
@@ -78,7 +77,7 @@ export const secp256k1: Signer = {
     const privateKeyBytes = Secp256k1.utils.randomPrivateKey();
     const publicKeyBytes = await Secp256k1.getPublicKey(privateKeyBytes);
 
-    const d = base64url.baseEncode(privateKeyBytes);
+    const d = encoder.bytesToBase64Url(privateKeyBytes);
     const publicJwk: PublicJwk = publicKeyToJwk(publicKeyBytes);
     const privateJwk: PrivateJwk = { ...publicJwk, d };
 

--- a/src/store/message-store-level.ts
+++ b/src/store/message-store-level.ts
@@ -1,7 +1,6 @@
 import type { BaseMessage, DataReferencingMessage } from '../core/types';
 import type { MessageStore } from './message-store';
-
-import { base64url } from 'multiformats/bases/base64';
+import * as encoder from '../utils/encoder';
 import { BlockstoreLevel } from './blockstore-level';
 import { CID } from 'multiformats/cid';
 import { exporter } from 'ipfs-unixfs-exporter';
@@ -91,7 +90,7 @@ export class MessageStoreLevel implements MessageStore {
       offset += chunk.length;
     }
 
-    dataReferencingMessage.encodedData = base64url.baseEncode(dataBytes);
+    dataReferencingMessage.encodedData = encoder.bytesToBase64Url(dataBytes);
 
     return messageJson;
   }
@@ -147,7 +146,7 @@ export class MessageStoreLevel implements MessageStore {
 
     // if `encodedData` is present we'll decode it then chunk it and store it as unix-fs dag-pb encoded
     if (encodedData) {
-      const content = base64url.baseDecode(encodedData);
+      const content = encoder.base64urlToBytes(encodedData);
       const chunk = importer([{ content }], this.db, { cidVersion: 1 });
 
       // for some reason no-unused-vars doesn't work in for loops. it's not entirely surprising because

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -1,4 +1,4 @@
-import { base64url } from 'multiformats/bases/base64';
+import * as encoder from '../utils/encoder';
 import { CID } from 'multiformats/cid';
 import { importer } from 'ipfs-unixfs-importer';
 
@@ -21,7 +21,7 @@ export function toBytes(data: Data): Uint8Array {
 
 export function base64UrlEncode(data: Data): string {
   const dataBytes = toBytes(data);
-  return base64url.baseEncode(dataBytes);
+  return encoder.bytesToBase64Url(dataBytes);
 }
 
 /**


### PR DESCRIPTION
This change was to implement a refactor of the codebase which would modify the files to use the encoder.ts file instead of directly referencing underlying dependencies/libraries.