### PR TITLE
Better schema validation 135

### DIFF
--- a/src/validation/json-schemas/collections/collections-write.json
+++ b/src/validation/json-schemas/collections/collections-write.json
@@ -70,49 +70,48 @@
       ],
       "allOf": [
         {
-          "allOf": [
+          "anyOf": [
             {
+              "$comment": "rule defining published and datePublished relationship"
+            },
+            {
+              "properties": {
+                "published": {
+                  "type": "boolean",
+                  "enum": [
+                    true
+                  ]
+                }
+              },
+              "required": [
+                "datePublished"
+              ]
+            },
+            {
+              "properties": {
+                "published": {
+                  "type": "boolean",
+                  "enum": [
+                    false
+                  ]
+                }
+              },
               "not": {
-                "allOf": [
-                  {
-                    "not": {
-                      "required": [
-                        "published"
-                      ]
-                    }
-                  },
-                  {
-                    "required": [
-                      "datePublished"
-                    ]
-                  }
+                "required": [
+                  "datePublished"
                 ]
               }
             },
             {
-              "anyOf": [
+              "allOf": [
                 {
-                  "properties": {
-                    "published": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    }
-                  },
-                  "required": [
-                    "datePublished"
-                  ]
+                  "not": {
+                    "required": [
+                      "published"
+                    ]
+                  }
                 },
                 {
-                  "properties": {
-                    "published": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    }
-                  },
                   "not": {
                     "required": [
                       "datePublished"

--- a/src/validation/json-schemas/collections/collections-write.json
+++ b/src/validation/json-schemas/collections/collections-write.json
@@ -68,28 +68,52 @@
         "dateCreated",
         "dataFormat"
       ],
-      "oneOf": [
+      "allOf": [
         {
-          "required": [
-            "parentId",
-            "contextId"
+          "anyOf": [
+            {
+              "properties": {
+                "published": true
+              },
+              "required": ["datePublished"]
+            },
+            {
+              "properties": {
+                "published": false
+              },
+              "not": {
+                "required": [
+                  "datePublished"
+                ]
+              }
+            }          
           ]
         },
         {
-          "allOf": [
+          "oneOf": [
             {
-              "not": {
-                "required": [
-                  "parentId"
-                ]
-              }
+              "required": [
+                "parentId",
+                "contextId"
+              ]
             },
             {
-              "not": {
-                "required": [
-                  "contextId"
-                ]
-              }
+              "allOf": [
+                {
+                  "not": {
+                    "required": [
+                      "parentId"
+                    ]
+                  }
+                },
+                {
+                  "not": {
+                    "required": [
+                      "contextId"
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/src/validation/json-schemas/collections/collections-write.json
+++ b/src/validation/json-schemas/collections/collections-write.json
@@ -70,34 +70,56 @@
       ],
       "allOf": [
         {
-          "anyOf": [
+          "allOf": [
             {
-              "properties": {
-                "published": {
-                  "type": "boolean",
-                  "enum": [
-                    true
-                  ]
-                }
-              },
-              "required": [
-                "datePublished"
-              ]
-            },
-            {
-              "properties": {
-                "published": {
-                  "type": "boolean",
-                  "enum": [
-                    false
-                  ]
-                }
-              },
               "not": {
-                "required": [
-                  "datePublished"
+                "allOf": [
+                  {
+                    "not": {
+                      "required": [
+                        "published"
+                      ]
+                    }
+                  },
+                  {
+                    "required": [
+                      "datePublished"
+                    ]
+                  }
                 ]
               }
+            },
+            {
+              "anyOf": [
+                {
+                  "properties": {
+                    "published": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    }
+                  },
+                  "required": [
+                    "datePublished"
+                  ]
+                },
+                {
+                  "properties": {
+                    "published": {
+                      "type": "boolean",
+                      "enum": [
+                        false
+                      ]
+                    }
+                  },
+                  "not": {
+                    "required": [
+                      "datePublished"
+                    ]
+                  }
+                }
+              ]
             }
           ]
         },

--- a/src/validation/json-schemas/collections/collections-write.json
+++ b/src/validation/json-schemas/collections/collections-write.json
@@ -70,10 +70,8 @@
       ],
       "allOf": [
         {
+          "$comment": "rule defining published and datePublished relationship",
           "anyOf": [
-            {
-              "$comment": "rule defining published and datePublished relationship"
-            },
             {
               "properties": {
                 "published": {

--- a/src/validation/json-schemas/collections/collections-write.json
+++ b/src/validation/json-schemas/collections/collections-write.json
@@ -73,20 +73,32 @@
           "anyOf": [
             {
               "properties": {
-                "published": true
+                "published": {
+                  "type": "boolean",
+                  "enum": [
+                    true
+                  ]
+                }
               },
-              "required": ["datePublished"]
+              "required": [
+                "datePublished"
+              ]
             },
             {
               "properties": {
-                "published": false
+                "published": {
+                  "type": "boolean",
+                  "enum": [
+                    false
+                  ]
+                }
               },
               "not": {
                 "required": [
                   "datePublished"
                 ]
               }
-            }          
+            }
           ]
         },
         {

--- a/src/validation/json-schemas/collections/collections-write.json
+++ b/src/validation/json-schemas/collections/collections-write.json
@@ -82,7 +82,7 @@
                 }
               },
               "required": [
-                "datePublished"
+                "published", "datePublished"
               ]
             },
             {

--- a/tests/interfaces/collections/handlers/collections-query.spec.ts
+++ b/tests/interfaces/collections/handlers/collections-query.spec.ts
@@ -96,7 +96,7 @@ describe('handleCollectionsQuery()', () => {
         { requester: bob, target: alice, recipientDid: alice.did, schema, data: encoder.stringToBytes('3') }
       );
       const record4Data = await TestDataGenerator.generateCollectionsWriteMessage(
-        { requester: alice, target: alice, schema, data: encoder.stringToBytes('4'), published: true }
+        { requester: alice, target: alice, schema, data: encoder.stringToBytes('4'), published: true, datePublished: 123 }
       );
 
       await messageStore.put(record1Data.message, { author: alice.did });

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -257,16 +257,17 @@ export class TestDataGenerator {
     const data = input?.data ?? TestDataGenerator.randomBytes(32);
 
     const options: CollectionsWriteOptions = {
-      target      : target.did,
-      recipient   : input?.recipientDid ?? target.did, // use target if recipient is not explicitly set
-      protocol    : input?.protocol,
-      contextId   : input?.contextId,
-      schema      : input?.schema ?? TestDataGenerator.randomString(20),
-      recordId    : input?.recordId ?? uuidv4(),
-      parentId    : input?.parentId,
-      published   : input?.published,
-      dataFormat  : input?.dataFormat ?? 'application/json',
-      dateCreated : input?.dateCreated,
+      target        : target.did,
+      recipient     : input?.recipientDid ?? target.did, // use target if recipient is not explicitly set
+      protocol      : input?.protocol,
+      contextId     : input?.contextId,
+      schema        : input?.schema ?? TestDataGenerator.randomString(20),
+      recordId      : input?.recordId ?? uuidv4(),
+      parentId      : input?.parentId,
+      published     : input?.published,
+      dataFormat    : input?.dataFormat ?? 'application/json',
+      dateCreated   : input?.dateCreated,
+      datePublished : input?.datePublished,
       data,
       signatureInput
     };

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -76,6 +76,7 @@ export type GenerateCollectionsWriteMessageInput = {
   data?: Uint8Array;
   dataFormat?: string;
   dateCreated? : number;
+  datePublished? : number;
 };
 
 export type GenerateCollectionsWriteMessageOutput = {

--- a/tests/validation/json-schemas/collections/collections-write.spec.ts
+++ b/tests/validation/json-schemas/collections/collections-write.spec.ts
@@ -220,6 +220,6 @@ describe('CollectionsWrite schema definition', () => {
 
     expect(() => {
       Message.validateJsonSchema(invalidMessage);
-    }).throws('must not have property \'datePublished\'');
+    }).throws('must have required property \'datePublished\'');
   });
 });

--- a/tests/validation/json-schemas/collections/collections-write.spec.ts
+++ b/tests/validation/json-schemas/collections/collections-write.spec.ts
@@ -199,14 +199,14 @@ describe('CollectionsWrite schema definition', () => {
   it('should throw if published is true and datePublished is missing', () => {
     const invalidMessage = {
       descriptor: {
-        target        : 'did:example:anyDid',
-        method        : 'CollectionsWrite',
-        parentId      : 'invalid', // must have `contextId` to exist
-        dataCid       : 'anyCid',
-        dataFormat    : 'application/json',
-        dateCreated   : 123,
-        recordId      : uuidv4(),
-        published     : true,
+        target      : 'did:example:anyDid',
+        method      : 'CollectionsWrite',
+        parentId    : 'invalid', // must have `contextId` to exist
+        dataCid     : 'anyCid',
+        dataFormat  : 'application/json',
+        dateCreated : 123,
+        recordId    : uuidv4(),
+        published   : true
       },
       authorization: {
         payload    : 'anyPayload',
@@ -220,6 +220,6 @@ describe('CollectionsWrite schema definition', () => {
 
     expect(() => {
       Message.validateJsonSchema(invalidMessage);
-    }).throws('must have required property \'datePublished\'');
+    }).throws('must not have property \'datePublished\'');
   });
 });

--- a/tests/validation/json-schemas/collections/collections-write.spec.ts
+++ b/tests/validation/json-schemas/collections/collections-write.spec.ts
@@ -173,13 +173,12 @@ describe('CollectionsWrite schema definition', () => {
       descriptor: {
         target        : 'did:example:anyDid',
         method        : 'CollectionsWrite',
-        parentId      : 'invalid', // must have `contextId` to exist
         dataCid       : 'anyCid',
         dataFormat    : 'application/json',
         dateCreated   : 123,
         recordId      : uuidv4(),
         published     : false,
-        datePublished : 123
+        datePublished : 123 // must not be present when not published
       },
       authorization: {
         payload    : 'anyPayload',
@@ -201,12 +200,11 @@ describe('CollectionsWrite schema definition', () => {
       descriptor: {
         target      : 'did:example:anyDid',
         method      : 'CollectionsWrite',
-        parentId    : 'invalid', // must have `contextId` to exist
         dataCid     : 'anyCid',
         dataFormat  : 'application/json',
         dateCreated : 123,
         recordId    : uuidv4(),
-        published   : true
+        published   : true //datePublished must be present
       },
       authorization: {
         payload    : 'anyPayload',

--- a/tests/validation/json-schemas/collections/collections-write.spec.ts
+++ b/tests/validation/json-schemas/collections/collections-write.spec.ts
@@ -189,12 +189,12 @@ describe('CollectionsWrite schema definition', () => {
         }]
       },
       encodedData: 'anything'
-    }
+    };
 
     expect(() => {
       Message.validateJsonSchema(invalidMessage);
     }).throws('must not have property \'datePublished\'');
-  })
+  });
 
   it('should throw if published is true and datePublished is missing', () => {
     const invalidMessage = {
@@ -216,10 +216,10 @@ describe('CollectionsWrite schema definition', () => {
         }]
       },
       encodedData: 'anything'
-    }
+    };
 
     expect(() => {
       Message.validateJsonSchema(invalidMessage);
     }).throws('must have required property \'datePublished\'');
-  })
+  });
 });

--- a/tests/validation/json-schemas/collections/collections-write.spec.ts
+++ b/tests/validation/json-schemas/collections/collections-write.spec.ts
@@ -220,4 +220,30 @@ describe('CollectionsWrite schema definition', () => {
       Message.validateJsonSchema(invalidMessage);
     }).throws('must have required property \'datePublished\'');
   });
+
+  it('should throw if published is missing and datePublished is present', () => {
+    const invalidMessage = {
+      descriptor: {
+        target        : 'did:example:anyDid',
+        method        : 'CollectionsWrite',
+        dataCid       : 'anyCid',
+        dataFormat    : 'application/json',
+        dateCreated   : 123,
+        recordId      : uuidv4(),
+        datePublished : 123 //published must be present
+      },
+      authorization: {
+        payload    : 'anyPayload',
+        signatures : [{
+          protected : 'anyProtectedHeader',
+          signature : 'anySignature'
+        }]
+      },
+      encodedData: 'anything'
+    };
+
+    expect(() => {
+      Message.validateJsonSchema(invalidMessage);
+    }).throws('must have required property \'published\'');
+  });
 });

--- a/tests/validation/json-schemas/collections/collections-write.spec.ts
+++ b/tests/validation/json-schemas/collections/collections-write.spec.ts
@@ -192,7 +192,7 @@ describe('CollectionsWrite schema definition', () => {
 
     expect(() => {
       Message.validateJsonSchema(invalidMessage);
-    }).throws('must not have property \'datePublished\'');
+    }).throws('published: must be equal to one of the allowed values');
   });
 
   it('should throw if published is true and datePublished is missing', () => {

--- a/tests/validation/json-schemas/collections/collections-write.spec.ts
+++ b/tests/validation/json-schemas/collections/collections-write.spec.ts
@@ -244,6 +244,6 @@ describe('CollectionsWrite schema definition', () => {
 
     expect(() => {
       Message.validateJsonSchema(invalidMessage);
-    }).throws('must have required property \'published\'');
+    }).throws('must NOT be valid');
   });
 });

--- a/tests/validation/json-schemas/collections/collections-write.spec.ts
+++ b/tests/validation/json-schemas/collections/collections-write.spec.ts
@@ -167,4 +167,59 @@ describe('CollectionsWrite schema definition', () => {
       Message.validateJsonSchema(invalidMessage);
     }).throws('must have required property \'contextId\'');
   });
+
+  it('should throw if published is false and datePublished is present', () => {
+    const invalidMessage = {
+      descriptor: {
+        target        : 'did:example:anyDid',
+        method        : 'CollectionsWrite',
+        parentId      : 'invalid', // must have `contextId` to exist
+        dataCid       : 'anyCid',
+        dataFormat    : 'application/json',
+        dateCreated   : 123,
+        recordId      : uuidv4(),
+        published     : false,
+        datePublished : 123
+      },
+      authorization: {
+        payload    : 'anyPayload',
+        signatures : [{
+          protected : 'anyProtectedHeader',
+          signature : 'anySignature'
+        }]
+      },
+      encodedData: 'anything'
+    }
+
+    expect(() => {
+      Message.validateJsonSchema(invalidMessage);
+    }).throws('must not have property \'datePublished\'');
+  })
+
+  it('should throw if published is true and datePublished is missing', () => {
+    const invalidMessage = {
+      descriptor: {
+        target        : 'did:example:anyDid',
+        method        : 'CollectionsWrite',
+        parentId      : 'invalid', // must have `contextId` to exist
+        dataCid       : 'anyCid',
+        dataFormat    : 'application/json',
+        dateCreated   : 123,
+        recordId      : uuidv4(),
+        published     : true,
+      },
+      authorization: {
+        payload    : 'anyPayload',
+        signatures : [{
+          protected : 'anyProtectedHeader',
+          signature : 'anySignature'
+        }]
+      },
+      encodedData: 'anything'
+    }
+
+    expect(() => {
+      Message.validateJsonSchema(invalidMessage);
+    }).throws('must have required property \'datePublished\'');
+  })
 });

--- a/tests/validation/json-schemas/collections/collections-write.spec.ts
+++ b/tests/validation/json-schemas/collections/collections-write.spec.ts
@@ -244,6 +244,6 @@ describe('CollectionsWrite schema definition', () => {
 
     expect(() => {
       Message.validateJsonSchema(invalidMessage);
-    }).throws('must NOT be valid');
+    }).throws('must have required property \'published\'');
   });
 });


### PR DESCRIPTION
Fixes #135 

- `"published": true` requires field `datePublished` be present
- `"published": false` requires field `datePublished` NOT be present
- Missing key `"published"` requires `datePublished` NOT be present