### PR TITLE
Support all common variants of importing/requiring

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "node": ">= 16"
   },
   "main": "./dist/cjs/src/index.js",
-  "exports": "./dist/esm/src/index.js",
+  "module": "./dist/esm/src/index.js",
+  "exports": {
+    "import": "./dist/esm/src/index.js",
+    "require": "./dist/cjs/src/index.js"
+  },
   "browser": {
     "./dist/esm/src/index.js": "./dist/bundles/browser.js",
     "./dist/cjs/src/index.js": "./dist/bundles/browser.js"


### PR DESCRIPTION
newer version of node use the `exports` property in `package.json` instead of `main` to figure out which file to import/require. Currently, the `package.json` in this repo only exports an `esm` distribution. This causes using the `cjs` distribution in newer versions of node to bork. 

This PR changes `exports` to support `cjs` and `esm`. Also added the `module` property because some bundlers look for it