### PR TITLE
update getCurrentDateInHighPrecision to use Temporal API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "7.0.1",
+        "@js-temporal/polyfill": "^0.4.3",
         "@noble/ed25519": "1.6.0",
         "@noble/secp256k1": "1.5.5",
         "@swc/helpers": "0.3.8",
@@ -238,6 +239,23 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.4.3.tgz",
+      "integrity": "sha512-6Fmjo/HlkyVCmJzAPnvtEWlcbQUSRhi8qlN9EtJA/wP7FqXsevLLrlojR44kzNzrRkpf7eDJ+z7b4xQD/Ycypw==",
+      "dependencies": {
+        "jsbi": "^4.1.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@js-temporal/polyfill/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/@multiformats/murmur3": {
       "version": "1.1.3",
@@ -3493,6 +3511,11 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
+      "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -6252,6 +6275,22 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@js-temporal/polyfill": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.4.3.tgz",
+      "integrity": "sha512-6Fmjo/HlkyVCmJzAPnvtEWlcbQUSRhi8qlN9EtJA/wP7FqXsevLLrlojR44kzNzrRkpf7eDJ+z7b4xQD/Ycypw==",
+      "requires": {
+        "jsbi": "^4.1.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
+      }
+    },
     "@multiformats/murmur3": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.1.3.tgz",
@@ -8582,6 +8621,11 @@
       "requires": {
         "argparse": "^2.0.1"
       }
+    },
+    "jsbi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
+      "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@ipld/dag-cbor": "7.0.1",
+    "@js-temporal/polyfill": "^0.4.3",
     "@noble/ed25519": "1.6.0",
     "@noble/secp256k1": "1.5.5",
     "@swc/helpers": "0.3.8",

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,3 +1,5 @@
+import { Temporal } from '@js-temporal/polyfill';
+
 /**
  * sleeps for the desired duration
  * @param durationInMillisecond the desired amount of sleep time
@@ -7,6 +9,10 @@ export function sleep(durationInMillisecond): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, durationInMillisecond));
 }
 
+/**
+ * returns system time as a plain ISO date string with microsecond precision
+ * using @js-temporal/polyfill
+ */
 export function getCurrentDateInHighPrecision(): string {
-  return new Date().toISOString().replace('Z','000');
+  return Temporal.Now.plainDateTimeISO().toString({ smallestUnit: 'microseconds' });
 }


### PR DESCRIPTION
This PR updates `getCurrentDateInHighPrecision` to use the upcoming [Temporal API](https://github.com/tc39/proposal-temporal). The Temporal API proposal is in Stage 3 and is not expected to change significantly. I think it is a better alternative to using the Performance API, which is intended for different purposes.

For now it is implemented using the recommended [polyfill](https://github.com/js-temporal/temporal-polyfill).