### PR TITLE
#170 - fixed bug where records with `published` explicitly set to `false` is included as published records

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Code Coverage
 
-![Statements](https://img.shields.io/badge/statements-92.26%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-91.16%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-88.88%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-92.26%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-92.27%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-91.23%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-88.88%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-92.27%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/src/interfaces/collections/handlers/collections-query.ts
+++ b/src/interfaces/collections/handlers/collections-query.ts
@@ -89,7 +89,7 @@ async function fetchPublishedRecords(collectionsQuery: CollectionsQuery, message
   const includeCriteria = {
     target            : collectionsQuery.target,
     method            : DwnMethodName.CollectionsWrite,
-    published         : true,
+    published         : 'true',
     isLatestBaseState : 'true',
     ...collectionsQuery.message.descriptor.filter
   };
@@ -116,7 +116,7 @@ async function fetchUnpublishedRecordsForRequester(collectionsQuery: Collections
 
   // exclude all published records
   const excludeCriteria = {
-    published: true
+    published: 'true'
   };
 
   const unpublishedRecordsForRequester = await messageStore.query(includeCriteria, excludeCriteria);
@@ -140,7 +140,7 @@ async function fetchUnpublishedRecordsByRequester(collectionsQuery: CollectionsQ
 
   // exclude all published records
   const excludeCriteria = {
-    published: true
+    published: 'true'
   };
 
   const unpublishedRecordsForRequester = await messageStore.query(includeCriteria, excludeCriteria);

--- a/src/interfaces/permissions/handlers/permissions-request.ts
+++ b/src/interfaces/permissions/handlers/permissions-request.ts
@@ -26,7 +26,8 @@ export const handlePermissionsRequest: MethodHandler = async (
   }
 
   try {
-    await messageStore.put(message, { author, target });
+    const index = { author, target, ... message.descriptor };
+    await messageStore.put(message, index);
 
     return new MessageReply({
       status: { code: 202, detail: 'Accepted' }

--- a/src/interfaces/protocols/handlers/protocols-configure.ts
+++ b/src/interfaces/protocols/handlers/protocols-configure.ts
@@ -53,7 +53,8 @@ export const handleProtocolsConfigure: MethodHandler = async (
     let messageReply: MessageReply;
     if (incomingMessageIsNewest) {
       const { author, target } = protocolsConfigure;
-      await messageStore.put(message, { author, target });
+      const index = { author, target, ... message.descriptor };
+      await messageStore.put(message, index);
 
       messageReply = new MessageReply({
         status: { code: 202, detail: 'Accepted' }

--- a/src/store/message-store-level.ts
+++ b/src/store/message-store-level.ts
@@ -127,7 +127,7 @@ export class MessageStoreLevel implements MessageStore {
     return;
   }
 
-  async put(messageJson: BaseMessage, additionalIndexes: { [key: string]: string }): Promise<void> {
+  async put(messageJson: BaseMessage, indexes: { [key: string]: string }): Promise<void> {
 
     // delete `encodedData` if it exists so `messageJson` is stored without it, `encodedData` will be decoded, chunked and stored separately below
     let encodedData = undefined;
@@ -157,8 +157,7 @@ export class MessageStoreLevel implements MessageStore {
 
     const indexDocument = {
       _id: encodedBlock.cid.toString(),
-      ...messageJson.descriptor,
-      ...additionalIndexes
+      ...indexes
     };
 
     // tokenSplitRegex is used to tokenize values. By default, only letters and digits are indexed,

--- a/src/store/message-store.ts
+++ b/src/store/message-store.ts
@@ -15,9 +15,9 @@ export interface MessageStore {
 
   /**
    * adds a message to the underlying store. Uses the message's cid as the key
-   * @param additionalIndexes additional indexes (key-value pairs) to be included as part of this put operation
+   * @param indexes indexes (key-value pairs) to be included as part of this put operation
    */
-  put(messageJson: BaseMessage, additionalIndexes: { [key: string]: string }): Promise<void>;
+  put(messageJson: BaseMessage, indexes: { [key: string]: string }): Promise<void>;
 
   /**
    * fetches a single message by `cid` from the underlying store. Returns `undefined`

--- a/tests/store/message-store.spec.ts
+++ b/tests/store/message-store.spec.ts
@@ -94,7 +94,8 @@ describe('MessageStoreLevel Tests', () => {
       expect(results.length).to.equal(1);
     });
 
-    it('should be able to update (delete and insert new) indexes to an existing message', async () => {
+    // https://github.com/TBD54566975/dwn-sdk-js/issues/170
+    it('#170 - should be able to update (delete and insert new) indexes to an existing message', async () => {
       const { target, message } = await TestDataGenerator.generateCollectionsWriteMessage();
 
       // inserting the message indicating it is the 'latest' in the index
@@ -122,7 +123,7 @@ describe('MessageStoreLevel Tests', () => {
       const schema = 'http://my-awesome-schema/awesomeness_schema#awesome-1?id=awesome_1';
       const messageData = await TestDataGenerator.generateCollectionsWriteMessage({ schema });
 
-      await messageStore.put(messageData.message, { });
+      await messageStore.put(messageData.message, { schema });
 
       const results = await messageStore.query({ schema });
       expect((results[0] as CollectionsWriteMessage).descriptor.schema).to.equal(schema);


### PR DESCRIPTION
If `published` is not set then behave as expected, but still, horrible security bug.