### PR TITLE
Implement DateSort #167

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-92.36%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-91.3%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-88.96%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-92.36%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-92.37%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-91.3%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-88.96%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-92.37%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-66.11%25-red.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-61.45%25-red.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-51.61%25-red.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-66.11%25-red.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-92.36%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-91.3%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-88.96%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-92.36%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-92.37%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-91.3%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-88.96%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-92.37%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-92.39%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-91.51%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-88.96%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-92.39%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-92.28%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-91.27%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-88.88%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-92.28%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-92.31%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-90.95%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-89.03%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-92.31%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-92.31%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-90.95%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-89.03%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-92.31%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-66.11%25-red.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-61.45%25-red.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-51.61%25-red.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-66.11%25-red.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Code Coverage
 
-![Statements](https://img.shields.io/badge/statements-92.27%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-91.23%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-88.88%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-92.27%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-92.29%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-90.88%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-89.03%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-92.29%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/src/core/message.ts
+++ b/src/core/message.ts
@@ -6,9 +6,10 @@ import { CollectionsWriteMessage } from '../interfaces/collections/types.js';
 import { GeneralJws } from '../jose/jws/general/types.js';
 import { GeneralJwsSigner } from '../jose/jws/general/signer.js';
 import { GeneralJwsVerifier } from '../jose/jws/general/verifier.js';
+import { generateCid } from '../utils/cid.js';
+import { lexicographicalCompare } from '../utils/string.js';
 import { validateJsonSchema } from '../validator.js';
 
-import { compareCids, generateCid } from '../utils/cid.js';
 
 export enum DwnMethodName {
   CollectionsWrite = 'CollectionsWrite',
@@ -83,7 +84,7 @@ export abstract class Message {
     // the < and > operators compare strings in lexicographical order
     const cidA = await Message.getCid(a);
     const cidB = await Message.getCid(b);
-    return compareCids(cidA, cidB);
+    return lexicographicalCompare(cidA, cidB);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export type { ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureMessage, Pr
 export type { DwnServiceEndpoint, ServiceEndpoint, DidDocument, DidResolutionResult, DidResolutionMetadata, DidDocumentMetadata, VerificationMethod } from './did/did-resolver.js';
 export { CollectionsQuery, CollectionsQueryOptions } from './interfaces/collections/messages/collections-query.js';
 export { CollectionsWrite, CollectionsWriteOptions } from './interfaces/collections/messages/collections-write.js';
+export { DateSort } from './interfaces/collections/messages/collections-query.js';
 export { DidKeyResolver } from './did/did-key-resolver.js';
 export { DidIonResolver } from './did/did-ion-resolver.js';
 export { DidResolver } from './did/did-resolver.js';

--- a/src/interfaces/collections/handlers/collections-query.ts
+++ b/src/interfaces/collections/handlers/collections-query.ts
@@ -170,43 +170,39 @@ async function handleDateSort(
   entries: BaseMessage[]
 ): Promise<BaseMessage[]> {
 
-  const publishedFilter = (message): boolean => {
-    return message.descriptor.published;
-  };
-
-  const compareDateCreatedAscending = (left, right): number => {
-    return Number(left.descriptor.dateCreated) - Number(right.descriptor.dateCreated);
-  };
-
-  const compareDateCreatedDescending = (left, right): number => {
-    return Number(right.descriptor.dateCreated) - Number(left.descriptor.dateCreated);
-  };
-
-  const compareDatePublishedAscending = (left, right): number => {
-    return Number(left.descriptor.datePublished) - Number(right.descriptor.datePublished);
-  };
-
-  const compareDatePublishedDescending = (left, right): number => {
-    return Number(right.descriptor.datePublished) - Number(left.descriptor.datePublished);
-  };
-
   const { dateSort } = collectionsQuery.message.descriptor;
   const collectionMessages = entries as CollectionsWriteMessage[];
 
   switch (dateSort) {
   case DateSortName.CreatedAscending:
-    return collectionMessages.sort(compareDateCreatedAscending);
+    return collectionMessages.sort(getCompareByPropertyFn('dateCreated', 'asc'));
   case DateSortName.CreatedDescending:
-    return collectionMessages.sort(compareDateCreatedDescending);
-  case DateSortName.PublishedAscending:
+    return collectionMessages.sort(getCompareByPropertyFn('dateCreated', 'desc'));
+  case DateSortName.PublishedAscending: 
     return collectionMessages
-      .filter(publishedFilter)
-      .sort(compareDatePublishedAscending);
-  case DateSortName.PublishedDescending:
+      .filter(m => m.descriptor.published)
+      .sort(getCompareByPropertyFn('datePublished', 'asc'));
+  case DateSortName.PublishedDescending: 
     return collectionMessages
-      .filter(publishedFilter)
-      .sort(compareDatePublishedDescending);
+      .filter(m => m.descriptor.published)
+      .sort(getCompareByPropertyFn('datePublished', 'desc'));
   default:
     throw new Error(`Invalid DateSort String: ${dateSort}`);
+  }
+}
+
+function getCompareByPropertyFn(
+  property: string, 
+  direction: 'asc' | 'desc'
+): (left: CollectionsWriteMessage, right: CollectionsWriteMessage) => number {
+
+  if (direction === 'asc') {
+   return (left, right): number => {
+      return Number(left.descriptor[property]) - Number(right.descriptor[property]);
+    }; 
+  }
+
+  return (left, right): number => {
+    return  Number(right.descriptor[property]) - Number(left.descriptor[property]);
   }
 }

--- a/src/interfaces/collections/handlers/collections-query.ts
+++ b/src/interfaces/collections/handlers/collections-query.ts
@@ -8,7 +8,7 @@ import { lexicographicalCompare } from '../../../utils/string.js';
 import { MessageReply } from '../../../core/message-reply.js';
 import { MessageStore } from '../../../store/message-store.js';
 import { removeUndefinedProperties } from '../../../utils/object.js';
-import { CollectionsQuery, DateSortName } from '../messages/collections-query.js';
+import { CollectionsQuery, DateSort } from '../messages/collections-query.js';
 
 export const handleCollectionsQuery: MethodHandler = async (
   message,
@@ -184,15 +184,15 @@ async function handleDateSort(
   const collectionMessages = entries as CollectionsWriteMessage[];
 
   switch (dateSort) {
-  case DateSortName.CreatedAscending:
+  case DateSort.CreatedAscending:
     return collectionMessages.sort((a, b) => lexicographicalCompare(a.descriptor.dateCreated, b.descriptor.dateCreated));
-  case DateSortName.CreatedDescending:
+  case DateSort.CreatedDescending:
     return collectionMessages.sort((a, b) => lexicographicalCompare(b.descriptor.dateCreated, a.descriptor.dateCreated));
-  case DateSortName.PublishedAscending:
+  case DateSort.PublishedAscending:
     return collectionMessages
       .filter(m => m.descriptor.published)
       .sort((a, b) => lexicographicalCompare(a.descriptor.datePublished, b.descriptor.datePublished));
-  case DateSortName.PublishedDescending:
+  case DateSort.PublishedDescending:
     return collectionMessages
       .filter(m => m.descriptor.published)
       .sort((a, b) => lexicographicalCompare(b.descriptor.datePublished, a.descriptor.datePublished));

--- a/src/interfaces/collections/handlers/collections-query.ts
+++ b/src/interfaces/collections/handlers/collections-query.ts
@@ -198,11 +198,23 @@ function getCompareByPropertyFn(
 
   if (direction === 'asc') {
     return (left, right): number => {
-      return left.descriptor[property] - right.descriptor[property];
+      if (left.descriptor[property] > right.descriptor[property]) {
+        return 1;
+      } else if (left.descriptor[property] < right.descriptor[property]) {
+        return -1;
+      } else {
+        return 0;
+      }
     };
   }
 
   return (left, right): number => {
-    return right.descriptor[property] - left.descriptor[property];
+    if (right.descriptor[property] > left.descriptor[property]) {
+      return 1;
+    } else if (right.descriptor[property] < left.descriptor[property]) {
+      return -1;
+    } else {
+      return 0;
+    }
   };
 }

--- a/src/interfaces/collections/handlers/collections-query.ts
+++ b/src/interfaces/collections/handlers/collections-query.ts
@@ -4,6 +4,7 @@ import type { CollectionsQueryMessage, CollectionsWriteMessage } from '../types.
 import { authenticate } from '../../../core/auth.js';
 import { BaseMessage } from '../../../core/types.js';
 import { DwnMethodName } from '../../../core/message.js';
+import { lexicographicalCompare } from '../../../utils/string.js';
 import { MessageReply } from '../../../core/message-reply.js';
 import { MessageStore } from '../../../store/message-store.js';
 import { removeUndefinedProperties } from '../../../utils/object.js';
@@ -184,46 +185,18 @@ async function handleDateSort(
 
   switch (dateSort) {
   case DateSortName.CreatedAscending:
-    return collectionMessages.sort(getCompareByPropertyFn('dateCreated', 'asc'));
+    return collectionMessages.sort((a, b) => lexicographicalCompare(a.descriptor.dateCreated, b.descriptor.dateCreated));
   case DateSortName.CreatedDescending:
-    return collectionMessages.sort(getCompareByPropertyFn('dateCreated', 'desc'));
+    return collectionMessages.sort((a, b) => lexicographicalCompare(b.descriptor.dateCreated, a.descriptor.dateCreated));
   case DateSortName.PublishedAscending:
     return collectionMessages
       .filter(m => m.descriptor.published)
-      .sort(getCompareByPropertyFn('datePublished', 'asc'));
+      .sort((a, b) => lexicographicalCompare(a.descriptor.datePublished, b.descriptor.datePublished));
   case DateSortName.PublishedDescending:
     return collectionMessages
       .filter(m => m.descriptor.published)
-      .sort(getCompareByPropertyFn('datePublished', 'desc'));
+      .sort((a, b) => lexicographicalCompare(b.descriptor.datePublished, a.descriptor.datePublished));
   default:
-    throw new Error(`Invalid DateSort String: ${dateSort}`);
+    throw new Error(`Invalid dateSort string: ${dateSort}`);
   }
-}
-
-function getCompareByPropertyFn(
-  property: string,
-  direction: 'asc' | 'desc'
-): (left: CollectionsWriteMessage, right: CollectionsWriteMessage) => number {
-
-  if (direction === 'asc') {
-    return (left, right): number => {
-      if (left.descriptor[property] > right.descriptor[property]) {
-        return 1;
-      } else if (left.descriptor[property] < right.descriptor[property]) {
-        return -1;
-      } else {
-        return 0;
-      }
-    };
-  }
-
-  return (left, right): number => {
-    if (right.descriptor[property] > left.descriptor[property]) {
-      return 1;
-    } else if (right.descriptor[property] < left.descriptor[property]) {
-      return -1;
-    } else {
-      return 0;
-    }
-  };
 }

--- a/src/interfaces/collections/handlers/collections-query.ts
+++ b/src/interfaces/collections/handlers/collections-query.ts
@@ -40,16 +40,17 @@ export const handleCollectionsQuery: MethodHandler = async (
       records = await fetchRecordsAsNonOwner(collectionsQuery, messageStore);
     }
 
+    // sort if `dataSort` is specified
+    if (collectionsQuery.message.descriptor.dateSort) {
+      records = await handleDateSort(collectionsQuery, records);
+    }
+
     // strip away `authorization` property for each record before responding
     const entries = [];
     for (const record of records) {
       const recordDuplicate = { ...record };
       delete recordDuplicate.authorization;
       entries.push(recordDuplicate);
-    }
-
-    if (collectionsQuery.message.descriptor.dateSort) {
-      entries = await handleDateSort(collectionsQuery, entries);
     }
 
     return new MessageReply({

--- a/src/interfaces/collections/handlers/collections-query.ts
+++ b/src/interfaces/collections/handlers/collections-query.ts
@@ -198,11 +198,11 @@ function getCompareByPropertyFn(
 
   if (direction === 'asc') {
     return (left, right): number => {
-      return Number(left.descriptor[property]) - Number(right.descriptor[property]);
+      return left.descriptor[property] - right.descriptor[property];
     };
   }
 
   return (left, right): number => {
-    return Number(right.descriptor[property]) - Number(left.descriptor[property]);
+    return right.descriptor[property] - left.descriptor[property];
   };
 }

--- a/src/interfaces/collections/handlers/collections-query.ts
+++ b/src/interfaces/collections/handlers/collections-query.ts
@@ -196,7 +196,5 @@ async function handleDateSort(
     return collectionMessages
       .filter(m => m.descriptor.published)
       .sort((a, b) => lexicographicalCompare(b.descriptor.datePublished, a.descriptor.datePublished));
-  default:
-    throw new Error(`Invalid dateSort string: ${dateSort}`);
   }
 }

--- a/src/interfaces/collections/handlers/collections-query.ts
+++ b/src/interfaces/collections/handlers/collections-query.ts
@@ -43,7 +43,7 @@ export const handleCollectionsQuery: MethodHandler = async (
 
     // sort if `dataSort` is specified
     if (collectionsQuery.message.descriptor.dateSort) {
-      records = await handleDateSort(collectionsQuery, records);
+      records = await sortRecords(records, collectionsQuery.message.descriptor.dateSort);
     }
 
     // strip away `authorization` property for each record before responding
@@ -162,25 +162,22 @@ async function fetchUnpublishedRecordsByRequester(collectionsQuery: CollectionsQ
 }
 
 /**
- * Handles dateSort field passed in the CollectionsQuery. There are 4 options for dateSort:
+ * Sorts the given records. There are 4 options for dateSort:
  * 1. createdAscending - Sort in ascending order based on when the message was created
  * 2. createdDescending - Sort in descending order based on when the message was created
  * 3. publishedAscending - If the message is published, sort in asc based on publish date
  * 4. publishedDescending - If the message is published, sort in desc based on publish date
  *
- * If dateSort is not present we return the unmodified list of entries. This method throws
- * if there is an unsupported DateSort operation.
- *
- * @param collectionsQuery - Underlying Collections Query
+ * If sorting is based on date published, records that are not published are filtered out.
  * @param entries - Entries to be sorted if dateSort is present
- * @returns List of Messages
+ * @param dateSort - Sorting scheme
+ * @returns Sorted Messages
  */
-async function handleDateSort(
-  collectionsQuery: CollectionsQuery,
-  entries: BaseMessage[]
+async function sortRecords(
+  entries: BaseMessage[],
+  dateSort: DateSort
 ): Promise<BaseMessage[]> {
 
-  const { dateSort } = collectionsQuery.message.descriptor;
   const collectionMessages = entries as CollectionsWriteMessage[];
 
   switch (dateSort) {

--- a/src/interfaces/collections/handlers/collections-query.ts
+++ b/src/interfaces/collections/handlers/collections-query.ts
@@ -1,13 +1,13 @@
-import type { CollectionsQueryMessage } from '../types.js';
 import type { MethodHandler } from '../../types.js';
+import type { CollectionsQueryMessage, CollectionsWriteMessage } from '../types.js';
 
 import { authenticate } from '../../../core/auth.js';
 import { BaseMessage } from '../../../core/types.js';
-import { CollectionsQuery } from '../messages/collections-query.js';
 import { DwnMethodName } from '../../../core/message.js';
 import { MessageReply } from '../../../core/message-reply.js';
 import { MessageStore } from '../../../store/message-store.js';
 import { removeUndefinedProperties } from '../../../utils/object.js';
+import { CollectionsQuery, DateSortName } from '../messages/collections-query.js';
 
 export const handleCollectionsQuery: MethodHandler = async (
   message,
@@ -38,6 +38,10 @@ export const handleCollectionsQuery: MethodHandler = async (
       entries = await fetchRecordsAsOwner(collectionsQuery, messageStore);
     } else {
       entries = await fetchRecordsAsNonOwner(collectionsQuery, messageStore);
+    }
+
+    if (collectionsQuery.message.descriptor.dateSort) {
+      entries = await handleDateSort(collectionsQuery, entries);
     }
 
     return new MessageReply({
@@ -145,4 +149,64 @@ async function fetchUnpublishedRecordsByRequester(collectionsQuery: CollectionsQ
 
   const unpublishedRecordsForRequester = await messageStore.query(includeCriteria, excludeCriteria);
   return unpublishedRecordsForRequester;
+}
+
+/**
+ * Handles dateSort field passed in the CollectionsQuery. There are 4 options for dateSort:
+ * 1. createdAscending - Sort in ascending order based on when the message was created
+ * 2. createdDescending - Sort in descending order based on when the message was created
+ * 3. publishedAscending - If the message is published, sort in asc based on publish date
+ * 4. publishedDescending - If the message is published, sort in desc based on publish date
+ *
+ * If dateSort is not present we return the unmodified list of entries. This method throws
+ * if there is an unsupported DateSort operation.
+ *
+ * @param collectionsQuery - Underlying Collections Query
+ * @param entries - Entries to be sorted if dateSort is present
+ * @returns List of Messages
+ */
+async function handleDateSort(
+  collectionsQuery: CollectionsQuery,
+  entries: BaseMessage[]
+): Promise<BaseMessage[]> {
+
+  const publishedFilter = (message): boolean => {
+    return message.descriptor.published;
+  };
+
+  const compareDateCreatedAscending = (left, right): number => {
+    return Number(left.descriptor.dateCreated) - Number(right.descriptor.dateCreated);
+  };
+
+  const compareDateCreatedDescending = (left, right): number => {
+    return Number(right.descriptor.dateCreated) - Number(left.descriptor.dateCreated);
+  };
+
+  const compareDatePublishedAscending = (left, right): number => {
+    return Number(left.descriptor.datePublished) - Number(right.descriptor.datePublished);
+  };
+
+  const compareDatePublishedDescending = (left, right): number => {
+    return Number(right.descriptor.datePublished) - Number(left.descriptor.datePublished);
+  };
+
+  const { dateSort } = collectionsQuery.message.descriptor;
+  const collectionMessages = entries as CollectionsWriteMessage[];
+
+  switch (dateSort) {
+  case DateSortName.CreatedAscending:
+    return collectionMessages.sort(compareDateCreatedAscending);
+  case DateSortName.CreatedDescending:
+    return collectionMessages.sort(compareDateCreatedDescending);
+  case DateSortName.PublishedAscending:
+    return collectionMessages
+      .filter(publishedFilter)
+      .sort(compareDatePublishedAscending);
+  case DateSortName.PublishedDescending:
+    return collectionMessages
+      .filter(publishedFilter)
+      .sort(compareDatePublishedDescending);
+  default:
+    throw new Error(`Invalid DateSort String: ${dateSort}`);
+  }
 }

--- a/src/interfaces/collections/handlers/collections-query.ts
+++ b/src/interfaces/collections/handlers/collections-query.ts
@@ -178,11 +178,11 @@ async function handleDateSort(
     return collectionMessages.sort(getCompareByPropertyFn('dateCreated', 'asc'));
   case DateSortName.CreatedDescending:
     return collectionMessages.sort(getCompareByPropertyFn('dateCreated', 'desc'));
-  case DateSortName.PublishedAscending: 
+  case DateSortName.PublishedAscending:
     return collectionMessages
       .filter(m => m.descriptor.published)
       .sort(getCompareByPropertyFn('datePublished', 'asc'));
-  case DateSortName.PublishedDescending: 
+  case DateSortName.PublishedDescending:
     return collectionMessages
       .filter(m => m.descriptor.published)
       .sort(getCompareByPropertyFn('datePublished', 'desc'));
@@ -192,17 +192,17 @@ async function handleDateSort(
 }
 
 function getCompareByPropertyFn(
-  property: string, 
+  property: string,
   direction: 'asc' | 'desc'
 ): (left: CollectionsWriteMessage, right: CollectionsWriteMessage) => number {
 
   if (direction === 'asc') {
-   return (left, right): number => {
+    return (left, right): number => {
       return Number(left.descriptor[property]) - Number(right.descriptor[property]);
-    }; 
+    };
   }
 
   return (left, right): number => {
-    return  Number(right.descriptor[property]) - Number(left.descriptor[property]);
-  }
+    return Number(right.descriptor[property]) - Number(left.descriptor[property]);
+  };
 }

--- a/src/interfaces/collections/messages/collections-query.ts
+++ b/src/interfaces/collections/messages/collections-query.ts
@@ -38,11 +38,6 @@ export class CollectionsQuery extends Message {
 
   public static async parse(message: CollectionsQueryMessage): Promise<CollectionsQuery> {
     await validateAuthorizationIntegrity(message);
-
-    if (message.descriptor.dateSort) {
-      throw new Error('`dateSort` not implemented');
-    }
-
     return new CollectionsQuery(message);
   }
 

--- a/src/interfaces/collections/messages/collections-query.ts
+++ b/src/interfaces/collections/messages/collections-query.ts
@@ -7,6 +7,13 @@ import { Message } from '../../../core/message.js';
 import { removeUndefinedProperties } from '../../../utils/object.js';
 import { validateAuthorizationIntegrity } from '../../../core/auth.js';
 
+export enum DateSortName {
+  CreatedAscending = 'createdAscending',
+  CreatedDescending = 'createdDescending',
+  PublishedAscending = 'publishedAscending',
+  PublishedDescending = 'publishedDescending'
+}
+
 export type CollectionsQueryOptions = AuthCreateOptions & {
   target: string;
   dateCreated?: string;

--- a/src/interfaces/collections/messages/collections-query.ts
+++ b/src/interfaces/collections/messages/collections-query.ts
@@ -7,7 +7,7 @@ import { Message } from '../../../core/message.js';
 import { removeUndefinedProperties } from '../../../utils/object.js';
 import { validateAuthorizationIntegrity } from '../../../core/auth.js';
 
-export enum DateSortName {
+export enum DateSort {
   CreatedAscending = 'createdAscending',
   CreatedDescending = 'createdDescending',
   PublishedAscending = 'publishedAscending',
@@ -26,7 +26,7 @@ export type CollectionsQueryOptions = AuthCreateOptions & {
     parentId?: string;
     dataFormat?: string;
   },
-  dateSort?: string;
+  dateSort?: DateSort;
 };
 
 export class CollectionsQuery extends Message {

--- a/src/interfaces/collections/messages/collections-write.ts
+++ b/src/interfaces/collections/messages/collections-write.ts
@@ -280,5 +280,3 @@ export class CollectionsWrite extends Message {
     return Message.compareCid(a, b);
   }
 }
-
-

--- a/src/interfaces/collections/types.ts
+++ b/src/interfaces/collections/types.ts
@@ -1,4 +1,5 @@
 import { BaseMessage } from '../../core/types.js';
+import { DateSort } from './messages/collections-query.js';
 import { DwnMethodName } from '../../core/message.js';
 
 export type CollectionsWriteDescriptor = {
@@ -34,7 +35,7 @@ export type CollectionsQueryDescriptor = {
     parentId?: string;
     dataFormat?: string;
   }
-  dateSort?: string;
+  dateSort?: DateSort;
 };
 
 export type CollectionsWriteAuthorizationPayload = {

--- a/src/utils/cid.ts
+++ b/src/utils/cid.ts
@@ -69,18 +69,3 @@ export function parseCid(str: string): CID {
 
   return cid;
 }
-
-/**
- * Compares two CIDs given in lexicographical order.
- * @returns 1 if `a` is larger than `b`; -1 if `a` is smaller/older than `b`; 0 otherwise (same message)
- */
-export function compareCids(a: CID, b: CID): number {
-  // the < and > operators compare strings in lexicographical order
-  if (a > b) {
-    return 1;
-  } else if (a < b) {
-    return -1;
-  } else {
-    return 0;
-  }
-}

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,0 +1,13 @@
+/**
+ * Compares two string given in lexicographical order.
+ * @returns 1 if `a` is larger than `b`; -1 if `a` is smaller/older than `b`; 0 otherwise (same message)
+ */
+export function lexicographicalCompare(a: string, b: string): number {
+  if (a > b) {
+    return 1;
+  } else if (a < b) {
+    return -1;
+  } else {
+    return 0;
+  }
+}

--- a/tests/interfaces/collections/handlers/collections-query.spec.ts
+++ b/tests/interfaces/collections/handlers/collections-query.spec.ts
@@ -83,7 +83,7 @@ describe('handleCollectionsQuery()', () => {
       expect(reply2.status.code).to.equal(200);
       expect(reply2.entries?.length).to.equal(1); // only 1 entry should match the query
     });
-    
+
     it('should not include `authorization` in returned records', async () => {
       // insert three messages into DB, two with matching protocol
       const alice = await TestDataGenerator.generatePersona();

--- a/tests/interfaces/collections/handlers/collections-query.spec.ts
+++ b/tests/interfaces/collections/handlers/collections-query.spec.ts
@@ -107,7 +107,7 @@ describe('handleCollectionsQuery()', () => {
       expect(queryReply.entries[0]['authorization']).to.equal(undefined);
     });
 
-    it.only('should omit records that are not published if `dateSort` sorts on `datePublished`', async () => {
+    it('should omit records that are not published if `dateSort` sorts on `datePublished`', async () => {
       // insert three messages into DB, two with matching protocol
       const alice = await TestDataGenerator.generatePersona();
       const schema = 'aSchema';

--- a/tests/interfaces/collections/handlers/collections-query.spec.ts
+++ b/tests/interfaces/collections/handlers/collections-query.spec.ts
@@ -9,7 +9,7 @@ import { handleCollectionsQuery } from '../../../../src/interfaces/collections/h
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
-import { CollectionsQuery, DateSortName } from '../../../../src/interfaces/collections/messages/collections-query.js';
+import { CollectionsQuery, DateSort } from '../../../../src/interfaces/collections/messages/collections-query.js';
 import { constructIndexes, handleCollectionsWrite } from '../../../../src/interfaces/collections/handlers/collections-write.js';
 
 chai.use(chaiAsPromised);
@@ -131,7 +131,7 @@ describe('handleCollectionsQuery()', () => {
       const publishedAscendingQueryData = await TestDataGenerator.generateCollectionsQueryMessage({
         requester : alice,
         target    : alice,
-        dateSort  : DateSortName.PublishedAscending,
+        dateSort  : DateSort.PublishedAscending,
         filter    : { schema }
       });
       const publishedAscendingQueryReply = await handleCollectionsQuery(publishedAscendingQueryData.message, messageStore, didResolverStub);
@@ -143,7 +143,7 @@ describe('handleCollectionsQuery()', () => {
       const publishedDescendingQueryData = await TestDataGenerator.generateCollectionsQueryMessage({
         requester : alice,
         target    : alice,
-        dateSort  : DateSortName.PublishedDescending,
+        dateSort  : DateSort.PublishedDescending,
         filter    : { schema }
       });
       const publishedDescendingQueryReply = await handleCollectionsQuery(publishedDescendingQueryData.message, messageStore, didResolverStub);
@@ -176,7 +176,7 @@ describe('handleCollectionsQuery()', () => {
       const createdAscendingQueryData = await TestDataGenerator.generateCollectionsQueryMessage({
         requester : alice,
         target    : alice,
-        dateSort  : DateSortName.CreatedAscending,
+        dateSort  : DateSort.CreatedAscending,
         filter    : { schema }
       });
       const createdAscendingQueryReply = await handleCollectionsQuery(createdAscendingQueryData.message, messageStore, didResolverStub);
@@ -189,7 +189,7 @@ describe('handleCollectionsQuery()', () => {
       const createdDescendingQueryData = await TestDataGenerator.generateCollectionsQueryMessage({
         requester : alice,
         target    : alice,
-        dateSort  : DateSortName.CreatedDescending,
+        dateSort  : DateSort.CreatedDescending,
         filter    : { schema }
       });
       const createdDescendingQueryReply = await handleCollectionsQuery(createdDescendingQueryData.message, messageStore, didResolverStub);
@@ -202,7 +202,7 @@ describe('handleCollectionsQuery()', () => {
       const publishedAscendingQueryData = await TestDataGenerator.generateCollectionsQueryMessage({
         requester : alice,
         target    : alice,
-        dateSort  : DateSortName.PublishedAscending,
+        dateSort  : DateSort.PublishedAscending,
         filter    : { schema }
       });
       const publishedAscendingQueryReply = await handleCollectionsQuery(publishedAscendingQueryData.message, messageStore, didResolverStub);
@@ -215,7 +215,7 @@ describe('handleCollectionsQuery()', () => {
       const publishedDescendingQueryData = await TestDataGenerator.generateCollectionsQueryMessage({
         requester : alice,
         target    : alice,
-        dateSort  : DateSortName.PublishedDescending,
+        dateSort  : DateSort.PublishedDescending,
         filter    : { schema }
       });
       const publishedDescendingQueryReply = await handleCollectionsQuery(publishedDescendingQueryData.message, messageStore, didResolverStub);
@@ -408,12 +408,13 @@ describe('handleCollectionsQuery()', () => {
   });
 
   it('should return 400 if fail parsing the message', async () => {
-    const { requester, message } = await TestDataGenerator.generateCollectionsQueryMessage({ dateSort: 'createdAscending' });
+    const { requester, message } = await TestDataGenerator.generateCollectionsQueryMessage();
 
     // setting up a stub method resolver & message store
     const didResolverStub = TestStubGenerator.createDidResolverStub(requester);
     const messageStoreStub = sinon.createStubInstance(MessageStoreLevel);
 
+    // stub the `parse()` function to throw an error
     sinon.stub(CollectionsQuery, 'parse').throws('anyError');
     const reply = await handleCollectionsQuery(message, messageStoreStub, didResolverStub);
 

--- a/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
@@ -2,11 +2,11 @@ import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
 
-import { compareCids } from '../../../../src/utils/cid.js';
 import { DidKeyResolver } from '../../../../src/did/did-key-resolver.js';
 import { GeneralJwsSigner } from '../../../../src/jose/jws/general/signer.js';
 import { handleProtocolsConfigure } from '../../../../src/interfaces/protocols/handlers/protocols-configure.js';
 import { handleProtocolsQuery } from '../../../../src/interfaces/protocols/handlers/protocols-query.js';
+import { lexicographicalCompare } from '../../../../src/utils/string.js';
 import { Message } from '../../../../src/core/message.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
@@ -105,7 +105,7 @@ describe('handleProtocolsQuery()', () => {
         messageDataWithMediumLexicographicValue,
         messageDataWithLargestLexicographicValue
       ]: GenerateProtocolsConfigureMessageOutput[]
-        = messageDataWithCid.sort((messageDataA, messageDataB) => { return compareCids(messageDataA.cid, messageDataB.cid); });
+        = messageDataWithCid.sort((messageDataA, messageDataB) => { return lexicographicalCompare(messageDataA.cid, messageDataB.cid); });
 
       // write the protocol with the middle lexicographic value
       let reply = await handleProtocolsConfigure(messageDataWithMediumLexicographicValue.message, messageStore, didResolver);

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -16,6 +16,7 @@ import {
   CollectionsWrite,
   CollectionsWriteMessage,
   CollectionsWriteOptions,
+  DateSort,
   HooksWrite,
   HooksWriteMessage,
   HooksWriteOptions,
@@ -106,7 +107,7 @@ export type GenerateCollectionsQueryMessageInput = {
     parentId?: string;
     dataFormat?: string;
   }
-  dateSort?: string;
+  dateSort?: DateSort;
 };
 
 export type GenerateCollectionsQueryMessageOutput = {


### PR DESCRIPTION
### Problem
`dateSort` has not yet been implemented for `CollectionsQuery` message types. Today, if a `CollectionQuery` contains the `dateSort` field the request will throw an error. We want to implement this behavior. ref: #167 

### Solution

The solution to this problem entails the following:

1. Add a new `enum DateSortName` to encapsulate the raw string values that can be passed in.
2. Implement a `handleDateSort` function that accepts a `collectionQuery` and an array of `BaseMessage`.

The `handleDateSort` function extracts the `dateSort` value, and casts the BaseMessage type to a `CollectionWriteMessage` to gain access to the properties required to sort / filter entries. Then, we switch on `dateSort` and sort accordingly.

### Result
We can now support a `CollectionQuery` that contains a `dateSort` field.
