### PR TITLE
Browser extension compatibility

### DIFF
--- a/build/esbuild-browser-config.cjs
+++ b/build/esbuild-browser-config.cjs
@@ -7,7 +7,7 @@ module.exports = {
   sourcemap   : true,
   platform    : 'browser',
   target      : ['chrome101'],
-  plugins     : [NodeGlobalsPolyfillPlugin({ process: true })],
+  plugins     : [NodeGlobalsPolyfillPlugin()],
   define      : {
     'global': 'window'
   }

--- a/build/esbuild-browser-config.cjs
+++ b/build/esbuild-browser-config.cjs
@@ -9,6 +9,6 @@ module.exports = {
   target      : ['chrome101'],
   plugins     : [NodeGlobalsPolyfillPlugin()],
   define      : {
-    'global': 'window'
+    'global': 'globalThis'
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/dwn-sdk-js",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "A reference implementation of https://identity.foundation/decentralized-web-node/spec/",
   "type": "module",
   "types": "./dist/esm/src/index.d.ts",


### PR DESCRIPTION
adjust bundle to use standard way of accessing the global `this` value (and hence the global object itself) across browser environments. `globalThis` is guaranteed to work in window and non-window contexts (e.g. web workers). This allows for consistent access to the global object without having to know which environment the code is being run in.
