### PR TITLE
#209 - added support for attestation property in records

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-93.86%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-91.25%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-90.9%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.86%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.06%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-92.32%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-90.9%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.06%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.54%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.9%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.51%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.54%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.56%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.93%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.51%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.56%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.06%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-92.76%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-90.9%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.06%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.54%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.9%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.51%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.54%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.06%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-92.32%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-90.9%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.06%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.06%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-92.76%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-90.9%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.06%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-93.84%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-91.25%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-90.9%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.84%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-93.86%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-91.25%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-90.9%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.86%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-92.19%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-90.85%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-93.84%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-91.25%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-90.9%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.84%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/json-schemas/records/records-write.json
+++ b/json-schemas/records/records-write.json
@@ -15,6 +15,9 @@
     "contextId": {
       "type": "string"
     },
+    "attestation": {
+      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+    },
     "authorization": {
       "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3421,9 +3421,9 @@
       "dev": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "node_modules/http-errors": {
@@ -9927,9 +9927,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "http-errors": {

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -5,7 +5,7 @@ import { DidResolver } from '../did/did-resolver.js';
 import { GeneralJws } from '../jose/jws/general/types.js';
 import { GeneralJwsVerifier } from '../jose/jws/general/verifier.js';
 import { Message } from './message.js';
-import { generateCid, parseCid } from '../utils/cid.js';
+import { computeCid, parseCid } from '../utils/cid.js';
 
 type AuthorizationPayloadConstraints = {
   /** permissible properties within payload. Note that `descriptorCid` is implied and does not need to be added */
@@ -45,7 +45,7 @@ export async function validateAuthorizationIntegrity(
 
   // `descriptorCid` validation - ensure that the provided descriptorCid matches the CID of the actual message
   const providedDescriptorCid = parseCid(descriptorCid); // parseCid throws an exception if parsing fails
-  const expectedDescriptorCid = await generateCid(message.descriptor);
+  const expectedDescriptorCid = await computeCid(message.descriptor);
   if (!providedDescriptorCid.equals(expectedDescriptorCid)) {
     throw new Error(`provided descriptorCid ${providedDescriptorCid} does not match expected CID ${expectedDescriptorCid}`);
   }

--- a/src/core/message.ts
+++ b/src/core/message.ts
@@ -2,10 +2,10 @@ import type { SignatureInput } from '../jose/jws/general/types.js';
 import type { BaseDecodedAuthorizationPayload, BaseMessage, Descriptor, TimestampedMessage } from './types.js';
 
 import { CID } from 'multiformats/cid';
+import { computeCid } from '../utils/cid.js';
 import { GeneralJws } from '../jose/jws/general/types.js';
 import { GeneralJwsSigner } from '../jose/jws/general/signer.js';
 import { GeneralJwsVerifier } from '../jose/jws/general/verifier.js';
-import { generateCid } from '../utils/cid.js';
 import { lexicographicalCompare } from '../utils/string.js';
 import { RecordsWriteMessage } from '../interfaces/records/types.js';
 import { validateJsonSchema } from '../validator.js';
@@ -79,7 +79,7 @@ export abstract class Message {
       delete (messageCopy as RecordsWriteMessage).encodedData;
     }
 
-    const cid = await generateCid(messageCopy);
+    const cid = await computeCid(messageCopy);
     return cid;
   }
 
@@ -128,7 +128,7 @@ export abstract class Message {
     descriptor: Descriptor,
     signatureInput: SignatureInput
   ): Promise<GeneralJws> {
-    const descriptorCid = await generateCid(descriptor);
+    const descriptorCid = await computeCid(descriptor);
 
     const authPayload: BaseDecodedAuthorizationPayload = { descriptorCid: descriptorCid.toString() };
     const authPayloadStr = JSON.stringify(authPayload);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,4 +1,4 @@
-import type { GeneralJws, SignatureInput } from '../jose/jws/general/types.js';
+import type { GeneralJws } from '../jose/jws/general/types.js';
 
 /**
  * Intersection type for all concrete message types.
@@ -41,8 +41,4 @@ export type DataReferencingMessage = {
   };
 
   encodedData: string;
-};
-
-export type AuthCreateOptions = {
-  signatureInput: SignatureInput
 };

--- a/src/dwn.ts
+++ b/src/dwn.ts
@@ -68,7 +68,7 @@ export class Dwn {
       message = JSON.parse(requestString);
     } catch (error) {
       return new MessageReply({
-        status: { code: 400, detail: error.message }
+        status: { code: 400, detail: 'unable to JSON parse request' }
       });
     }
 
@@ -85,7 +85,7 @@ export class Dwn {
     const dwnMethod = rawMessage?.descriptor?.method;
     if (dwnInterface === undefined || dwnMethod === undefined) {
       return new MessageReply({
-        status: { code: 400, detail: `DWN interface or method is undefined` }
+        status: { code: 400, detail: `Both interface and method must be present, interface: ${dwnInterface}, method: ${dwnMethod}` }
       });
     }
 

--- a/src/interfaces/hooks/messages/hooks-write.ts
+++ b/src/interfaces/hooks/messages/hooks-write.ts
@@ -1,4 +1,4 @@
-import type { AuthCreateOptions } from '../../../core/types.js';
+import type { SignatureInput } from '../../../jose/jws/general/types.js';
 import type { HooksWriteDescriptor, HooksWriteMessage } from '../../hooks/types.js';
 
 import { getCurrentTimeInHighPrecision } from '../../../utils/time.js';
@@ -9,7 +9,7 @@ import { DwnInterfaceName, DwnMethodName, Message } from '../../../core/message.
 /**
  * Input to `HookssWrite.create()`.
  */
-export type HooksWriteOptions = AuthCreateOptions & {
+export type HooksWriteOptions = {
   dateCreated?: string,
   /**
    * leave as `undefined` for customer handler.
@@ -18,7 +18,8 @@ export type HooksWriteOptions = AuthCreateOptions & {
   uri?: string,
   filter: {
     method: string,
-  }
+  },
+  authorizationSignatureInput: SignatureInput;
 };
 
 /**
@@ -47,7 +48,7 @@ export class HooksWrite extends Message {
     // Error: `undefined` is not supported by the IPLD Data Model and cannot be encoded
     removeUndefinedProperties(descriptor);
 
-    const authorization = await Message.signAsAuthorization(descriptor, options.signatureInput);
+    const authorization = await Message.signAsAuthorization(descriptor, options.authorizationSignatureInput);
     const message = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/permissions/messages/permissions-grant.ts
+++ b/src/interfaces/permissions/messages/permissions-grant.ts
@@ -4,7 +4,7 @@ import type { PermissionConditions, PermissionScope } from '../types';
 import type { PermissionsGrantDescriptor, PermissionsGrantMessage } from '../types';
 
 import { CID } from 'multiformats/cid';
-import { generateCid } from '../../../utils/cid';
+import { computeCid } from '../../../utils/cid';
 import { getCurrentTimeInHighPrecision } from '../../../utils/time';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -101,7 +101,7 @@ export class PermissionsGrant extends Message {
       signatureInput : signatureInput
     });
 
-    delegatedGrant.delegatedFrom = await generateCid(this.message);
+    delegatedGrant.delegatedFrom = await computeCid(this.message);
     delegatedGrant.delegationChain = this.message;
 
     return delegatedGrant;

--- a/src/interfaces/permissions/messages/permissions-grant.ts
+++ b/src/interfaces/permissions/messages/permissions-grant.ts
@@ -1,4 +1,3 @@
-import type { AuthCreateOptions } from '../../../core/types';
 import type { SignatureInput } from '../../../jose/jws/general/types';
 import type { PermissionConditions, PermissionScope } from '../types';
 import type { PermissionsGrantDescriptor, PermissionsGrantMessage } from '../types';
@@ -11,7 +10,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { DEFAULT_CONDITIONS, PermissionsRequest } from './permissions-request';
 import { DwnInterfaceName, DwnMethodName, Message } from '../../../core/message';
 
-type PermissionsGrantOptions = AuthCreateOptions & {
+type PermissionsGrantOptions = {
   dateCreated?: string;
   conditions?: PermissionConditions;
   description: string;
@@ -20,6 +19,7 @@ type PermissionsGrantOptions = AuthCreateOptions & {
   objectId?: string;
   permissionsRequestId?: string;
   scope: PermissionScope;
+  authorizationSignatureInput: SignatureInput;
 };
 
 export class PermissionsGrant extends Message {
@@ -46,7 +46,7 @@ export class PermissionsGrant extends Message {
       scope       : options.scope,
     };
 
-    const authorization = await Message.signAsAuthorization(descriptor, options.signatureInput);
+    const authorization = await Message.signAsAuthorization(descriptor, options.authorizationSignatureInput);
     const message: PermissionsGrantMessage = { descriptor, authorization };
 
     Message.validateJsonSchema(message);
@@ -58,12 +58,12 @@ export class PermissionsGrant extends Message {
   /**
    * generates a PermissionsGrant using the provided PermissionsRequest
    * @param permissionsRequest
-   * @param signatureInput - the private key and additional signature material of the grantor
+   * @param authorizationSignatureInput - the private key and additional signature material of the grantor
    * @param conditionOverrides - any conditions that the grantor may want to override
    */
   static async fromPermissionsRequest(
     permissionsRequest: PermissionsRequest,
-    signatureInput: SignatureInput,
+    authorizationSignatureInput: SignatureInput,
     conditionOverrides: Partial<PermissionConditions> = {}
   ): Promise<PermissionsGrant> {
     const conditions = { ...permissionsRequest.conditions, ...conditionOverrides };
@@ -75,17 +75,17 @@ export class PermissionsGrant extends Message {
       grantedTo            : permissionsRequest.grantedTo,
       permissionsRequestId : permissionsRequest.id,
       scope                : permissionsRequest.scope,
-      signatureInput       : signatureInput
+      authorizationSignatureInput
     });
   }
 
   /**
    * delegates the permission to the DID provided
    * @param to - the DID of the grantee
-   * @param signatureInput - the private key and additional signature material of this permission's `grantedTo`
+   * @param authorizationSignatureInput - the private key and additional signature material of this permission's `grantedTo`
    * @throws {Error} - if the permission cannot be delegated
    */
-  async delegate(to: string, signatureInput: SignatureInput): Promise<PermissionsGrant> {
+  async delegate(to: string, authorizationSignatureInput: SignatureInput): Promise<PermissionsGrant> {
     // throw an exception if the permission cannot be delegated
     if (!this.conditions.delegation) {
       throw new Error('this permission cannot be delegated');
@@ -93,12 +93,12 @@ export class PermissionsGrant extends Message {
 
     // `grantedBy` of the delegated permission will be `grantedTo` of the permission being delegated because the grantee is the delegator
     const delegatedGrant = await PermissionsGrant.create({
-      conditions     : this.conditions,
-      description    : this.description,
-      grantedBy      : this.grantedTo,
-      grantedTo      : to,
-      scope          : this.scope,
-      signatureInput : signatureInput
+      conditions  : this.conditions,
+      description : this.description,
+      grantedBy   : this.grantedTo,
+      grantedTo   : to,
+      scope       : this.scope,
+      authorizationSignatureInput
     });
 
     delegatedGrant.delegatedFrom = await computeCid(this.message);

--- a/src/interfaces/permissions/messages/permissions-request.ts
+++ b/src/interfaces/permissions/messages/permissions-request.ts
@@ -1,4 +1,4 @@
-import type { AuthCreateOptions } from '../../../core/types.js';
+import type { SignatureInput } from '../../../jose/jws/general/types.js';
 import type { PermissionConditions, PermissionScope } from '../types.js';
 import type { PermissionsRequestDescriptor, PermissionsRequestMessage } from '../types.js';
 
@@ -7,7 +7,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { validateAuthorizationIntegrity } from '../../../core/auth.js';
 import { DwnInterfaceName, DwnMethodName, Message } from '../../../core/message.js';
 
-type PermissionsRequestOptions = AuthCreateOptions & {
+type PermissionsRequestOptions = {
   dateCreated?: string;
   conditions?: PermissionConditions;
   description: string;
@@ -15,6 +15,7 @@ type PermissionsRequestOptions = AuthCreateOptions & {
   grantedBy: string;
   objectId?: string;
   scope: PermissionScope;
+  authorizationSignatureInput: SignatureInput;
 };
 
 export class PermissionsRequest extends Message {
@@ -49,7 +50,7 @@ export class PermissionsRequest extends Message {
 
     Message.validateJsonSchema({ descriptor, authorization: { } });
 
-    const auth = await Message.signAsAuthorization(descriptor, options.signatureInput);
+    const auth = await Message.signAsAuthorization(descriptor, options.authorizationSignatureInput);
     const message: PermissionsRequestMessage = { descriptor, authorization: auth };
 
     return new PermissionsRequest(message);

--- a/src/interfaces/protocols/messages/protocols-configure.ts
+++ b/src/interfaces/protocols/messages/protocols-configure.ts
@@ -1,4 +1,4 @@
-import type { AuthCreateOptions } from '../../../core/types.js';
+import type { SignatureInput } from '../../../jose/jws/general/types.js';
 import type { ProtocolDefinition, ProtocolsConfigureDescriptor, ProtocolsConfigureMessage } from '../types.js';
 
 import { getCurrentTimeInHighPrecision } from '../../../utils/time.js';
@@ -6,10 +6,11 @@ import { validateAuthorizationIntegrity } from '../../../core/auth.js';
 
 import { DwnInterfaceName, DwnMethodName, Message } from '../../../core/message.js';
 
-export type ProtocolsConfigureOptions = AuthCreateOptions & {
+export type ProtocolsConfigureOptions = {
   dateCreated? : string;
   protocol: string;
   definition : ProtocolDefinition;
+  authorizationSignatureInput: SignatureInput;
 };
 
 export class ProtocolsConfigure extends Message {
@@ -36,7 +37,7 @@ export class ProtocolsConfigure extends Message {
 
     Message.validateJsonSchema({ descriptor, authorization: { } });
 
-    const authorization = await Message.signAsAuthorization(descriptor, options.signatureInput);
+    const authorization = await Message.signAsAuthorization(descriptor, options.authorizationSignatureInput);
     const message = { descriptor, authorization };
 
     const protocolsConfigure = new ProtocolsConfigure(message);

--- a/src/interfaces/protocols/messages/protocols-query.ts
+++ b/src/interfaces/protocols/messages/protocols-query.ts
@@ -1,4 +1,4 @@
-import type { AuthCreateOptions } from '../../../core/types.js';
+import type { SignatureInput } from '../../../jose/jws/general/types.js';
 import type { ProtocolsQueryDescriptor, ProtocolsQueryMessage } from '../types.js';
 
 import { getCurrentTimeInHighPrecision } from '../../../utils/time.js';
@@ -7,11 +7,12 @@ import { validateAuthorizationIntegrity } from '../../../core/auth.js';
 
 import { DwnInterfaceName, DwnMethodName, Message } from '../../../core/message.js';
 
-export type ProtocolsQueryOptions = AuthCreateOptions & {
+export type ProtocolsQueryOptions = {
   dateCreated?: string;
   filter?: {
     protocol: string;
   }
+  authorizationSignatureInput: SignatureInput;
 };
 
 export class ProtocolsQuery extends Message {
@@ -41,7 +42,7 @@ export class ProtocolsQuery extends Message {
 
     Message.validateJsonSchema({ descriptor, authorization: { } });
 
-    const authorization = await Message.signAsAuthorization(descriptor, options.signatureInput);
+    const authorization = await Message.signAsAuthorization(descriptor, options.authorizationSignatureInput);
     const message = { descriptor, authorization };
 
     const protocolsQuery = new ProtocolsQuery(message);

--- a/src/interfaces/records/handlers/records-write.ts
+++ b/src/interfaces/records/handlers/records-write.ts
@@ -8,7 +8,6 @@ import { MessageReply } from '../../../core/message-reply.js';
 import { RecordsWrite } from '../messages/records-write.js';
 import { TimestampedMessage } from '../../../core/types.js';
 
-
 export const handleRecordsWrite: MethodHandler = async (
   tenant,
   message,

--- a/src/interfaces/records/messages/records-delete.ts
+++ b/src/interfaces/records/messages/records-delete.ts
@@ -1,16 +1,17 @@
-import type { AuthCreateOptions } from '../../../core/types.js';
 import type { RecordsDeleteDescriptor, RecordsDeleteMessage } from '../types.js';
 
 import { getCurrentTimeInHighPrecision } from '../../../utils/time.js';
 import { Message } from '../../../core/message.js';
 import { removeUndefinedProperties } from '../../../utils/object.js';
+import { SignatureInput } from '../../../jose/jws/general/types.js';
 
 import { authorize, validateAuthorizationIntegrity } from '../../../core/auth.js';
 import { DwnInterfaceName, DwnMethodName } from '../../../core/message.js';
 
-export type RecordsDeleteOptions = AuthCreateOptions & {
+export type RecordsDeleteOptions = {
   recordId: string;
   dateModified?: string;
+  authorizationSignatureInput: SignatureInput;
 };
 
 export class RecordsDelete extends Message {
@@ -50,7 +51,7 @@ export class RecordsDelete extends Message {
     // Error: `undefined` is not supported by the IPLD Data Model and cannot be encoded
     removeUndefinedProperties(descriptor);
 
-    const authorization = await Message.signAsAuthorization(descriptor, options.signatureInput);
+    const authorization = await Message.signAsAuthorization(descriptor, options.authorizationSignatureInput);
     const message: RecordsDeleteMessage = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/records/messages/records-query.ts
+++ b/src/interfaces/records/messages/records-query.ts
@@ -1,4 +1,4 @@
-import type { AuthCreateOptions } from '../../../core/types.js';
+import type { SignatureInput } from '../../../jose/jws/general/types.js';
 import type { RecordsQueryDescriptor, RecordsQueryMessage } from '../types.js';
 
 import { getCurrentTimeInHighPrecision } from '../../../utils/time.js';
@@ -14,7 +14,7 @@ export enum DateSort {
   PublishedDescending = 'publishedDescending'
 }
 
-export type RecordsQueryOptions = AuthCreateOptions & {
+export type RecordsQueryOptions = {
   dateCreated?: string;
   filter: {
     recipient?: string;
@@ -26,6 +26,7 @@ export type RecordsQueryOptions = AuthCreateOptions & {
     dataFormat?: string;
   },
   dateSort?: DateSort;
+  authorizationSignatureInput: SignatureInput;
 };
 
 export class RecordsQuery extends Message {
@@ -53,7 +54,7 @@ export class RecordsQuery extends Message {
     // Error: `undefined` is not supported by the IPLD Data Model and cannot be encoded
     removeUndefinedProperties(descriptor);
 
-    const authorization = await Message.signAsAuthorization(descriptor, options.signatureInput);
+    const authorization = await Message.signAsAuthorization(descriptor, options.authorizationSignatureInput);
     const message = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/records/messages/records-write.ts
+++ b/src/interfaces/records/messages/records-write.ts
@@ -265,6 +265,17 @@ export class RecordsWrite extends Message {
         `contextId in message ${this.message.contextId} does not match contextId in authorization: ${this.authorizationPayload.contextId}`
       );
     }
+
+    // if `attestation` is given in message, make sure the correct `attestationCid` is in the `authorization`
+    if (this.message.attestation !== undefined) {
+      const expectedAttestationCid = (await computeCid(this.message.attestation)).toString();
+      const actualAttestationCid = this.authorizationPayload.attestationCid;
+      if (actualAttestationCid !== expectedAttestationCid) {
+        throw new Error(
+          `CID ${expectedAttestationCid} of attestation property in message does not match attestationCid in authorization: ${actualAttestationCid}`
+        );
+      }
+    }
   }
 
   /**

--- a/src/interfaces/records/messages/records-write.ts
+++ b/src/interfaces/records/messages/records-write.ts
@@ -341,7 +341,7 @@ export class RecordsWrite extends Message {
       descriptorCid
     };
 
-    const attestationCid = attestation ? await computeCid(attestation) : undefined;
+    const attestationCid = attestation ? (await computeCid(attestation)).toString() : undefined;
 
     if (contextId !== undefined) { authorizationPayload.contextId = contextId; } // assign `contextId` only if it is defined
     if (attestationCid !== undefined) { authorizationPayload.attestationCid = attestationCid; } // assign `attestationCid` only if it is defined

--- a/src/interfaces/records/types.ts
+++ b/src/interfaces/records/types.ts
@@ -1,5 +1,6 @@
 import { BaseMessage } from '../../core/types.js';
 import { DateSort } from './messages/records-query.js';
+import { GeneralJws } from '../../jose/jws/general/types.js';
 import { DwnInterfaceName, DwnMethodName } from '../../core/message.js';
 
 export type RecordsWriteDescriptor = {
@@ -21,6 +22,7 @@ export type RecordsWriteMessage = BaseMessage & {
   recordId: string,
   contextId?: string;
   descriptor: RecordsWriteDescriptor;
+  attestation?: GeneralJws;
   encodedData?: string;
 };
 
@@ -50,10 +52,15 @@ export type RecordsQueryDescriptor = {
   dateSort?: DateSort;
 };
 
+export type RecordsWriteAttestationPayload = {
+  descriptorCid: string;
+};
+
 export type RecordsWriteAuthorizationPayload = {
   recordId: string;
   contextId?: string;
   descriptorCid: string;
+  attestationCid?: string;
 };
 
 export type RecordsQueryMessage = BaseMessage & {

--- a/src/utils/cid.ts
+++ b/src/utils/cid.ts
@@ -30,7 +30,7 @@ export async function getDagPbCid(content: Uint8Array): Promise<CID> {
 }
 
 /**
- * generates a V1 CID for the provided payload
+ * Computes a V1 CID for the provided payload
  * @param payload
  * @param codecCode - the codec to use. Defaults to cbor
  * @param multihashCode - the multihasher to use. Defaults to sha256
@@ -39,7 +39,7 @@ export async function getDagPbCid(content: Uint8Array): Promise<CID> {
  * @throws {Error} encoding fails
  * @throws {Error} if hasher is not supported
  */
-export async function generateCid(payload: any, codecCode = cbor.code, multihashCode = sha256.code): Promise<CID> {
+export async function computeCid(payload: any, codecCode = cbor.code, multihashCode = sha256.code): Promise<CID> {
   const codec = codecs[codecCode];
   if (!codec) {
     throw new Error(`codec [${codecCode}] not supported`);

--- a/tests/core/protocol-authorization.spec.ts
+++ b/tests/core/protocol-authorization.spec.ts
@@ -25,7 +25,7 @@ describe('Protocol-Based Authorization', async () => {
     it('should throw if requester DID is not the target tenant when no allow rule defined', async () => {
       const alice = await TestDataGenerator.generatePersona();
       const bob = await TestDataGenerator.generatePersona();
-      const { recordsWrite } = await TestDataGenerator.generateRecordsWriteMessage({ requester: bob });
+      const { recordsWrite } = await TestDataGenerator.generateRecordsWrite({ requester: bob });
       const ruleSet: ProtocolRuleSet = {};
 
       expect(() => {
@@ -35,7 +35,7 @@ describe('Protocol-Based Authorization', async () => {
 
     it('should throw if action performed is not in an allowed action list', async () => {
       const did = 'did:example:alice';
-      const { recordsWrite } = await TestDataGenerator.generateRecordsWriteMessage();
+      const { recordsWrite } = await TestDataGenerator.generateRecordsWrite();
       const ruleSet: ProtocolRuleSet = {
         allow: {
           anyone: {

--- a/tests/dwn.spec.ts
+++ b/tests/dwn.spec.ts
@@ -3,39 +3,67 @@ import sinon from 'sinon';
 import chai, { expect } from 'chai';
 
 import { Config } from '../src/dwn.js';
-import { Did } from '../src/did/did.js';
 import { DidKeyResolver } from '../src/did/did-key-resolver.js';
 import { Dwn } from '../src/dwn.js';
+import { Encoder } from '../src/index.js';
 import { Message } from '../src/core/message.js';
 import { MessageStoreLevel } from '../src/store/message-store-level.js';
 import { TestDataGenerator } from './utils/test-data-generator.js';
-import { DidMethodResolver, DidResolutionResult } from '../src/did/did-resolver.js';
 
 chai.use(chaiAsPromised);
 
 describe('DWN', () => {
-  describe('processMessage()', () => {
-    let messageStore: MessageStoreLevel;
+  let messageStore: MessageStoreLevel;
+  let dwn: Dwn;
 
-    before(async () => {
-      // important to follow this pattern to initialize the message store in tests
-      // so that different suites can reuse the same block store and index location for testing
-      messageStore = new MessageStoreLevel({
-        blockstoreLocation : 'TEST-BLOCKSTORE',
-        indexLocation      : 'TEST-INDEX'
+  before(async () => {
+    // important to follow this pattern to initialize the message store in tests
+    // so that different suites can reuse the same block store and index location for testing
+    messageStore = new MessageStoreLevel({
+      blockstoreLocation : 'TEST-BLOCKSTORE',
+      indexLocation      : 'TEST-INDEX'
+    });
+
+    await messageStore.open();
+
+    const dwnConfig: Config = { messageStore };
+    dwn = await Dwn.create(dwnConfig);
+  });
+
+  beforeEach(async () => {
+    await messageStore.clear(); // clean up before each test rather than after so that a test does not depend on other tests to do the clean up
+  });
+
+  after(async () => {
+    await messageStore.close();
+    dwn.close();
+  });
+
+  describe('processRequest()', () => {
+    it('should process a raw request', async () => {
+      const alice = await DidKeyResolver.generate();
+
+      const { message } = await TestDataGenerator.generateRecordsWrite({
+        requester: alice,
       });
+      const messageBytes = Encoder.objectToBytes(message);
 
-      await messageStore.open();
+      const reply = await dwn.processRequest(alice.did, messageBytes);
+
+      expect(reply.status.code).to.equal(202);
     });
 
-    beforeEach(async () => {
-      await messageStore.clear(); // clean up before each test rather than after so that a test does not depend on other tests to do the clean up
-    });
+    it('should throw 400 if given invalid JSON request', async () => {
+      const messageBytes = Encoder.stringToBytes('{{invalidJson');
 
-    after(async () => {
-      await messageStore.close();
+      const alice = await DidKeyResolver.generate();
+      const reply = await dwn.processRequest(alice.did, messageBytes);
+      expect(reply.status.code).to.equal(400);
+      expect(reply.status.detail).to.contain('unable to JSON parse request');
     });
+  });
 
+  describe('processMessage()', () => {
     it('should process RecordsWrite message signed by a `did:key` DID', async () => {
       // generate a `did:key` DID
       const alice = await DidKeyResolver.generate();
@@ -44,32 +72,14 @@ describe('DWN', () => {
         requester: alice,
       });
 
-      const dwnConfig: Config = { messageStore };
-      const dwn = await Dwn.create(dwnConfig);
-
       const reply = await dwn.processMessage(alice.did, messageData.message);
 
       expect(reply.status.code).to.equal(202);
     });
 
     it('should process RecordsQuery message', async () => {
-      const { requester, message } = await TestDataGenerator.generateRecordsQuery();
-      const generatedDidMethod = Did.getMethodName(requester.did);
-
-      // setting up a stub method resolver
-      const didResolutionResult = TestDataGenerator.createDidResolutionResult(requester);
-      const resolveStub = sinon.stub<[string], Promise<DidResolutionResult>>();
-      resolveStub.withArgs(requester.did).resolves(didResolutionResult);
-      const methodResolverStub = <DidMethodResolver>{
-        method  : () => { return generatedDidMethod; },
-        resolve : resolveStub
-      };
-
-      const dwnConfig: Config = {
-        DidMethodResolvers: [methodResolverStub],
-        messageStore
-      };
-      const dwn = await Dwn.create(dwnConfig);
+      const alice = await DidKeyResolver.generate();
+      const { requester, message } = await TestDataGenerator.generateRecordsQuery({ requester: alice });
 
       const tenant = requester.did;
       const reply = await dwn.processMessage(tenant, message);
@@ -79,8 +89,6 @@ describe('DWN', () => {
     });
 
     it('#191 - regression - should run JSON schema validation', async () => {
-      const dwn = await Dwn.create({});
-
       const invalidMessage = {
         descriptor: {
           interface : 'Records',
@@ -98,6 +106,21 @@ describe('DWN', () => {
 
       expect(reply.status.code).to.equal(400);
       expect(reply.status.detail).to.contain(`must have required property 'recordId'`);
+    });
+
+    it('should throw 400 if given no interface or method found in message', async () => {
+      const alice = await DidKeyResolver.generate();
+      const reply1 = await dwn.processMessage(alice.did, undefined ); // missing message entirely, thus missing both `interface` and `method`
+      expect(reply1.status.code).to.equal(400);
+      expect(reply1.status.detail).to.contain('Both interface and method must be present');
+
+      const reply2 = await dwn.processMessage(alice.did, { descriptor: { method: 'anyValue' } }); // missing `interface`
+      expect(reply2.status.code).to.equal(400);
+      expect(reply2.status.detail).to.contain('Both interface and method must be present');
+
+      const reply3 = await dwn.processMessage(alice.did, { descriptor: { interface: 'anyValue' } }); // missing `method`
+      expect(reply3.status.code).to.equal(400);
+      expect(reply3.status.detail).to.contain('Both interface and method must be present');
     });
   });
 });

--- a/tests/dwn.spec.ts
+++ b/tests/dwn.spec.ts
@@ -40,7 +40,7 @@ describe('DWN', () => {
       // generate a `did:key` DID
       const alice = await DidKeyResolver.generate();
 
-      const messageData = await TestDataGenerator.generateRecordsWriteMessage({
+      const messageData = await TestDataGenerator.generateRecordsWrite({
         requester: alice,
       });
 
@@ -53,7 +53,7 @@ describe('DWN', () => {
     });
 
     it('should process RecordsQuery message', async () => {
-      const { requester, message } = await TestDataGenerator.generateRecordsQueryMessage();
+      const { requester, message } = await TestDataGenerator.generateRecordsQuery();
       const generatedDidMethod = Did.getMethodName(requester.did);
 
       // setting up a stub method resolver

--- a/tests/interfaces/permissions/messages/permissions-request.spec.ts
+++ b/tests/interfaces/permissions/messages/permissions-request.spec.ts
@@ -56,7 +56,7 @@ describe('PermissionsRequest', () => {
   describe('create', () => {
     it('creates a PermissionsRequest message', async () => {
       const { privateJwk } = await secp256k1.generateKeyPair();
-      const signatureInput = {
+      const authorizationSignatureInput = {
         privateJwk,
         protectedHeader: {
           alg : privateJwk.alg as string,
@@ -69,7 +69,7 @@ describe('PermissionsRequest', () => {
         grantedBy   : 'did:jank:bob',
         grantedTo   : 'did:jank:alice',
         scope       : { method: 'RecordsWrite' },
-        signatureInput
+        authorizationSignatureInput
       });
 
       expect(message.grantedTo).to.equal('did:jank:alice');
@@ -81,7 +81,7 @@ describe('PermissionsRequest', () => {
 
     it('uses default conditions if none are provided', async () => {
       const { privateJwk } = await secp256k1.generateKeyPair();
-      const signatureInput = {
+      const authorizationSignatureInput = {
         privateJwk,
         protectedHeader: {
           alg : privateJwk.alg as string,
@@ -94,7 +94,7 @@ describe('PermissionsRequest', () => {
         grantedBy   : 'did:jank:bob',
         grantedTo   : 'did:jank:alice',
         scope       : { method: 'RecordsWrite' },
-        signatureInput
+        authorizationSignatureInput
       });
 
       const { conditions } = message;

--- a/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
@@ -10,7 +10,7 @@ import { lexicographicalCompare } from '../../../../src/utils/string.js';
 import { Message } from '../../../../src/core/message.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
-import { GenerateProtocolsConfigureMessageOutput, TestDataGenerator } from '../../../utils/test-data-generator.js';
+import { GenerateProtocolsConfigureOutput, TestDataGenerator } from '../../../utils/test-data-generator.js';
 
 import { DidResolver, Encoder } from '../../../../src/index.js';
 
@@ -43,7 +43,7 @@ describe('handleProtocolsQuery()', () => {
     });
 
     it('should return 400 if failed to parse the message', async () => {
-      const { requester, message, protocolsConfigure } = await TestDataGenerator.generateProtocolsConfigureMessage();
+      const { requester, message, protocolsConfigure } = await TestDataGenerator.generateProtocolsConfigure();
       const tenant = requester.did;
 
       // intentionally create more than one signature, which is not allowed
@@ -67,7 +67,7 @@ describe('handleProtocolsQuery()', () => {
     it('should return 401 if auth fails', async () => {
       const alice = await DidKeyResolver.generate();
       alice.keyId = 'wrongValue'; // to fail authentication
-      const { message } = await TestDataGenerator.generateProtocolsConfigureMessage({ requester: alice });
+      const { message } = await TestDataGenerator.generateProtocolsConfigure({ requester: alice });
 
       const reply = await handleProtocolsConfigure(alice.did, message, messageStore, didResolver);
       expect(reply.status.code).to.equal(401);
@@ -78,9 +78,9 @@ describe('handleProtocolsQuery()', () => {
       // generate three versions of the same protocol message
       const alice = await DidKeyResolver.generate();
       const protocol = 'exampleProtocol';
-      const messageData1 = await TestDataGenerator.generateProtocolsConfigureMessage({ requester: alice, protocol });
-      const messageData2 = await TestDataGenerator.generateProtocolsConfigureMessage({ requester: alice, protocol });
-      const messageData3 = await TestDataGenerator.generateProtocolsConfigureMessage({ requester: alice, protocol });
+      const messageData1 = await TestDataGenerator.generateProtocolsConfigure({ requester: alice, protocol });
+      const messageData2 = await TestDataGenerator.generateProtocolsConfigure({ requester: alice, protocol });
+      const messageData3 = await TestDataGenerator.generateProtocolsConfigure({ requester: alice, protocol });
 
       const messageDataWithCid = [];
       for (const messageData of [messageData1, messageData2, messageData3]) {
@@ -93,7 +93,7 @@ describe('handleProtocolsQuery()', () => {
         messageDataWithSmallestLexicographicValue,
         messageDataWithMediumLexicographicValue,
         messageDataWithLargestLexicographicValue
-      ]: GenerateProtocolsConfigureMessageOutput[]
+      ]: GenerateProtocolsConfigureOutput[]
         = messageDataWithCid.sort((messageDataA, messageDataB) => { return lexicographicalCompare(messageDataA.cid, messageDataB.cid); });
 
       // write the protocol with the middle lexicographic value
@@ -109,7 +109,7 @@ describe('handleProtocolsQuery()', () => {
       expect(reply.status.code).to.equal(202);
 
       // test that old protocol message is removed from DB and only the newer protocol message remains
-      const queryMessageData = await TestDataGenerator.generateProtocolsQueryMessage({ requester: alice, filter: { protocol } });
+      const queryMessageData = await TestDataGenerator.generateProtocolsQuery({ requester: alice, filter: { protocol } });
       reply = await handleProtocolsQuery(alice.did, queryMessageData.message, messageStore, didResolver);
 
       expect(reply.status.code).to.equal(200);

--- a/tests/interfaces/protocols/handlers/protocols-query.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-query.spec.ts
@@ -47,16 +47,16 @@ describe('handleProtocolsQuery()', () => {
       const didResolverStub = TestStubGenerator.createDidResolverStub(alice);
 
       // insert three messages into DB, two with matching protocol
-      const message1Data = await TestDataGenerator.generateProtocolsConfigureMessage({ requester: alice });
-      const message2Data = await TestDataGenerator.generateProtocolsConfigureMessage({ requester: alice });
-      const message3Data = await TestDataGenerator.generateProtocolsConfigureMessage({ requester: alice });
+      const message1Data = await TestDataGenerator.generateProtocolsConfigure({ requester: alice });
+      const message2Data = await TestDataGenerator.generateProtocolsConfigure({ requester: alice });
+      const message3Data = await TestDataGenerator.generateProtocolsConfigure({ requester: alice });
 
       await handleProtocolsConfigure(alice.did, message1Data.message, messageStore, didResolverStub);
       await handleProtocolsConfigure(alice.did, message2Data.message, messageStore, didResolverStub);
       await handleProtocolsConfigure(alice.did, message3Data.message, messageStore, didResolverStub);
 
       // testing singular conditional query
-      const queryMessageData = await TestDataGenerator.generateProtocolsQueryMessage({
+      const queryMessageData = await TestDataGenerator.generateProtocolsQuery({
         requester : alice,
         filter    : { protocol: message1Data.message.descriptor.protocol }
       });
@@ -67,7 +67,7 @@ describe('handleProtocolsQuery()', () => {
       expect(reply.entries?.length).to.equal(1); // only 1 entry should match the query on protocol
 
       // testing fetch-all query without filter
-      const queryMessageData2 = await TestDataGenerator.generateProtocolsQueryMessage({
+      const queryMessageData2 = await TestDataGenerator.generateProtocolsQuery({
         requester: alice
       });
 
@@ -78,7 +78,7 @@ describe('handleProtocolsQuery()', () => {
     });
 
     it('should return 400 if failed to parse the message', async () => {
-      const { requester, message, protocolsQuery } = await TestDataGenerator.generateProtocolsQueryMessage();
+      const { requester, message, protocolsQuery } = await TestDataGenerator.generateProtocolsQuery();
       const tenant = requester.did;
 
       // replace `authorization` with incorrect `descriptorCid`, even though signature is still valid
@@ -101,7 +101,7 @@ describe('handleProtocolsQuery()', () => {
     it('should return 401 if auth fails', async () => {
       const alice = await DidKeyResolver.generate();
       alice.keyId = 'wrongValue'; // to fail authentication
-      const messageData = await TestDataGenerator.generateProtocolsQueryMessage({ requester: alice });
+      const messageData = await TestDataGenerator.generateProtocolsQuery({ requester: alice });
 
       const reply = await handleProtocolsQuery(alice.did, messageData.message, messageStore, didResolver);
 

--- a/tests/interfaces/protocols/messages/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols/messages/protocols-configure.spec.ts
@@ -1,25 +1,27 @@
 import chaiAsPromised from 'chai-as-promised';
 import chai, { expect } from 'chai';
 
+import dexProtocolDefinition from '../../../vectors/protocol-definitions/dex.json' assert { type: 'json' };
 import { getCurrentTimeInHighPrecision } from '../../../../src/utils/time.js';
-import { RecordsQuery } from '../../../../src/interfaces/records/messages/records-query.js';
+import { ProtocolsConfigure } from '../../../../src/index.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 
 chai.use(chaiAsPromised);
 
-describe('RecordsQuery', () => {
+describe('ProtocolsConfigure', () => {
   describe('create()', () => {
     it('should use `dateCreated` as is if given', async () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const currentTime = getCurrentTimeInHighPrecision();
-      const recordsQuery = await RecordsQuery.create({
-        filter                      : { schema: 'anything' },
+      const protocolsConfigure = await ProtocolsConfigure.create({
         dateCreated                 : currentTime,
+        protocol                    : 'anyValue',
+        definition                  : dexProtocolDefinition,
         authorizationSignatureInput : TestDataGenerator.createSignatureInputFromPersona(alice),
       });
 
-      expect(recordsQuery.message.descriptor.dateCreated).to.equal(currentTime);
+      expect(protocolsConfigure.message.descriptor.dateCreated).to.equal(currentTime);
     });
   });
 });

--- a/tests/interfaces/protocols/messages/protocols-query.spec.ts
+++ b/tests/interfaces/protocols/messages/protocols-query.spec.ts
@@ -2,24 +2,24 @@ import chaiAsPromised from 'chai-as-promised';
 import chai, { expect } from 'chai';
 
 import { getCurrentTimeInHighPrecision } from '../../../../src/utils/time.js';
-import { RecordsQuery } from '../../../../src/interfaces/records/messages/records-query.js';
+import { ProtocolsQuery } from '../../../../src/interfaces/protocols/messages/protocols-query.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 
 chai.use(chaiAsPromised);
 
-describe('RecordsQuery', () => {
+describe('ProtocolsQuery', () => {
   describe('create()', () => {
     it('should use `dateCreated` as is if given', async () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const currentTime = getCurrentTimeInHighPrecision();
-      const recordsQuery = await RecordsQuery.create({
-        filter                      : { schema: 'anything' },
+      const protocolsQuery = await ProtocolsQuery.create({
+        filter                      : { protocol: 'anyValue' },
         dateCreated                 : currentTime,
         authorizationSignatureInput : TestDataGenerator.createSignatureInputFromPersona(alice),
       });
 
-      expect(recordsQuery.message.descriptor.dateCreated).to.equal(currentTime);
+      expect(protocolsQuery.message.descriptor.dateCreated).to.equal(currentTime);
     });
   });
 });

--- a/tests/interfaces/records/handlers/records-delete.spec.ts
+++ b/tests/interfaces/records/handlers/records-delete.spec.ts
@@ -63,8 +63,8 @@ describe('handleRecordsDelete()', () => {
 
       // testing delete
       const recordsDelete = await RecordsDelete.create({
-        recordId       : writeData.message.recordId,
-        signatureInput : TestDataGenerator.createSignatureInputFromPersona(alice)
+        recordId                    : writeData.message.recordId,
+        authorizationSignatureInput : TestDataGenerator.createSignatureInputFromPersona(alice)
       });
 
       const deleteReply = await handleRecordsDelete(alice.did, recordsDelete.message, messageStore, didResolver);
@@ -87,8 +87,8 @@ describe('handleRecordsDelete()', () => {
       // generate subsequent write and delete with the delete having an earlier timestamp
       // NOTE: creating RecordsDelete first ensures it has an earlier `dateModified` time
       const recordsDelete = await RecordsDelete.create({
-        recordId       : initialWriteData.message.recordId,
-        signatureInput : TestDataGenerator.createSignatureInputFromPersona(alice)
+        recordId                    : initialWriteData.message.recordId,
+        authorizationSignatureInput : TestDataGenerator.createSignatureInputFromPersona(alice)
       });
       const subsequentWriteData = await TestDataGenerator.generateFromRecordsWrite({
         existingWrite : initialWriteData.recordsWrite,

--- a/tests/interfaces/records/handlers/records-delete.spec.ts
+++ b/tests/interfaces/records/handlers/records-delete.spec.ts
@@ -48,12 +48,12 @@ describe('handleRecordsDelete()', () => {
       const alice = await DidKeyResolver.generate();
 
       // insert data
-      const writeData = await TestDataGenerator.generateRecordsWriteMessage({ requester: alice });
+      const writeData = await TestDataGenerator.generateRecordsWrite({ requester: alice });
       const writeReply = await handleRecordsWrite(alice.did, writeData.message, messageStore, didResolver);
       expect(writeReply.status.code).to.equal(202);
 
       // ensure data is inserted
-      const queryData = await TestDataGenerator.generateRecordsQueryMessage({
+      const queryData = await TestDataGenerator.generateRecordsQuery({
         requester : alice,
         filter    : { recordId: writeData.message.recordId }
       });
@@ -80,7 +80,7 @@ describe('handleRecordsDelete()', () => {
       const alice = await DidKeyResolver.generate();
 
       // initial write
-      const initialWriteData = await TestDataGenerator.generateRecordsWriteMessage({ requester: alice });
+      const initialWriteData = await TestDataGenerator.generateRecordsWrite({ requester: alice });
       const initialWriteReply = await handleRecordsWrite(alice.did, initialWriteData.message, messageStore, didResolver);
       expect(initialWriteReply.status.code).to.equal(202);
 
@@ -104,7 +104,7 @@ describe('handleRecordsDelete()', () => {
       expect(deleteReply.status.code).to.equal(409);
 
       // ensure data still exists
-      const queryData = await TestDataGenerator.generateRecordsQueryMessage({
+      const queryData = await TestDataGenerator.generateRecordsQuery({
         requester : alice,
         filter    : { recordId: initialWriteData.message.recordId }
       });

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1165,6 +1165,18 @@ describe('handleRecordsWrite()', () => {
     });
   });
 
+  it('should fail validation with 400 if expected CID of `attestation` mismatches the `attestationCid` in `authorization`', async () => {
+    const alice = await DidKeyResolver.generate();
+    const bob = await DidKeyResolver.generate();
+    const { message } = await TestDataGenerator.generateRecordsWrite({ requester: alice, attesters: [alice, bob] });
+
+    // strip away one signature to cause difference in expected and actual attestation CID
+    message.attestation.signatures = [message.attestation.signatures[0]];
+    const writeReply = await handleRecordsWrite(alice.did, message, messageStore, didResolver);
+    expect(writeReply.status.code).to.equal(400);
+    expect(writeReply.status.detail).to.contain('does not match attestationCid');
+  });
+
   it('should return 400 if `recordId` in `authorization` payload mismatches with `recordId` in the message', async () => {
     const { requester, message, recordsWrite } = await TestDataGenerator.generateRecordsWrite();
 

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -261,7 +261,7 @@ describe('handleRecordsWrite()', () => {
           const newWrite = await RecordsWrite.createFrom({
             unsignedRecordsWriteMessage : recordsWrite.message,
             published                   : true,
-            signatureInput              : TestDataGenerator.createSignatureInputFromPersona(requester)
+            authorizationSignatureInput : TestDataGenerator.createSignatureInputFromPersona(requester)
           });
 
           const newWriteReply = await handleRecordsWrite(tenant, newWrite.message, messageStore, didResolverStub);
@@ -296,7 +296,7 @@ describe('handleRecordsWrite()', () => {
           const newWrite = await RecordsWrite.createFrom({
             unsignedRecordsWriteMessage : recordsWrite.message,
             data                        : newData,
-            signatureInput              : TestDataGenerator.createSignatureInputFromPersona(requester)
+            authorizationSignatureInput : TestDataGenerator.createSignatureInputFromPersona(requester)
           });
 
           const newWriteReply = await handleRecordsWrite(tenant, newWrite.message, messageStore, didResolverStub);

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -53,7 +53,7 @@ describe('handleRecordsWrite()', () => {
       // write a message into DB
       const requester = await DidKeyResolver.generate();
       const data1 = new TextEncoder().encode('data1');
-      const recordsWriteMessageData = await TestDataGenerator.generateRecordsWriteMessage({ requester, data: data1 });
+      const recordsWriteMessageData = await TestDataGenerator.generateRecordsWrite({ requester, data: data1 });
 
       const didResolver = new DidResolver();
 
@@ -62,7 +62,7 @@ describe('handleRecordsWrite()', () => {
       expect(recordsWriteReply.status.code).to.equal(202);
 
       const recordId = recordsWriteMessageData.message.recordId;
-      const recordsQueryMessageData = await TestDataGenerator.generateRecordsQueryMessage({
+      const recordsQueryMessageData = await TestDataGenerator.generateRecordsQuery({
         requester,
         filter: { recordId }
       });
@@ -111,7 +111,7 @@ describe('handleRecordsWrite()', () => {
       // start by writing an originating message
       const requester = await TestDataGenerator.generatePersona();
       const tenant = requester.did;
-      const originatingMessageData = await TestDataGenerator.generateRecordsWriteMessage({
+      const originatingMessageData = await TestDataGenerator.generateRecordsWrite({
         requester,
         data: Encoder.stringToBytes('unused')
       });
@@ -155,7 +155,7 @@ describe('handleRecordsWrite()', () => {
       expect(recordsWriteReply.status.code).to.equal(202);
 
       // query to fetch the record
-      const recordsQueryMessageData = await TestDataGenerator.generateRecordsQueryMessage({
+      const recordsQueryMessageData = await TestDataGenerator.generateRecordsQuery({
         requester,
         filter: { recordId: originatingMessageData.message.recordId }
       });
@@ -191,7 +191,7 @@ describe('handleRecordsWrite()', () => {
     });
 
     it('should not allow changes to immutable properties', async () => {
-      const initialWriteData = await TestDataGenerator.generateRecordsWriteMessage();
+      const initialWriteData = await TestDataGenerator.generateRecordsWrite();
       const tenant = initialWriteData.requester.did;
       const didResolverStub = TestStubGenerator.createDidResolverStub(initialWriteData.requester);
       const initialWriteReply = await handleRecordsWrite(tenant, initialWriteData.message, messageStore, didResolverStub);
@@ -202,7 +202,7 @@ describe('handleRecordsWrite()', () => {
       const schema = initialWriteData.message.descriptor.schema;
 
       // dateCreated test
-      let childMessageData = await TestDataGenerator.generateRecordsWriteMessage({
+      let childMessageData = await TestDataGenerator.generateRecordsWrite({
         requester   : initialWriteData.requester,
         recordId,
         schema,
@@ -216,7 +216,7 @@ describe('handleRecordsWrite()', () => {
       expect(reply.status.detail).to.contain('dateCreated is an immutable property');
 
       // schema test
-      childMessageData = await TestDataGenerator.generateRecordsWriteMessage({
+      childMessageData = await TestDataGenerator.generateRecordsWrite({
         requester  : initialWriteData.requester,
         recordId,
         schema     : 'should-not-allowed-to-be-modified',
@@ -230,7 +230,7 @@ describe('handleRecordsWrite()', () => {
       expect(reply.status.detail).to.contain('schema is an immutable property');
 
       // dataFormat test
-      childMessageData = await TestDataGenerator.generateRecordsWriteMessage({
+      childMessageData = await TestDataGenerator.generateRecordsWrite({
         requester  : initialWriteData.requester,
         recordId,
         schema,
@@ -247,7 +247,7 @@ describe('handleRecordsWrite()', () => {
     describe('initial write & subsequent tests', () => {
       describe('createFrom()', () => {
         it('should accept a publish RecordsWrite using createFrom() without specifying datePublished', async () => {
-          const { message, requester, recordsWrite } = await TestDataGenerator.generateRecordsWriteMessage({
+          const { message, requester, recordsWrite } = await TestDataGenerator.generateRecordsWrite({
             published: false
           });
           const tenant = requester.did;
@@ -269,7 +269,7 @@ describe('handleRecordsWrite()', () => {
           expect(newWriteReply.status.code).to.equal(202);
 
           // verify the new record state can be queried
-          const recordsQueryMessageData = await TestDataGenerator.generateRecordsQueryMessage({
+          const recordsQueryMessageData = await TestDataGenerator.generateRecordsQuery({
             requester,
             filter: { recordId: message.recordId }
           });
@@ -281,7 +281,7 @@ describe('handleRecordsWrite()', () => {
         });
 
         it('should inherit parent published state when using createFrom() to create RecordsWrite', async () => {
-          const { message, requester, recordsWrite } = await TestDataGenerator.generateRecordsWriteMessage({
+          const { message, requester, recordsWrite } = await TestDataGenerator.generateRecordsWrite({
             published: true
           });
           const tenant = requester.did;
@@ -304,7 +304,7 @@ describe('handleRecordsWrite()', () => {
           expect(newWriteReply.status.code).to.equal(202);
 
           // verify the new record state can be queried
-          const recordsQueryMessageData = await TestDataGenerator.generateRecordsQueryMessage({
+          const recordsQueryMessageData = await TestDataGenerator.generateRecordsQuery({
             requester,
             filter: { recordId: message.recordId }
           });
@@ -322,7 +322,7 @@ describe('handleRecordsWrite()', () => {
 
       it('should fail with 400 if modifying a record but its initial write cannot be found in DB', async () => {
         const recordId = await TestDataGenerator.randomCborSha256Cid();
-        const { message, requester } = await TestDataGenerator.generateRecordsWriteMessage({
+        const { message, requester } = await TestDataGenerator.generateRecordsWrite({
           recordId,
           data: Encoder.stringToBytes('anything') // simulating modification of a message
         });
@@ -336,7 +336,7 @@ describe('handleRecordsWrite()', () => {
       });
 
       it('should return 400 if `dateCreated` and `dateModified` are not the same in an initial write', async () => {
-        const { requester, message } = await TestDataGenerator.generateRecordsWriteMessage({
+        const { requester, message } = await TestDataGenerator.generateRecordsWrite({
           dateCreated  : '2023-01-10T10:20:30.405060',
           dateModified : getCurrentTimeInHighPrecision() // this always generate a different timestamp
         });
@@ -351,7 +351,7 @@ describe('handleRecordsWrite()', () => {
 
       it('should return 400 if `contextId` in an initial protocol-base write mismatches with the expected deterministic `contextId`', async () => {
         // generate a message with protocol so that computed contextId is also computed and included in message
-        const { message } = await TestDataGenerator.generateRecordsWriteMessage({ protocol: 'anyValue' });
+        const { message } = await TestDataGenerator.generateRecordsWrite({ protocol: 'anyValue' });
 
         message.contextId = await TestDataGenerator.randomCborSha256Cid(); // make contextId mismatch from computed value
 
@@ -390,7 +390,7 @@ describe('handleRecordsWrite()', () => {
         };
         const alice = await TestDataGenerator.generatePersona();
 
-        const protocolsConfigureMessageData = await TestDataGenerator.generateProtocolsConfigureMessage({
+        const protocolsConfigureMessageData = await TestDataGenerator.generateProtocolsConfigure({
           requester: alice,
           protocol,
           protocolDefinition
@@ -405,7 +405,7 @@ describe('handleRecordsWrite()', () => {
         // generate a `RecordsWrite` message from bob allowed by anyone
         const bob = await TestDataGenerator.generatePersona();
         const bobData = new TextEncoder().encode('data from bob');
-        const emailMessageDataFromBob = await TestDataGenerator.generateRecordsWriteMessage(
+        const emailMessageDataFromBob = await TestDataGenerator.generateRecordsWrite(
           {
             requester : bob,
             protocol,
@@ -420,7 +420,7 @@ describe('handleRecordsWrite()', () => {
         expect(bobWriteReply.status.code).to.equal(202);
 
         // verify bob's message got written to the DB
-        const messageDataForQueryingBobsWrite = await TestDataGenerator.generateRecordsQueryMessage({
+        const messageDataForQueryingBobsWrite = await TestDataGenerator.generateRecordsQuery({
           requester : alice,
           filter    : { recordId: emailMessageDataFromBob.message.recordId }
         });
@@ -440,7 +440,7 @@ describe('handleRecordsWrite()', () => {
 
         const alice = await TestDataGenerator.generatePersona();
 
-        const protocolsConfigureMessageData = await TestDataGenerator.generateProtocolsConfigureMessage({
+        const protocolsConfigureMessageData = await TestDataGenerator.generateProtocolsConfigure({
           requester: alice,
           protocol,
           protocolDefinition
@@ -455,7 +455,7 @@ describe('handleRecordsWrite()', () => {
         // write a credential application to Alice's DWN to simulate that she has sent a credential application to a VC issuer
         const vcIssuer = await TestDataGenerator.generatePersona();
         const encodedCredentialApplication = new TextEncoder().encode('credential application data');
-        const credentialApplicationData = await TestDataGenerator.generateRecordsWriteMessage({
+        const credentialApplicationData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : vcIssuer.did,
           protocol,
@@ -469,7 +469,7 @@ describe('handleRecordsWrite()', () => {
 
         // generate a credential application response message from VC issuer
         const encodedCredentialResponse = new TextEncoder().encode('credential response data');
-        const credentialResponseData = await TestDataGenerator.generateRecordsWriteMessage(
+        const credentialResponseData = await TestDataGenerator.generateRecordsWrite(
           {
             requester    : vcIssuer,
             recipientDid : alice.did,
@@ -487,7 +487,7 @@ describe('handleRecordsWrite()', () => {
         expect(credentialResponseReply.status.code).to.equal(202);
 
         // verify VC issuer's message got written to the DB
-        const messageDataForQueryingCredentialResponse = await TestDataGenerator.generateRecordsQueryMessage({
+        const messageDataForQueryingCredentialResponse = await TestDataGenerator.generateRecordsQuery({
           requester : alice,
           filter    : { recordId: credentialResponseData.message.recordId }
         });
@@ -528,7 +528,7 @@ describe('handleRecordsWrite()', () => {
         };
         const alice = await TestDataGenerator.generatePersona();
 
-        const protocolsConfigureData = await TestDataGenerator.generateProtocolsConfigureMessage({
+        const protocolsConfigureData = await TestDataGenerator.generateProtocolsConfigure({
           requester: alice,
           protocol,
           protocolDefinition
@@ -543,7 +543,7 @@ describe('handleRecordsWrite()', () => {
         // generate a `RecordsWrite` message from bob
         const bob = await TestDataGenerator.generatePersona();
         const bobData = new TextEncoder().encode('data from bob');
-        const notesMessageDataFromBob = await TestDataGenerator.generateRecordsWriteMessage(
+        const notesMessageDataFromBob = await TestDataGenerator.generateRecordsWrite(
           {
             requester : bob,
             protocol,
@@ -558,7 +558,7 @@ describe('handleRecordsWrite()', () => {
         expect(bobWriteReply.status.code).to.equal(202);
 
         // verify bob's message got written to the DB
-        const messageDataForQueryingBobsWrite = await TestDataGenerator.generateRecordsQueryMessage({
+        const messageDataForQueryingBobsWrite = await TestDataGenerator.generateRecordsQuery({
           requester : alice,
           filter    : { recordId: notesMessageDataFromBob.message.recordId }
         });
@@ -610,7 +610,7 @@ describe('handleRecordsWrite()', () => {
         };
         const alice = await TestDataGenerator.generatePersona();
 
-        const protocolsConfigureData = await TestDataGenerator.generateProtocolsConfigureMessage({
+        const protocolsConfigureData = await TestDataGenerator.generateProtocolsConfigure({
           requester: alice,
           protocol,
           protocolDefinition
@@ -625,7 +625,7 @@ describe('handleRecordsWrite()', () => {
         // generate a `RecordsWrite` message from bob
         const bob = await TestDataGenerator.generatePersona();
         const bobData = new TextEncoder().encode('data from bob');
-        const notesMessageDataFromBob = await TestDataGenerator.generateRecordsWriteMessage(
+        const notesMessageDataFromBob = await TestDataGenerator.generateRecordsWrite(
           {
             requester : bob,
             protocol,
@@ -640,7 +640,7 @@ describe('handleRecordsWrite()', () => {
         expect(bobWriteReply.status.code).to.equal(202);
 
         // verify bob's message got written to the DB
-        const messageDataForQueryingBobsWrite = await TestDataGenerator.generateRecordsQueryMessage({
+        const messageDataForQueryingBobsWrite = await TestDataGenerator.generateRecordsQuery({
           requester : alice,
           filter    : { recordId: notesMessageDataFromBob.message.recordId }
         });
@@ -652,7 +652,7 @@ describe('handleRecordsWrite()', () => {
         // generate a new message from carol updating the existing notes, which should not be allowed/accepted
         const carol = await TestDataGenerator.generatePersona();
         const newNotesData = new TextEncoder().encode('different data by carol');
-        const newNotesMessageDataFromBob = await TestDataGenerator.generateRecordsWriteMessage(
+        const newNotesMessageDataFromBob = await TestDataGenerator.generateRecordsWrite(
           {
             requester : carol,
             protocol,
@@ -696,7 +696,7 @@ describe('handleRecordsWrite()', () => {
         };
         const alice = await TestDataGenerator.generatePersona();
 
-        const protocolsConfigureData = await TestDataGenerator.generateProtocolsConfigureMessage({
+        const protocolsConfigureData = await TestDataGenerator.generateProtocolsConfigure({
           requester: alice,
           protocol,
           protocolDefinition
@@ -711,7 +711,7 @@ describe('handleRecordsWrite()', () => {
         // generate a `RecordsWrite` message from bob
         const bob = await TestDataGenerator.generatePersona();
         const bobData = new TextEncoder().encode('data from bob');
-        const notesMessageDataFromBob = await TestDataGenerator.generateRecordsWriteMessage(
+        const notesMessageDataFromBob = await TestDataGenerator.generateRecordsWrite(
           {
             requester : bob,
             protocol,
@@ -726,7 +726,7 @@ describe('handleRecordsWrite()', () => {
         expect(bobWriteReply.status.code).to.equal(202);
 
         // verify bob's message got written to the DB
-        const messageDataForQueryingBobsWrite = await TestDataGenerator.generateRecordsQueryMessage({
+        const messageDataForQueryingBobsWrite = await TestDataGenerator.generateRecordsQuery({
           requester : alice,
           filter    : { recordId: notesMessageDataFromBob.message.recordId }
         });
@@ -736,7 +736,7 @@ describe('handleRecordsWrite()', () => {
         expect((bobRecordQueryReply.entries![0] as RecordsWriteMessage).encodedData).to.equal(base64url.baseEncode(bobData));
 
         // generate a new message from bob changing immutable recipientDid
-        const newNotesMessageDataFromBob = await TestDataGenerator.generateRecordsWriteMessage(
+        const newNotesMessageDataFromBob = await TestDataGenerator.generateRecordsWrite(
           {
             requester    : bob,
             dateCreated  : notesMessageDataFromBob.message.descriptor.dateCreated,
@@ -764,7 +764,7 @@ describe('handleRecordsWrite()', () => {
 
         const alice = await TestDataGenerator.generatePersona();
 
-        const protocolsConfigureData = await TestDataGenerator.generateProtocolsConfigureMessage({
+        const protocolsConfigureData = await TestDataGenerator.generateProtocolsConfigure({
           requester: alice,
           protocol,
           protocolDefinition
@@ -779,7 +779,7 @@ describe('handleRecordsWrite()', () => {
         // write a credential application to Alice's DWN to simulate that she has sent a credential application to a VC issuer
         const vcIssuer = await TestDataGenerator.generatePersona();
         const encodedCredentialApplication = new TextEncoder().encode('credential application data');
-        const credentialApplicationData = await TestDataGenerator.generateRecordsWriteMessage({
+        const credentialApplicationData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : vcIssuer.did,
           protocol,
@@ -794,7 +794,7 @@ describe('handleRecordsWrite()', () => {
         // generate a credential application response message from a fake VC issuer
         const fakeVcIssuer = await TestDataGenerator.generatePersona();
         const encodedCredentialResponse = new TextEncoder().encode('credential response data');
-        const credentialResponseData = await TestDataGenerator.generateRecordsWriteMessage(
+        const credentialResponseData = await TestDataGenerator.generateRecordsWrite(
           {
             requester    : fakeVcIssuer,
             recipientDid : alice.did,
@@ -817,7 +817,7 @@ describe('handleRecordsWrite()', () => {
         const alice = await DidKeyResolver.generate();
         const protocol = 'nonExistentProtocol';
         const data = Encoder.stringToBytes('any data');
-        const credentialApplicationMessageData = await TestDataGenerator.generateRecordsWriteMessage({
+        const credentialApplicationMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : alice.did,
           protocol,
@@ -833,7 +833,7 @@ describe('handleRecordsWrite()', () => {
         const alice = await DidKeyResolver.generate();
 
         const protocol = 'https://identity.foundation/decentralized-web-node/protocols/credential-issuance';
-        const protocolConfigureMessageData = await TestDataGenerator.generateProtocolsConfigureMessage({
+        const protocolConfigureMessageData = await TestDataGenerator.generateProtocolsConfigure({
           requester          : alice,
           protocol,
           protocolDefinition : credentialIssuanceProtocolDefinition
@@ -843,7 +843,7 @@ describe('handleRecordsWrite()', () => {
         expect(protocolConfigureReply.status.code).to.equal(202);
 
         const data = Encoder.stringToBytes('any data');
-        const credentialApplicationMessageData = await TestDataGenerator.generateRecordsWriteMessage({
+        const credentialApplicationMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : alice.did,
           protocol,
@@ -861,7 +861,7 @@ describe('handleRecordsWrite()', () => {
 
         const protocol = 'https://identity.foundation/decentralized-web-node/protocols/credential-issuance';
         const protocolDefinition = credentialIssuanceProtocolDefinition;
-        const protocolConfigureMessageData = await TestDataGenerator.generateProtocolsConfigureMessage({
+        const protocolConfigureMessageData = await TestDataGenerator.generateProtocolsConfigure({
           requester: alice,
           protocol,
           protocolDefinition
@@ -872,7 +872,7 @@ describe('handleRecordsWrite()', () => {
         expect(protocolConfigureReply.status.code).to.equal(202);
 
         const data = Encoder.stringToBytes('any data');
-        const credentialApplicationMessageData = await TestDataGenerator.generateRecordsWriteMessage({
+        const credentialApplicationMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : alice.did,
           protocol,
@@ -900,7 +900,7 @@ describe('handleRecordsWrite()', () => {
             privateNote: {}
           }
         };
-        const protocolConfigureMessageData = await TestDataGenerator.generateProtocolsConfigureMessage({
+        const protocolConfigureMessageData = await TestDataGenerator.generateProtocolsConfigure({
           requester: alice,
           protocol,
           protocolDefinition
@@ -911,7 +911,7 @@ describe('handleRecordsWrite()', () => {
 
         // test that Alice is allowed to write to her own DWN
         const data = Encoder.stringToBytes('any data');
-        const aliceWriteMessageData = await TestDataGenerator.generateRecordsWriteMessage({
+        const aliceWriteMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : alice.did,
           protocol,
@@ -924,7 +924,7 @@ describe('handleRecordsWrite()', () => {
 
         // test that Bob is not allowed to write to Alice's DWN
         const bob = await DidKeyResolver.generate();
-        const bobWriteMessageData = await TestDataGenerator.generateRecordsWriteMessage({
+        const bobWriteMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : bob,
           recipientDid : alice.did,
           protocol,
@@ -948,7 +948,7 @@ describe('handleRecordsWrite()', () => {
 
         // write the VC issuance protocol
         const protocol = 'https://identity.foundation/decentralized-web-node/protocols/credential-issuance';
-        const protocolConfigureMessageData = await TestDataGenerator.generateProtocolsConfigureMessage({
+        const protocolConfigureMessageData = await TestDataGenerator.generateProtocolsConfigure({
           requester          : alice,
           protocol,
           protocolDefinition : invalidProtocolDefinition
@@ -959,7 +959,7 @@ describe('handleRecordsWrite()', () => {
 
         // simulate Alice's VC applications with both issuer
         const data = Encoder.stringToBytes('irrelevant');
-        const messageDataWithIssuerA = await TestDataGenerator.generateRecordsWriteMessage({
+        const messageDataWithIssuerA = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : issuer.did,
           schema       : credentialIssuanceProtocolDefinition.labels.credentialApplication.schema,
@@ -972,7 +972,7 @@ describe('handleRecordsWrite()', () => {
         expect(reply.status.code).to.equal(202);
 
         // simulate issuer attempting to respond to Alice's VC application
-        const invalidResponseDataByIssuerA = await TestDataGenerator.generateRecordsWriteMessage({
+        const invalidResponseDataByIssuerA = await TestDataGenerator.generateRecordsWrite({
           requester    : issuer,
           recipientDid : alice.did,
           schema       : credentialIssuanceProtocolDefinition.labels.credentialResponse.schema,
@@ -998,7 +998,7 @@ describe('handleRecordsWrite()', () => {
 
         // write the VC issuance protocol
         const protocol = 'https://identity.foundation/decentralized-web-node/protocols/credential-issuance';
-        const protocolConfigureMessageData = await TestDataGenerator.generateProtocolsConfigureMessage({
+        const protocolConfigureMessageData = await TestDataGenerator.generateProtocolsConfigure({
           requester          : alice,
           protocol,
           protocolDefinition : invalidProtocolDefinition
@@ -1009,7 +1009,7 @@ describe('handleRecordsWrite()', () => {
 
         // simulate Alice's VC application to an issuer
         const data = Encoder.stringToBytes('irrelevant');
-        const messageDataWithIssuerA = await TestDataGenerator.generateRecordsWriteMessage({
+        const messageDataWithIssuerA = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : issuer.did,
           schema       : credentialIssuanceProtocolDefinition.labels.credentialApplication.schema,
@@ -1022,7 +1022,7 @@ describe('handleRecordsWrite()', () => {
         expect(reply.status.code).to.equal(202);
 
         // simulate issuer attempting to respond to Alice's VC application
-        const invalidResponseDataByIssuerA = await TestDataGenerator.generateRecordsWriteMessage({
+        const invalidResponseDataByIssuerA = await TestDataGenerator.generateRecordsWrite({
           requester    : issuer,
           recipientDid : alice.did,
           schema       : credentialIssuanceProtocolDefinition.labels.credentialResponse.schema,
@@ -1049,7 +1049,7 @@ describe('handleRecordsWrite()', () => {
         const protocolDefinition: ProtocolDefinition = dexProtocolDefinition;
 
         // write the DEX protocol in the PFI
-        const protocolConfigureMessageData = await TestDataGenerator.generateProtocolsConfigureMessage({
+        const protocolConfigureMessageData = await TestDataGenerator.generateProtocolsConfigure({
           requester          : pfi,
           protocol,
           protocolDefinition : protocolDefinition
@@ -1060,7 +1060,7 @@ describe('handleRecordsWrite()', () => {
 
         // simulate Alice's ask and PFI's offer already occurred
         const data = Encoder.stringToBytes('irrelevant');
-        const askMessageData = await TestDataGenerator.generateRecordsWriteMessage({
+        const askMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
           schema       : 'ask',
@@ -1072,7 +1072,7 @@ describe('handleRecordsWrite()', () => {
         let reply = await handleRecordsWrite(pfi.did, askMessageData.message, messageStore, didResolver);
         expect(reply.status.code).to.equal(202);
 
-        const offerMessageData = await TestDataGenerator.generateRecordsWriteMessage({
+        const offerMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : pfi,
           recipientDid : alice.did,
           schema       : 'offer',
@@ -1086,7 +1086,7 @@ describe('handleRecordsWrite()', () => {
         expect(reply.status.code).to.equal(202);
 
         // the actual test: making sure fulfillment message is accepted
-        const fulfillmentMessageData = await TestDataGenerator.generateRecordsWriteMessage({
+        const fulfillmentMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
           schema       : 'fulfillment',
@@ -1099,7 +1099,7 @@ describe('handleRecordsWrite()', () => {
         expect(reply.status.code).to.equal(202);
 
         // verify the fulfillment message is stored
-        const recordsQueryMessageData = await TestDataGenerator.generateRecordsQueryMessage({
+        const recordsQueryMessageData = await TestDataGenerator.generateRecordsQuery({
           requester : pfi,
           filter    : { recordId: fulfillmentMessageData.message.recordId }
         });
@@ -1125,7 +1125,7 @@ describe('handleRecordsWrite()', () => {
         const protocolDefinition: ProtocolDefinition = dexProtocolDefinition;
 
         // write the DEX protocol in the PFI
-        const protocolConfigureMessageData = await TestDataGenerator.generateProtocolsConfigureMessage({
+        const protocolConfigureMessageData = await TestDataGenerator.generateProtocolsConfigure({
           requester          : pfi,
           protocol,
           protocolDefinition : protocolDefinition
@@ -1136,7 +1136,7 @@ describe('handleRecordsWrite()', () => {
 
         // simulate Alice's ask
         const data = Encoder.stringToBytes('irrelevant');
-        const askMessageData = await TestDataGenerator.generateRecordsWriteMessage({
+        const askMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
           schema       : 'ask',
@@ -1149,7 +1149,7 @@ describe('handleRecordsWrite()', () => {
         expect(reply.status.code).to.equal(202);
 
         // the actual test: making sure fulfillment message fails
-        const fulfillmentMessageData = await TestDataGenerator.generateRecordsWriteMessage({
+        const fulfillmentMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
           schema       : 'fulfillment',
@@ -1166,7 +1166,7 @@ describe('handleRecordsWrite()', () => {
   });
 
   it('should return 400 if `recordId` in `authorization` payload mismatches with `recordId` in the message', async () => {
-    const { requester, message, recordsWrite } = await TestDataGenerator.generateRecordsWriteMessage();
+    const { requester, message, recordsWrite } = await TestDataGenerator.generateRecordsWrite();
 
     // replace `authorization` with mismatching `record`, even though signature is still valid
     const authorizationPayload = { ...recordsWrite.authorizationPayload };
@@ -1187,7 +1187,7 @@ describe('handleRecordsWrite()', () => {
 
   it('should return 400 if `contextId` in `authorization` payload mismatches with `contextId` in the message', async () => {
     // generate a message with protocol so that computed contextId is also computed and included in message
-    const { requester, message, recordsWrite } = await TestDataGenerator.generateRecordsWriteMessage({ protocol: 'anyValue' });
+    const { requester, message, recordsWrite } = await TestDataGenerator.generateRecordsWrite({ protocol: 'anyValue' });
 
     // replace `authorization` with mismatching `contextId`, even though signature is still valid
     const authorizationPayload = { ...recordsWrite.authorizationPayload };
@@ -1207,7 +1207,7 @@ describe('handleRecordsWrite()', () => {
   });
 
   it('should return 400 if actual CID of `data` mismatches with `dataCid` in descriptor', async () => {
-    const messageData = await TestDataGenerator.generateRecordsWriteMessage();
+    const messageData = await TestDataGenerator.generateRecordsWrite();
     messageData.message.encodedData = base64url.baseEncode(TestDataGenerator.randomBytes(50));
 
     const didResolverStub = sinon.createStubInstance(DidResolver);
@@ -1220,7 +1220,7 @@ describe('handleRecordsWrite()', () => {
   });
 
   it('should return 401 if signature check fails', async () => {
-    const { requester, message } = await TestDataGenerator.generateRecordsWriteMessage();
+    const { requester, message } = await TestDataGenerator.generateRecordsWrite();
 
     // setting up a stub did resolver & message store
     // intentionally not supplying the public key so a different public key is generated to simulate invalid signature
@@ -1237,7 +1237,7 @@ describe('handleRecordsWrite()', () => {
 
   it('should return 401 if an authorized requester is attempting write', async () => {
     const requester = await TestDataGenerator.generatePersona();
-    const { message } = await TestDataGenerator.generateRecordsWriteMessage({ requester });
+    const { message } = await TestDataGenerator.generateRecordsWrite({ requester });
 
     // setting up a stub did resolver & message store
     const didResolverStub = TestStubGenerator.createDidResolverStub(requester);

--- a/tests/interfaces/records/messages/records-delete.spec.ts
+++ b/tests/interfaces/records/messages/records-delete.spec.ts
@@ -14,9 +14,9 @@ describe('RecordsDelete', () => {
 
       const currentTime = getCurrentTimeInHighPrecision();
       const recordsDelete = await RecordsDelete.create({
-        recordId       : 'anything',
-        signatureInput : TestDataGenerator.createSignatureInputFromPersona(alice),
-        dateModified   : currentTime
+        recordId                    : 'anything',
+        authorizationSignatureInput : TestDataGenerator.createSignatureInputFromPersona(alice),
+        dateModified                : currentTime
       });
 
       expect(recordsDelete.message.descriptor.dateModified).to.equal(currentTime);
@@ -26,8 +26,8 @@ describe('RecordsDelete', () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const recordsDelete = await RecordsDelete.create({
-        recordId       : 'anything',
-        signatureInput : TestDataGenerator.createSignatureInputFromPersona(alice)
+        recordId                    : 'anything',
+        authorizationSignatureInput : TestDataGenerator.createSignatureInputFromPersona(alice)
       });
 
       expect(recordsDelete.message.descriptor.dateModified).to.exist;

--- a/tests/interfaces/records/messages/records-query.spec.ts
+++ b/tests/interfaces/records/messages/records-query.spec.ts
@@ -14,9 +14,9 @@ describe('RecordsQuery', () => {
 
       const currentTime = getCurrentTimeInHighPrecision();
       const recordsDelete = await RecordsQuery.create({
-        filter         : { schema: 'anything' },
-        dateCreated    : currentTime,
-        signatureInput : TestDataGenerator.createSignatureInputFromPersona(alice),
+        filter                      : { schema: 'anything' },
+        dateCreated                 : currentTime,
+        authorizationSignatureInput : TestDataGenerator.createSignatureInputFromPersona(alice),
       });
 
       expect(recordsDelete.message.descriptor.dateCreated).to.equal(currentTime);

--- a/tests/interfaces/records/messages/records-write.spec.ts
+++ b/tests/interfaces/records/messages/records-write.spec.ts
@@ -19,12 +19,12 @@ describe('RecordsWrite', () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const options = {
-        recipient      : alice.did,
-        data           : TestDataGenerator.randomBytes(10),
-        dataFormat     : 'application/json',
-        dateCreated    : '2022-10-14T10:20:30.405060',
-        recordId       : await TestDataGenerator.randomCborSha256Cid(),
-        signatureInput : TestDataGenerator.createSignatureInputFromPersona(alice)
+        recipient                   : alice.did,
+        data                        : TestDataGenerator.randomBytes(10),
+        dataFormat                  : 'application/json',
+        dateCreated                 : '2022-10-14T10:20:30.405060',
+        recordId                    : await TestDataGenerator.randomCborSha256Cid(),
+        authorizationSignatureInput : TestDataGenerator.createSignatureInputFromPersona(alice)
       };
       const recordsWrite = await RecordsWrite.create(options);
 
@@ -45,12 +45,12 @@ describe('RecordsWrite', () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const options = {
-        recipient      : alice.did,
-        data           : TestDataGenerator.randomBytes(10),
-        dataFormat     : 'application/json',
-        recordId       : await TestDataGenerator.randomCborSha256Cid(),
-        published      : true,
-        signatureInput : TestDataGenerator.createSignatureInputFromPersona(alice)
+        recipient                   : alice.did,
+        data                        : TestDataGenerator.randomBytes(10),
+        dataFormat                  : 'application/json',
+        recordId                    : await TestDataGenerator.randomCborSha256Cid(),
+        published                   : true,
+        authorizationSignatureInput : TestDataGenerator.createSignatureInputFromPersona(alice)
       };
       const recordsWrite = await RecordsWrite.create(options);
 
@@ -69,7 +69,7 @@ describe('RecordsWrite', () => {
       const write = await RecordsWrite.createFrom({
         unsignedRecordsWriteMessage : recordsWrite.message,
         datePublished               : getCurrentTimeInHighPrecision(),
-        signatureInput              : TestDataGenerator.createSignatureInputFromPersona(requester)
+        authorizationSignatureInput : TestDataGenerator.createSignatureInputFromPersona(requester)
       });
 
       expect(write.message.descriptor.published).to.be.true;

--- a/tests/interfaces/records/messages/records-write.spec.ts
+++ b/tests/interfaces/records/messages/records-write.spec.ts
@@ -62,7 +62,7 @@ describe('RecordsWrite', () => {
 
   describe('createFrom()', () => {
     it('should create a RecordsWrite with `published` set to `true` with just `publishedDate` given', async () => {
-      const { requester, recordsWrite } = await TestDataGenerator.generateRecordsWriteMessage({
+      const { requester, recordsWrite } = await TestDataGenerator.generateRecordsWrite({
         published: false
       });
 
@@ -79,7 +79,7 @@ describe('RecordsWrite', () => {
   describe('compareModifiedTime', () => {
     it('should return 0 if age is same', async () => {
       const dateModified = getCurrentTimeInHighPrecision();
-      const a = (await TestDataGenerator.generateRecordsWriteMessage({ dateModified })).message;
+      const a = (await TestDataGenerator.generateRecordsWrite({ dateModified })).message;
       const b = JSON.parse(JSON.stringify(a)); // create a deep copy of `a`
 
       const compareResult = await RecordsWrite.compareModifiedTime(a, b);
@@ -89,11 +89,11 @@ describe('RecordsWrite', () => {
 
   describe('getNewestMessage', () => {
     it('should return the newest message', async () => {
-      const a = (await TestDataGenerator.generateRecordsWriteMessage()).message;
+      const a = (await TestDataGenerator.generateRecordsWrite()).message;
       await sleep(1); // need to sleep for at least one millisecond else some messages get generated with the same time
-      const b = (await TestDataGenerator.generateRecordsWriteMessage()).message;
+      const b = (await TestDataGenerator.generateRecordsWrite()).message;
       await sleep(1);
-      const c = (await TestDataGenerator.generateRecordsWriteMessage()).message; // c is the newest since its created last
+      const c = (await TestDataGenerator.generateRecordsWrite()).message; // c is the newest since its created last
 
       const newestMessage = await RecordsWrite.getNewestMessage([b, c, a]);
       expect((newestMessage as any).recordId).to.equal(c.recordId);
@@ -102,7 +102,7 @@ describe('RecordsWrite', () => {
 
   describe('getCid', () => {
     it('should return the same value with or without `encodedData`', async () => {
-      const messageData = await TestDataGenerator.generateRecordsWriteMessage();
+      const messageData = await TestDataGenerator.generateRecordsWrite();
 
       const messageWithoutEncodedData = { ...messageData.message };
       delete messageWithoutEncodedData.encodedData;
@@ -116,7 +116,7 @@ describe('RecordsWrite', () => {
 
   describe('isInitialWrite', () => {
     it('should return false if given message is not a RecordsWrite', async () => {
-      const { message }= await TestDataGenerator.generateRecordsQueryMessage();
+      const { message }= await TestDataGenerator.generateRecordsQuery();
       const isInitialWrite = await RecordsWrite.isInitialWrite(message);
       expect(isInitialWrite).to.be.false;
     });

--- a/tests/store/message-store.spec.ts
+++ b/tests/store/message-store.spec.ts
@@ -1,6 +1,6 @@
+import { computeCid } from '../../src/utils/cid.js';
 import { DidKeyResolver } from '../../src/index.js';
 import { expect } from 'chai';
-import { generateCid } from '../../src/utils/cid.js';
 import { Message } from '../../src/core/message.js';
 import { MessageStoreLevel } from '../../src/store/message-store-level.js';
 import { RecordsWriteMessage } from '../../src/interfaces/records/types.js';
@@ -78,10 +78,10 @@ describe('MessageStoreLevel Tests', () => {
 
       await messageStore.put(message, {});
 
-      const expectedCid = await generateCid(message);
+      const expectedCid = await computeCid(message);
 
       const jsonMessage = await messageStore.get(expectedCid);
-      const resultCid = await generateCid(jsonMessage);
+      const resultCid = await computeCid(jsonMessage);
 
       expect(resultCid.equals(expectedCid)).to.be.true;
     });

--- a/tests/store/message-store.spec.ts
+++ b/tests/store/message-store.spec.ts
@@ -74,7 +74,7 @@ describe('MessageStoreLevel Tests', () => {
     });
 
     it('stores messages as cbor/sha256 encoded blocks with CID as key', async () => {
-      const { message } = await TestDataGenerator.generatePermissionsRequestMessage();
+      const { message } = await TestDataGenerator.generatePermissionsRequest();
 
       await messageStore.put(message, {});
 
@@ -90,7 +90,7 @@ describe('MessageStoreLevel Tests', () => {
     it('#170 - should be able to update (delete and insert new) indexes to an existing message', async () => {
       const alice = await DidKeyResolver.generate();
 
-      const { message } = await TestDataGenerator.generateRecordsWriteMessage();
+      const { message } = await TestDataGenerator.generateRecordsWrite();
 
       // inserting the message indicating it is the 'latest' in the index
       await messageStore.put(message, { tenant: alice.did, latest: 'true' });
@@ -115,7 +115,7 @@ describe('MessageStoreLevel Tests', () => {
 
     it('should index properties with characters beyond just letters and digits', async () => {
       const schema = 'http://my-awesome-schema/awesomeness_schema#awesome-1?id=awesome_1';
-      const messageData = await TestDataGenerator.generateRecordsWriteMessage({ schema });
+      const messageData = await TestDataGenerator.generateRecordsWrite({ schema });
 
       await messageStore.put(messageData.message, { schema });
 

--- a/tests/utils/cid.spec.ts
+++ b/tests/utils/cid.spec.ts
@@ -4,7 +4,7 @@ import * as cbor from '@ipld/dag-cbor';
 import chaiAsPromised from 'chai-as-promised';
 import chai, { expect } from 'chai';
 
-import { generateCid } from '../../src/utils/cid.js';
+import { computeCid } from '../../src/utils/cid.js';
 import { sha256 } from 'multiformats/hashes/sha2';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 
@@ -12,7 +12,7 @@ import { TestDataGenerator } from '../utils/test-data-generator.js';
 chai.use(chaiAsPromised);
 
 describe('CID', () => {
-  describe('generateCid', () => {
+  describe('computeCid', () => {
     xit('throws an error if codec is not supported');
     xit('throws an error if multihasher is not supported');
     xit('generates a cbor/sha256 v1 cid by default');
@@ -23,7 +23,7 @@ describe('CID', () => {
         b : TestDataGenerator.randomString(32),
         c : TestDataGenerator.randomString(32)
       };
-      const generatedCid = await generateCid(anyTestData);
+      const generatedCid = await computeCid(anyTestData);
       const encodedBlock = await block.encode({ value: anyTestData, codec: cbor, hasher: sha256 });
 
       expect(generatedCid.toString()).to.equal(encodedBlock.cid.toString());
@@ -41,8 +41,8 @@ describe('CID', () => {
         c : 'c',
         a : 'a'
       };
-      const cid1 = await generateCid(data1);
-      const cid2 = await generateCid(data2);
+      const cid1 = await computeCid(data1);
+      const cid2 = await computeCid(data2);
 
       expect(cid1.toString()).to.equal(cid2.toString());
     });

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -212,13 +212,13 @@ export class TestDataGenerator {
       definition.records[generatedLabel] = {};
     }
 
-    const signatureInput = TestDataGenerator.createSignatureInputFromPersona(requester);
+    const authorizationSignatureInput = TestDataGenerator.createSignatureInputFromPersona(requester);
 
     const options: ProtocolsConfigureOptions = {
       dateCreated : input?.dateCreated,
       protocol    : input?.protocol ?? TestDataGenerator.randomString(20),
       definition,
-      signatureInput
+      authorizationSignatureInput
     };
 
     const protocolsConfigure = await ProtocolsConfigure.create(options);
@@ -237,12 +237,12 @@ export class TestDataGenerator {
     // generate requester persona if not given
     const requester = input?.requester ?? await TestDataGenerator.generatePersona();
 
-    const signatureInput = TestDataGenerator.createSignatureInputFromPersona(requester);
+    const authorizationSignatureInput = TestDataGenerator.createSignatureInputFromPersona(requester);
 
     const options: ProtocolsQueryOptions = {
       dateCreated : input?.dateCreated,
       filter      : input?.filter,
-      signatureInput
+      authorizationSignatureInput
     };
     removeUndefinedProperties(options);
 
@@ -263,7 +263,7 @@ export class TestDataGenerator {
   public static async generateRecordsWriteMessage(input?: GenerateRecordsWriteMessageInput): Promise<GenerateRecordsWriteMessageOutput> {
     const requester = input?.requester ?? await TestDataGenerator.generatePersona();
 
-    const signatureInput = TestDataGenerator.createSignatureInputFromPersona(requester);
+    const authorizationSignatureInput = TestDataGenerator.createSignatureInputFromPersona(requester);
 
     const data = input?.data ?? TestDataGenerator.randomBytes(32);
 
@@ -280,7 +280,7 @@ export class TestDataGenerator {
       dateModified  : input?.dateModified,
       datePublished : input?.datePublished,
       data,
-      signatureInput
+      authorizationSignatureInput
     };
 
 
@@ -312,7 +312,7 @@ export class TestDataGenerator {
       published,
       datePublished,
       dateModified                : input.dateModified,
-      signatureInput              : TestDataGenerator.createSignatureInputFromPersona(input.requester)
+      authorizationSignatureInput : TestDataGenerator.createSignatureInputFromPersona(input.requester)
     };
 
     const recordsWrite = await RecordsWrite.createFrom(options);
@@ -325,11 +325,11 @@ export class TestDataGenerator {
   public static async generateRecordsQueryMessage(input?: GenerateRecordsQueryMessageInput): Promise<GenerateRecordsQueryMessageOutput> {
     const requester = input?.requester ?? await TestDataGenerator.generatePersona();
 
-    const signatureInput = TestDataGenerator.createSignatureInputFromPersona(requester);
+    const authorizationSignatureInput = TestDataGenerator.createSignatureInputFromPersona(requester);
 
     const options: RecordsQueryOptions = {
       dateCreated : input?.dateCreated,
-      signatureInput,
+      authorizationSignatureInput,
       filter      : input?.filter ?? { schema: TestDataGenerator.randomString(10) }, // must have one filter property if no filter is given
       dateSort    : input?.dateSort
     };
@@ -351,8 +351,8 @@ export class TestDataGenerator {
     const requester = await DidKeyResolver.generate();
 
     const recordsDelete = await RecordsDelete.create({
-      recordId       : await TestDataGenerator.randomCborSha256Cid(),
-      signatureInput : TestDataGenerator.createSignatureInputFromPersona(requester)
+      recordId                    : await TestDataGenerator.randomCborSha256Cid(),
+      authorizationSignatureInput : TestDataGenerator.createSignatureInputFromPersona(requester)
     });
 
     return {
@@ -368,11 +368,11 @@ export class TestDataGenerator {
   public static async generateHooksWriteMessage(input?: GenerateHooksWriteMessageInput): Promise<GenerateHooksWriteMessageOutput> {
     const requester = input?.requester ?? await TestDataGenerator.generatePersona();
 
-    const signatureInput = TestDataGenerator.createSignatureInputFromPersona(requester);
+    const authorizationSignatureInput = TestDataGenerator.createSignatureInputFromPersona(requester);
 
     const options: HooksWriteOptions = {
       dateCreated : input?.dateCreated,
-      signatureInput,
+      authorizationSignatureInput,
       filter      : input?.filter ?? { method: 'RecordsWrite' }, // hardcode to filter on `RecordsWrite` if no filter is given
     };
     removeUndefinedProperties(options);
@@ -391,12 +391,12 @@ export class TestDataGenerator {
   public static async generatePermissionsRequestMessage(): Promise<{ message: BaseMessage }> {
     const { privateJwk } = await ed25519.generateKeyPair();
     const permissionRequest = await PermissionsRequest.create({
-      dateCreated    : getCurrentTimeInHighPrecision(),
-      description    : 'drugs',
-      grantedBy      : 'did:jank:bob',
-      grantedTo      : 'did:jank:alice',
-      scope          : { method: 'RecordsWrite' },
-      signatureInput : { privateJwk: privateJwk, protectedHeader: { alg: privateJwk.alg as string, kid: 'whatev' } }
+      dateCreated                 : getCurrentTimeInHighPrecision(),
+      description                 : 'drugs',
+      grantedBy                   : 'did:jank:bob',
+      grantedTo                   : 'did:jank:alice',
+      scope                       : { method: 'RecordsWrite' },
+      authorizationSignatureInput : { privateJwk: privateJwk, protectedHeader: { alg: privateJwk.alg as string, kid: 'whatev' } }
     });
 
     return { message: permissionRequest.message };


### PR DESCRIPTION
1. RecordsWrite can now include an `attestation` property
2. `attestation` property is returned in results of a RecordsQuery

Will add support for `attester` in RecordsQuery filter in the next PR.