### PR TITLE
Browser Bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,52 +12,19 @@ This repository contains a reference implementation of Decentralized Web Node (D
 Proposals and issues for the specification itself should be submitted as pull requests to the [spec repo](https://github.com/decentralized-identity/decentralized-web-node).
 
 ## Installation
-Since this SDK is still in early stages, we haven't yet published to npm. Until then, we suggest using [`npm link`](https://docs.npmjs.com/cli/v8/commands/npm-link) to use this SDK in your own project. Steps:
 ```bash
-# clone this repo somewhere
-git clone https://github.com/TBD54566975/dwn-sdk-js.git
-cd dwn-sdk-js
-# install deps
-npm install
-# transpile typescript and build bundles
-npm run build
-
-# cd into your project dir
-cd /path/to/your/project
-# first creates a global link, and then links the global installation target into your project's node_modules folder.
-npm link ../path/to/where/you/cloned/dwn-sdk-js
-
-# profit
+npm install @tbd54566975/dwn-sdk-js
 ```
 
 ## Usage
+```javascript
+import { Dwn } from '@tbd54566975/dwn-sdk-js';
 
-### nodeJS
+// cool things
+```
+_Note: Works in both node and browser environments_
 
-- **ESM**
-  ```javascript
-  import { Dwn } from 'dwn-sdk';
-
-  // cool things
-  ```
-
-- **CJS**
-  ```javascript
-  const { Dwn } = require('dwn-sdk');
-
-  // cool things
-  ```
-### Browser:
-
-- **UMD Bundle**
-  ```html
-  <script type="text/javascript" src="node_modules/dwn-sdk/dist/bundles/bundle.umd.js"></script>
-  ```
-
-- **ESM Bundle**
-  ```html
-  <script type="text/javascript" src="node_modules/dwn-sdk/dist/bundles/bundle.esm.js"></script>
-  ```
+⚠ Currently, in order to use this sdk in **node environments** you'll have to include the `--es-module-specifier-resolution=node` flag when running your javascript. 
 
 ## Project Resources
 

--- a/create-browser-bundle.cjs
+++ b/create-browser-bundle.cjs
@@ -1,0 +1,6 @@
+const browserConfig = require('./esbuild-browser-config.cjs');
+
+require('esbuild').build({
+  ...browserConfig,
+  outfile: 'dist/bundles/browser.js',
+});

--- a/create-bundle.cjs
+++ b/create-bundle.cjs
@@ -3,9 +3,14 @@ const { NodeGlobalsPolyfillPlugin } = require('@esbuild-plugins/node-globals-pol
 require('esbuild').build({
   entryPoints : ['./src/index.ts'],
   bundle      : true,
-  minify      : true,
+  // minify      : true,
+  format      : 'esm',
   sourcemap   : true,
+  platform    : 'browser',
   target      : ['chrome101'],
   plugins     : [NodeGlobalsPolyfillPlugin({ process: true })],
-  outfile     : 'dist/bundles/index.cjs',
+  define      : {
+    'global': 'window'
+  },
+  outfile: 'dist/bundles/browser.js',
 });

--- a/create-bundle.cjs
+++ b/create-bundle.cjs
@@ -1,8 +1,11 @@
+const { NodeGlobalsPolyfillPlugin } = require('@esbuild-plugins/node-globals-polyfill');
+
 require('esbuild').build({
   entryPoints : ['./src/index.ts'],
   bundle      : true,
   minify      : true,
   sourcemap   : true,
   target      : ['chrome101'],
+  plugins     : [NodeGlobalsPolyfillPlugin({ process: true })],
   outfile     : 'dist/bundles/index.cjs',
 });

--- a/create-bundle.cjs
+++ b/create-bundle.cjs
@@ -3,7 +3,6 @@ const { NodeGlobalsPolyfillPlugin } = require('@esbuild-plugins/node-globals-pol
 require('esbuild').build({
   entryPoints : ['./src/index.ts'],
   bundle      : true,
-  // minify      : true,
   format      : 'esm',
   sourcemap   : true,
   platform    : 'browser',

--- a/esbuild-browser-config.cjs
+++ b/esbuild-browser-config.cjs
@@ -1,6 +1,6 @@
 const { NodeGlobalsPolyfillPlugin } = require('@esbuild-plugins/node-globals-polyfill');
 
-require('esbuild').build({
+module.exports = {
   entryPoints : ['./src/index.ts'],
   bundle      : true,
   format      : 'esm',
@@ -10,6 +10,5 @@ require('esbuild').build({
   plugins     : [NodeGlobalsPolyfillPlugin({ process: true })],
   define      : {
     'global': 'window'
-  },
-  outfile: 'dist/bundles/browser.js',
-});
+  }
+};

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -31,11 +31,9 @@ module.exports = function(config) {
     esbuild: {
       mainFields : ['browser', 'module', 'main'],
       target     : ['chrome101'],
-      plugins    : [NodeGlobalsPolyfillPlugin({
-        process: true
-      })],
-      sourcemap : true,
-      define    : {
+      plugins    : [NodeGlobalsPolyfillPlugin({ process: true })],
+      sourcemap  : true,
+      define     : {
         'global': 'window'
       },
     },

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -1,8 +1,7 @@
 // Karma is what we're using to run our tests in browser environments
 // Karma does not support .mjs
 
-
-const { NodeGlobalsPolyfillPlugin } = require('@esbuild-plugins/node-globals-polyfill');
+const esbuildBrowserConfig = require('./esbuild-browser-config.cjs');
 
 module.exports = function(config) {
   config.set({
@@ -28,15 +27,7 @@ module.exports = function(config) {
       'tests/**/*.ts': ['esbuild']
     },
 
-    esbuild: {
-      mainFields : ['browser', 'module', 'main'],
-      target     : ['chrome101'],
-      plugins    : [NodeGlobalsPolyfillPlugin({ process: true })],
-      sourcemap  : true,
-      define     : {
-        'global': 'window'
-      },
-    },
+    esbuild: esbuildBrowserConfig,
 
     // list of files / patterns to exclude
     exclude: [],

--- a/package.json
+++ b/package.json
@@ -7,15 +7,8 @@
   "engines": {
     "node": ">= 16"
   },
-  "module": "./dist/bundles/index.cjs",
-  "exports": {
-    "require": "./dist/bundles/index.cjs",
-    "import": "./dist/bundles/index.cjs"
-  },
-  "browser": {
-    "events": "events",
-    "util": "util"
-  },
+  "module": "./dist/bundles/browser.js",
+  "exports": "./dist/esm/src/index.js",
   "@comment files": [
     "the files property informs npm about which files we want to include in our published package.",
     "dist will include all transpiled js. There's no point in including .ts files"

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "engines": {
     "node": ">= 16"
   },
-  "exports": {
-    ".": "./dist/esm/src/index.js",
-    "./browser": "./dist/bundles/browser.js"
+  "exports": "./dist/esm/src/index.js",
+  "browser": {
+    "./dist/esm/src/index.js": "./dist/bundles/browser.js"
   },
   "@comment files": [
     "the files property informs npm about which files we want to include in our published package.",
@@ -23,7 +23,7 @@
     "build:esm": "tsc",
     "build": "npm-run-all -l clean -p build:esm bundle",
     "clean": "rimraf dist",
-    "bundle": "node create-bundle.cjs",
+    "bundle": "node create-browser-bundle.cjs",
     "lint": "eslint . --ext .ts --max-warnings 0",
     "lint:fix": "eslint . --ext .ts --fix",
     "test:node": "tsc && c8 mocha --es-module-specifier-resolution=node \"dist/esm/tests/**/*.spec.js\" && npm run make-coverage-badges",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "engines": {
     "node": ">= 16"
   },
-  "module": "./dist/esm/src/index.js",
+  "module": "./dist/bundles/index.cjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/src/index.js"
+    "require": "./dist/bundles/index.cjs",
+    "import": "./dist/bundles/index.cjs"
   },
   "browser": {
     "events": "events",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
   "engines": {
     "node": ">= 16"
   },
-  "module": "./dist/bundles/browser.js",
-  "exports": "./dist/esm/src/index.js",
+  "exports": {
+    ".": "./dist/esm/src/index.js",
+    "./browser": "./dist/bundles/browser.js"
+  },
   "@comment files": [
     "the files property informs npm about which files we want to include in our published package.",
     "dist will include all transpiled js. There's no point in including .ts files"


### PR DESCRIPTION
This PR addresses issues using the sdk in the browser by including the necessary polyfills as a part of the bundle that's imported via `import { Dwn } from '@tbd54566975/dwn-sdk-js` in browser environments. Additionally, the browser tests and bundling script now use the same build configuration. 