### PR TITLE
Fix did ion resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-92.39%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-91.51%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-88.96%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-92.39%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-92.4%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-91.3%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-88.96%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-92.4%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/dwn-sdk-js",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "A reference implementation of https://identity.foundation/decentralized-web-node/spec/",
   "type": "module",
   "types": "./dist/esm/src/index.d.ts",

--- a/src/did/did-ion-resolver.ts
+++ b/src/did/did-ion-resolver.ts
@@ -16,7 +16,7 @@ export class DidIonResolver implements DidMethodResolver {
   /**
    * @param resolutionEndpoint optional custom URL to send DID resolution request to
    */
-  constructor (private resolutionEndpoint: string = 'https://beta.discover.did.microsoft.com/1.0/identifiers/') { }
+  constructor (private resolutionEndpoint: string = 'https://discover.did.msidentity.com/1.0/identifiers/') { }
 
   method(): string {
     return 'ion';

--- a/src/did/did-ion-resolver.ts
+++ b/src/did/did-ion-resolver.ts
@@ -11,7 +11,7 @@ export class DidIonResolver implements DidMethodResolver {
   /**
    * @param resolutionEndpoint optional custom URL to send DID resolution request to
    */
-  constructor (private resolutionEndpoint: string = 'https://discover.did.microsoft.com/1.0/identifiers/') { }
+  constructor (private resolutionEndpoint: string = 'https://beta.discover.did.microsoft.com/1.0/identifiers/') { }
 
   method(): string {
     return 'ion';

--- a/tests/did/did-ion-resolver.spec.ts
+++ b/tests/did/did-ion-resolver.spec.ts
@@ -9,7 +9,7 @@ import { DidIonResolver } from '../../src/did/did-ion-resolver.js';
 chai.use(chaiAsPromised);
 
 describe('DidIonResolver', () => {
-  const defaultResolutionEndpoint = 'https://beta.discover.did.microsoft.com/1.0/identifiers/';
+  const defaultResolutionEndpoint = 'https://discover.did.msidentity.com/1.0/identifiers/';
   let networkAvailable = false;
   before(async () => {
     // test network connectivity, `networkAvailable` is used by tests to decide whether to run tests through real network calls or stubs

--- a/tests/did/did-ion-resolver.spec.ts
+++ b/tests/did/did-ion-resolver.spec.ts
@@ -9,7 +9,7 @@ import { DidIonResolver } from '../../src/did/did-ion-resolver.js';
 chai.use(chaiAsPromised);
 
 describe('DidIonResolver', () => {
-  const defaultResolutionEndpoint = 'https://discover.did.microsoft.com/1.0/identifiers/';
+  const defaultResolutionEndpoint = 'https://beta.discover.did.microsoft.com/1.0/identifiers/';
   let networkAvailable = false;
   before(async () => {
     // test network connectivity, `networkAvailable` is used by tests to decide whether to run tests through real network calls or stubs
@@ -38,7 +38,7 @@ describe('DidIonResolver', () => {
 
     // stub network call if network is not available
     if (!networkAvailable) {
-      sinon.stub(didIonResolver as any, 'fetch').resolves({
+      sinon.stub(globalThis as any, 'fetch').resolves({
         status : 200,
         json   : async () => Promise.resolve({
           didDocument         : { id: did },
@@ -58,7 +58,7 @@ describe('DidIonResolver', () => {
 
     // stub network call if network is not available
     if (!networkAvailable) {
-      sinon.stub(didIonResolver as any, 'fetch').resolves({ status: 404 });
+      sinon.stub(globalThis as any, 'fetch').resolves({ status: 404 });
     }
 
     const resolutionPromise = didIonResolver.resolve(did);


### PR DESCRIPTION
# Summary
* Updated resolution endpoint to `beta.discover.did.microsoft.com`. `discover.did.microsoft.com` wasn't working
<img width="982" alt="image" src="https://user-images.githubusercontent.com/4887440/209606850-35e9e58f-3439-45f8-866a-754dee37b05f.png">


* Fixed an issue that was causing ION DID resolution to bork in browser extensions.
    * `cross-fetch` is a [ponyfill](https://github.com/sindresorhus/ponyfill) that uses `XMLHTTPRequest` under the hood in browser environments. Unfortunately, `XMLHTTPRequest` cannot be used in MV3 browser extension background service workers. browser extensions get even more strict with `fetch` in that it cannot be referenced indirectly. 

Screenshot is a console in the context of a background service worker. Running `XMLHTTPRequestTest` shows that use of `XMLHTTPRequest` is not allowed. `IndirectReferenceTest` shows inability to use fetch when referenced indirectly

![image](https://user-images.githubusercontent.com/4887440/209607187-d55f42aa-6101-409b-862f-537759a88dce.png)
