### PR TITLE
moved `recordId` to be a sibling property with `descriptor`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,6 +12,7 @@ module.exports = {
     browser : true
   },
   rules: {
+    'curly'      : ['error', 'all'],
     'no-console' : 'off',
     'indent'     : [
       'error',
@@ -31,7 +32,7 @@ module.exports = {
     '@typescript-eslint/semi' : ['error', 'always'],
     'no-multi-spaces'         : ['error'],
     'no-trailing-spaces'      : ['error'],
-    'max-len'                 : ['error', { 'code': 150 }],
+    'max-len'                 : ['error', { 'code': 150, 'ignoreStrings': true }],
     'key-spacing'             : [
       'error',
       {

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Code Coverage
 
-![Statements](https://img.shields.io/badge/statements-91.32%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-88.97%25-yellow.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-87.75%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-91.32%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-91.33%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-88.97%25-yellow.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-87.75%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-91.33%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Code Coverage
 
-![Statements](https://img.shields.io/badge/statements-91.29%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-88.97%25-yellow.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-87.75%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-91.29%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-91.32%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-88.97%25-yellow.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-87.75%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-91.32%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/json-schemas/collections/collections-query.json
+++ b/json-schemas/collections/collections-query.json
@@ -51,10 +51,10 @@
               "type": "string"
             },
             "recordId": {
-              "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/uuid"
+              "type": "string"
             },
             "parentId": {
-              "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/uuid"
+              "type": "string"
             },
             "dataFormat": {
               "type": "string"

--- a/json-schemas/collections/collections-write.json
+++ b/json-schemas/collections/collections-write.json
@@ -5,9 +5,13 @@
   "additionalProperties": false,
   "required": [
     "authorization",
-    "descriptor"
+    "descriptor",
+    "recordId"
   ],
   "properties": {
+    "recordId": {
+      "type": "string"
+    },
     "contextId": {
       "type": "string"
     },
@@ -35,9 +39,6 @@
         "schema": {
           "type": "string"
         },
-        "recordId": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/uuid"
-        },
         "parentId": {
           "type": "string"
         },
@@ -62,7 +63,6 @@
       "required": [
         "target",
         "method",
-        "recordId",
         "dataCid",
         "dateCreated",
         "dataFormat"

--- a/json-schemas/permissions/definitions.json
+++ b/json-schemas/permissions/definitions.json
@@ -8,14 +8,20 @@
       "additionalProperties": false,
       "properties": {
         "attestation": {
-          "enum": ["optional", "required"],
+          "enum": [
+            "optional",
+            "required"
+          ],
           "type": "string"
         },
         "delegation": {
           "type": "boolean"
         },
         "encryption": {
-          "enum": ["optional", "required"],
+          "enum": [
+            "optional",
+            "required"
+          ],
           "type": "string"
         },
         "publication": {
@@ -38,7 +44,7 @@
           "type": "string"
         },
         "objectId": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/uuid"
+          "type": "string"
         },
         "schema": {
           "type": "string"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "7.0.1",
-        "@js-temporal/polyfill": "^0.4.3",
+        "@js-temporal/polyfill": "0.4.3",
         "@noble/ed25519": "1.6.0",
         "@noble/secp256k1": "1.5.5",
         "@swc/helpers": "0.3.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/dwn-sdk-js",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@ipld/dag-cbor": "7.0.1",
-    "@js-temporal/polyfill": "^0.4.3",
+    "@js-temporal/polyfill": "0.4.3",
     "@noble/ed25519": "1.6.0",
     "@noble/secp256k1": "1.5.5",
     "@swc/helpers": "0.3.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "A reference implementation of https://identity.foundation/decentralized-web-node/spec/",
   "type": "module",
   "types": "./dist/esm/src/index.d.ts",

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -26,7 +26,7 @@ export async function canonicalAuth(
   authorizationPayloadConstraints?: AuthorizationPayloadConstraints
 ): Promise<AuthVerificationResult> {
   // signature verification is computationally intensive, so we're going to start by validating the payload.
-  const parsedPayload = await validateSchema(message, authorizationPayloadConstraints);
+  const parsedPayload = await validateAuthorizationIntegrity(message, authorizationPayloadConstraints);
 
   const signers = await authenticate(message.authorization, didResolver);
   const author = signers[0];
@@ -36,7 +36,11 @@ export async function canonicalAuth(
   return { payload: parsedPayload, author };
 }
 
-export async function validateSchema(
+/**
+ * Validates the data integrity of the `authorization` property.
+ * NOTE signature is not verified.
+ */
+export async function validateAuthorizationIntegrity(
   message: BaseMessage,
   authorizationPayloadConstraints?: AuthorizationPayloadConstraints
 ): Promise<{ descriptorCid: CID, [key: string]: CID }> {
@@ -89,7 +93,6 @@ export async function validateSchema(
 }
 
 export async function authenticate(jws: GeneralJws, didResolver: DidResolver): Promise<string[]> {
-  // TODO: should we add an explicit check to ensure that there's only 1 signer?, Issue #65 https://github.com/TBD54566975/dwn-sdk-js/issues/65
   const verifier = new GeneralJwsVerifier(jws);
   const { signers } = await verifier.verify(didResolver);
   return signers;

--- a/src/interfaces/collections/handlers/collections-write.ts
+++ b/src/interfaces/collections/handlers/collections-write.ts
@@ -41,7 +41,7 @@ export const handleCollectionsWrite: MethodHandler = async (
     const query = {
       target   : incomingMessage.descriptor.target,
       method   : 'CollectionsWrite',
-      recordId : incomingMessage.descriptor.recordId
+      recordId : incomingMessage.recordId
     };
     const existingMessages = await messageStore.query(query) as CollectionsWriteMessage[];
 
@@ -56,7 +56,10 @@ export const handleCollectionsWrite: MethodHandler = async (
     // write the incoming message to DB if incoming message is newest
     let messageReply: MessageReply;
     if (incomingMessageIsNewest) {
-      const additionalIndexes: {[key:string]: string} = { author };
+      const additionalIndexes: {[key:string]: string} = {
+        recordId: incomingMessage.recordId,
+        author
+      };
 
       // add `contextId` to additional index if the message is a protocol based message
       if (incomingMessage.contextId !== undefined) { additionalIndexes.contextId = incomingMessage.contextId; }

--- a/src/interfaces/collections/messages/collections-query.ts
+++ b/src/interfaces/collections/messages/collections-query.ts
@@ -1,6 +1,6 @@
 import type { AuthCreateOptions, Authorizable, AuthVerificationResult } from '../../../core/types';
 import type { CollectionsQueryDescriptor, CollectionsQueryMessage } from '../types';
-import { authenticate, validateSchema } from '../../../core/auth';
+import { authenticate, validateAuthorizationIntegrity } from '../../../core/auth';
 import { DidResolver } from '../../../did/did-resolver';
 import { Message } from '../../../core/message';
 import { MessageStore } from '../../../store/message-store';
@@ -54,7 +54,7 @@ export class CollectionsQuery extends Message implements Authorizable {
     const message = this.message;
 
     // signature verification is computationally intensive, so we're going to start by validating the payload.
-    const parsedPayload = await validateSchema(message);
+    const parsedPayload = await validateAuthorizationIntegrity(message);
 
     const signers = await authenticate(message.authorization, didResolver);
     const author = signers[0];

--- a/src/interfaces/collections/messages/collections-write.ts
+++ b/src/interfaces/collections/messages/collections-write.ts
@@ -1,7 +1,7 @@
 import type { AuthCreateOptions, Authorizable, AuthVerificationResult } from '../../../core/types';
 import type { CollectionsWriteAuthorizationPayload, CollectionsWriteDescriptor, CollectionsWriteMessage } from '../types';
 import * as encoder from '../../../utils/encoder';
-import { authenticate, authorize, validateSchema } from '../../../core/auth';
+import { authenticate, authorize, validateAuthorizationIntegrity } from '../../../core/auth';
 import { DidResolver } from '../../../did/did-resolver';
 import { generateCid } from '../../../utils/cid';
 import { getDagCid } from '../../../utils/data';
@@ -94,7 +94,7 @@ export class CollectionsWrite extends Message implements Authorizable {
     const message = this.message as CollectionsWriteMessage;
 
     // signature verification is computationally intensive, so we're going to start by validating the payload.
-    const parsedPayload = await validateSchema(message, { allowedProperties: new Set(['recordId', 'contextId']) });
+    const parsedPayload = await validateAuthorizationIntegrity(message, { allowedProperties: new Set(['recordId', 'contextId']) });
 
     await this.validateIntegrity();
 
@@ -112,7 +112,7 @@ export class CollectionsWrite extends Message implements Authorizable {
   }
 
   /**
-   * Validates the integrity of the message assuming the message passed basic schema validation.
+   * Validates the integrity of the CollectionsWrite message assuming the message passed basic schema validation.
    * There is opportunity to integrate better with `validateSchema(...)`
    */
   private async validateIntegrity(): Promise<void> {

--- a/src/interfaces/collections/types.ts
+++ b/src/interfaces/collections/types.ts
@@ -6,7 +6,6 @@ export type CollectionsWriteDescriptor = {
   method: 'CollectionsWrite';
   protocol?: string;
   schema?: string;
-  recordId: string;
   parentId?: string;
   dataCid: string;
   dateCreated: string;
@@ -16,6 +15,7 @@ export type CollectionsWriteDescriptor = {
 };
 
 export type CollectionsWriteMessage = BaseMessage & {
+  recordId: string,
   contextId?: string;
   descriptor: CollectionsWriteDescriptor;
   encodedData?: string;
@@ -38,6 +38,7 @@ export type CollectionsQueryDescriptor = {
 };
 
 export type CollectionsWriteAuthorizationPayload = {
+  recordId: string;
   contextId?: string;
   descriptorCid: string;
 };

--- a/src/store/message-store-level.ts
+++ b/src/store/message-store-level.ts
@@ -49,7 +49,7 @@ export class MessageStoreLevel implements MessageStore {
     await this.db.open();
 
     // calling `searchIndex()` twice without closing its DB causes the process to hang (ie. calling this method consecutively),
-    // so check to see if the index has already been    opened" before opening it again.
+    // so check to see if the index has already been "opened" before opening it again.
     if (!this.index) {
       this.index = await searchIndex({ name: this.config.indexLocation });
     }

--- a/src/store/message-store-level.ts
+++ b/src/store/message-store-level.ts
@@ -48,9 +48,8 @@ export class MessageStoreLevel implements MessageStore {
 
     await this.db.open();
 
-    // TODO: look into using the same level we're using for blockstore, Issue #49 https://github.com/TBD54566975/dwn-sdk-js/issues/49
     // calling `searchIndex()` twice without closing its DB causes the process to hang (ie. calling this method consecutively),
-    // so check to see if the index has already been "opened" before opening it again.
+    // so check to see if the index has already been    opened" before opening it again.
     if (!this.index) {
       this.index = await searchIndex({ name: this.config.indexLocation });
     }
@@ -153,7 +152,7 @@ export class MessageStoreLevel implements MessageStore {
       // we really don't have to access the result of `chunk` because it's just outputting every unix-fs
       // entry that's getting written to the blockstore. the last entry contains the root cid
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      for await (const _ of chunk);
+      for await (const _ of chunk) { ; }
     }
 
     const indexDocument = {

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -32,7 +32,7 @@ export async function getDagCid(data: Data): Promise<CID> {
   const chunk = importer([{ content: dataBytes }], undefined, { onlyHash: true, cidVersion: 1 });
   let root;
 
-  for await (root of chunk);
+  for await (root of chunk) { ; }
 
   return root.cid;
 }

--- a/tests/interfaces/collections/messages/collections-write.spec.ts
+++ b/tests/interfaces/collections/messages/collections-write.spec.ts
@@ -5,7 +5,6 @@ import { MessageStoreLevel } from '../../../../src/store/message-store-level';
 import { getCurrentDateInHighPrecision, sleep } from '../../../../src/utils/time';
 import { TestDataGenerator } from '../../../utils/test-data-generator';
 import { TestStubGenerator } from '../../../utils/test-stub-generator';
-import { v4 as uuidv4 } from 'uuid';
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
@@ -31,7 +30,7 @@ describe('CollectionsWrite', () => {
         data        : TestDataGenerator.randomBytes(10),
         dataFormat  : 'application/json',
         dateCreated : '2022-10-14T10:20:30.405060',
-        recordId    : uuidv4(),
+        recordId    : await TestDataGenerator.randomCborSha256Cid(),
         signatureInput
       };
       const collectionsWrite = await CollectionsWrite.create(options);
@@ -42,7 +41,7 @@ describe('CollectionsWrite', () => {
       expect(message.encodedData).to.equal(base64url.baseEncode(options.data));
       expect(message.descriptor.dataFormat).to.equal(options.dataFormat);
       expect(message.descriptor.dateCreated).to.equal(options.dateCreated);
-      expect(message.descriptor.recordId).to.equal(options.recordId);
+      expect(message.recordId).to.equal(options.recordId);
 
       const resolverStub = TestStubGenerator.createDidResolverStub(alice);
       const messageStoreStub = sinon.createStubInstance(MessageStoreLevel);
@@ -90,12 +89,12 @@ describe('CollectionsWrite', () => {
       const c = (await TestDataGenerator.generateCollectionsWriteMessage()).message; // c is the newest since its created last
 
       const newestMessage = await CollectionsWrite.getNewestMessage([b, c, a]);
-      if (newestMessage?.descriptor.recordId !== c.descriptor.recordId) {
+      if (newestMessage?.recordId !== c.recordId) {
         console.log(`a: ${a.descriptor.dateCreated}`);
         console.log(`b: ${b.descriptor.dateCreated}`);
         console.log(`c: ${c.descriptor.dateCreated}`);
       }
-      expect(newestMessage?.descriptor.recordId).to.equal(c.descriptor.recordId);
+      expect(newestMessage?.recordId).to.equal(c.recordId);
     });
   });
 

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -266,7 +266,7 @@ export class TestDataGenerator {
       protocol      : input?.protocol,
       contextId     : input?.contextId,
       schema        : input?.schema ?? TestDataGenerator.randomString(20),
-      recordId      : input?.recordId ?? uuidv4(),
+      recordId      : input?.recordId ?? await TestDataGenerator.randomCborSha256Cid(),
       parentId      : input?.parentId,
       published     : input?.published,
       dataFormat    : input?.dataFormat ?? 'application/json',

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -27,7 +27,6 @@ import { PrivateJwk, PublicJwk } from '../../src/jose/types';
 import { removeUndefinedProperties } from '../../src/utils/object';
 import { secp256k1 } from '../../src/jose/algorithms/signing/secp256k1';
 import { sha256 } from 'multiformats/hashes/sha2';
-import { v4 as uuidv4 } from 'uuid';
 
 /**
  * A logical grouping of user data used to generate test messages.

--- a/tests/validation/json-schemas/collections/collections-write.spec.ts
+++ b/tests/validation/json-schemas/collections/collections-write.spec.ts
@@ -1,17 +1,16 @@
 import { expect } from 'chai';
 import { Message } from '../../../../src/core/message';
-import { v4 as uuidv4 } from 'uuid';
 
 describe('CollectionsWrite schema definition', () => {
   it('should allow descriptor with only required properties', async () => {
     const validMessage = {
-      descriptor: {
+      recordId   : 'anyRecordId',
+      descriptor : {
         target      : 'did:example:anyDid',
         method      : 'CollectionsWrite',
         dataCid     : 'anyCid',
         dataFormat  : 'application/json',
         dateCreated : '123',
-        recordId    : uuidv4(),
       },
       authorization: {
         payload    : 'anyPayload',
@@ -24,15 +23,38 @@ describe('CollectionsWrite schema definition', () => {
     Message.validateJsonSchema(validMessage);
   });
 
-  it('should throw if `authorization` is missing', () => {
-    const invalidMessage = {
+  it('should throw if `recordId` is missing', async () => {
+    const message = {
       descriptor: {
         target      : 'did:example:anyDid',
         method      : 'CollectionsWrite',
         dataCid     : 'anyCid',
         dataFormat  : 'application/json',
-        dateCreated : '123',
-        recordId    : uuidv4(),
+        dateCreated : '123'
+      },
+      authorization: {
+        payload    : 'anyPayload',
+        signatures : [{
+          protected : 'anyProtectedHeader',
+          signature : 'anySignature'
+        }]
+      },
+    };
+
+    expect(() => {
+      Message.validateJsonSchema(message);
+    }).throws('must have required property \'recordId\'');
+  });
+
+  it('should throw if `authorization` is missing', () => {
+    const invalidMessage = {
+      recordId   : 'anyRecordId',
+      descriptor : {
+        target      : 'did:example:anyDid',
+        method      : 'CollectionsWrite',
+        dataCid     : 'anyCid',
+        dataFormat  : 'application/json',
+        dateCreated : '123'
       }
     };
 
@@ -43,13 +65,13 @@ describe('CollectionsWrite schema definition', () => {
 
   it('should throw if unknown property is given in message', () => {
     const invalidMessage = {
-      descriptor: {
+      recordId   : 'anyRecordId',
+      descriptor : {
         target      : 'did:example:anyDid',
         method      : 'CollectionsWrite',
         dataCid     : 'anyCid',
         dataFormat  : 'application/json',
-        dateCreated : '123',
-        recordId    : uuidv4(),
+        dateCreated : '123'
       },
       authorization: {
         payload    : 'anyPayload',
@@ -68,13 +90,13 @@ describe('CollectionsWrite schema definition', () => {
 
   it('should throw if unknown property is given in the `descriptor`', () => {
     const invalidMessage = {
-      descriptor: {
+      recordId   : 'anyRecordId',
+      descriptor : {
         target          : 'did:example:anyDid',
         method          : 'CollectionsWrite',
         dataCid         : 'anyCid',
         dataFormat      : 'application/json',
         dateCreated     : '123',
-        recordId        : uuidv4(),
         unknownProperty : 'unknownProperty' // unknown property
       },
       authorization: {
@@ -93,13 +115,13 @@ describe('CollectionsWrite schema definition', () => {
 
   it('should throw if `encodedData` is not using base64url character set', () => {
     const invalidMessage = {
-      descriptor: {
+      recordId   : 'anyRecordId',
+      descriptor : {
         target      : 'did:example:anyDid',
         method      : 'CollectionsWrite',
         dataCid     : 'anyCid',
         dataFormat  : 'application/json',
-        dateCreated : '123',
-        recordId    : uuidv4(),
+        dateCreated : '123'
       },
       authorization: {
         payload    : 'anyPayload',
@@ -118,6 +140,7 @@ describe('CollectionsWrite schema definition', () => {
 
   it('should pass if `contextId` and `protocol` are both present', () => {
     const invalidMessage = {
+      recordId   : 'anyRecordId',
       contextId  : 'someContext', // protocol must exist
       descriptor : {
         target      : 'did:example:anyDid',
@@ -125,8 +148,7 @@ describe('CollectionsWrite schema definition', () => {
         protocol    : 'someProtocolId', // contextId must exist
         dataCid     : 'anyCid',
         dataFormat  : 'application/json',
-        dateCreated : '123',
-        recordId    : uuidv4(),
+        dateCreated : '123'
       },
       authorization: {
         payload    : 'anyPayload',
@@ -143,13 +165,13 @@ describe('CollectionsWrite schema definition', () => {
 
   it('should pass if `contextId` and `protocol` are both not present', () => {
     const invalidMessage = {
-      descriptor: {
+      recordId   : 'anyRecordId',
+      descriptor : {
         target      : 'did:example:anyDid',
         method      : 'CollectionsWrite',
         dataCid     : 'anyCid',
         dataFormat  : 'application/json',
-        dateCreated : '123',
-        recordId    : uuidv4(),
+        dateCreated : '123'
       },
       authorization: {
         payload    : 'anyPayload',
@@ -166,14 +188,14 @@ describe('CollectionsWrite schema definition', () => {
 
   it('should throw if `contextId` is set but `protocol` is missing', () => {
     const invalidMessage = {
+      recordId   : 'anyRecordId',
       contextId  : 'invalid', // must have `protocol` to exist
       descriptor : {
         target      : 'did:example:anyDid',
         method      : 'CollectionsWrite',
         dataCid     : 'anyCid',
         dataFormat  : 'application/json',
-        dateCreated : '123',
-        recordId    : uuidv4(),
+        dateCreated : '123'
       },
       authorization: {
         payload    : 'anyPayload',
@@ -192,14 +214,14 @@ describe('CollectionsWrite schema definition', () => {
 
   it('should throw if `protocol` is set but `contextId` is missing', () => {
     const invalidMessage = {
-      descriptor: {
+      recordId   : 'anyRecordId',
+      descriptor : {
         target      : 'did:example:anyDid',
         method      : 'CollectionsWrite',
         protocol    : 'invalid', // must have `contextId` to exist
         dataCid     : 'anyCid',
         dataFormat  : 'application/json',
-        dateCreated : '123',
-        recordId    : uuidv4(),
+        dateCreated : '123'
       },
       authorization: {
         payload    : 'anyPayload',
@@ -218,13 +240,13 @@ describe('CollectionsWrite schema definition', () => {
 
   it('should throw if published is false and datePublished is present', () => {
     const invalidMessage = {
-      descriptor: {
+      recordId   : 'anyRecordId',
+      descriptor : {
         target        : 'did:example:anyDid',
         method        : 'CollectionsWrite',
         dataCid       : 'anyCid',
         dataFormat    : 'application/json',
         dateCreated   : 123,
-        recordId      : uuidv4(),
         published     : false,
         datePublished : 123 // must not be present when not published
       },
@@ -245,13 +267,13 @@ describe('CollectionsWrite schema definition', () => {
 
   it('should throw if published is true and datePublished is missing', () => {
     const invalidMessage = {
-      descriptor: {
+      recordId   : 'anyRecordId',
+      descriptor : {
         target      : 'did:example:anyDid',
         method      : 'CollectionsWrite',
         dataCid     : 'anyCid',
         dataFormat  : 'application/json',
         dateCreated : 123,
-        recordId    : uuidv4(),
         published   : true //datePublished must be present
       },
       authorization: {
@@ -271,13 +293,13 @@ describe('CollectionsWrite schema definition', () => {
 
   it('should throw if published is missing and datePublished is present', () => {
     const invalidMessage = {
-      descriptor: {
+      recordId   : 'anyRecordId',
+      descriptor : {
         target        : 'did:example:anyDid',
         method        : 'CollectionsWrite',
         dataCid       : 'anyCid',
         dataFormat    : 'application/json',
         dateCreated   : 123,
-        recordId      : uuidv4(),
         datePublished : 123 //published must be present
       },
       authorization: {


### PR DESCRIPTION
1. moved `recordId` to be a sibling property with `descriptor`
2. added `curly`  linter rule
3. renamed `validateSchema()` 