### PR TITLE
npm release automation from a github release

### DIFF
--- a/.github/workflows/npm-publish-unstable.yml
+++ b/.github/workflows/npm-publish-unstable.yml
@@ -1,0 +1,21 @@
+name: publish unstable
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  publish-npm-unstable:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.8.0
+          registry-url: https://registry.npmjs.org/
+      - run: npm install
+      - run: npm run publish:unstable
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,33 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,23 +1,13 @@
 # This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
-name: Node.js Package
+name: publish stable
 
 on:
   release:
     types: [created]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - run: npm ci
-      - run: npm test
-
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
@@ -25,9 +15,15 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18.8.0
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
-      - run: npm publish
+      - run: npm clean-install
+      # check the licences allow list to avoid incorrectly licensed dependencies creeping in: 
+      - run: npm run license-check
+      # builds all bundles
+      - run: npm run build
+      # runs tests in node environment without attempting to generate code coverage badges
+      - run: npm run test:node:ci
+      - run: npm publish      
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/build/publish-unstable.sh
+++ b/build/publish-unstable.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# This script handles the publishing of the current 
+# commits as an npm based unstable package
+
+# Example if the current package.json version reads 0.1.0 
+# then the unstable release of 0.1.1-unstable.(current git commit reference)
+
+# Add dev dependencies to current path
+export PATH="$PATH:node_modules/.bin"
+
+# Minor version the current package
+npm version --no-git-tag-version --patch
+
+# Fetch the current version from the package.json
+new_version=$(node -pe "require('./package.json').version")
+
+# Fetch the new unstable version
+new_unstable_version=$new_version"-unstable.$(git rev-parse --short HEAD)-$(date +'%Y.%m.%d-%H-%M-%S') "
+
+# Set the unstable version in the package.json
+npm version $new_unstable_version --no-git-tag-version
+
+# Publish the unstable version
+npm publish --tag unstable --no-git-tag-version
+
+# Reset changes to the package.json
+git checkout -- package.json

--- a/build/publish-unstable.sh
+++ b/build/publish-unstable.sh
@@ -3,14 +3,8 @@
 # This script handles the publishing of the current 
 # commits as an npm based unstable package
 
-# Example if the current package.json version reads 0.1.0 
-# then the unstable release of 0.1.1-unstable.(current git commit reference)
-
 # Add dev dependencies to current path
 export PATH="$PATH:node_modules/.bin"
-
-# Minor version the current package
-npm version --no-git-tag-version --patch
 
 # Fetch the current version from the package.json
 new_version=$(node -pe "require('./package.json').version")

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "test:node:ci": "npm run compile-validators && tsc && c8 mocha \"dist/esm/tests/**/*.spec.js\"",
     "test:browser": "npm run compile-validators && cross-env karma start karma.conf.cjs",
     "test:browser-debug": "npm run compile-validators && cross-env karma start karma.conf.debug.cjs",
-    "license-check": "license-report --only=prod > license-report.json && node ./build/license-check.cjs"
+    "license-check": "license-report --only=prod > license-report.json && node ./build/license-check.cjs",
+    "publish:unstable": "./build/publish-unstable.sh"
   },
   "dependencies": {
     "@ipld/dag-cbor": "7.0.1",


### PR DESCRIPTION
this is the first pass at release automation for npm - using the off the shelf github action recommendation.

To use this - you "simply" create a release on the github side - it takes care of the rest.