### PR TITLE
#244 - add a `Options` to each method of `MessageStore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.87%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.93%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.61%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.87%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.77%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.04%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.68%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.77%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/src/store/message-store.ts
+++ b/src/store/message-store.ts
@@ -1,6 +1,10 @@
 import type { BaseMessage } from '../core/types.js';
 import type { RangeCriterion } from '../interfaces/records/types.js';
 
+export interface Options {
+  signal?: AbortSignal;
+}
+
 export interface MessageStore {
   /**
    * opens a connection to the underlying store
@@ -16,13 +20,17 @@ export interface MessageStore {
    * adds a message to the underlying store. Uses the message's cid as the key
    * @param indexes indexes (key-value pairs) to be included as part of this put operation
    */
-  put(messageJson: BaseMessage, indexes: { [key: string]: string }): Promise<void>;
+  put(
+    messageJson: BaseMessage,
+    indexes: { [key: string]: string },
+    options?: Options
+  ): Promise<void>;
 
   /**
    * Fetches a single message by `cid` from the underlying store.
    * Returns `undefined` no message was found.
    */
-  get(cid: string): Promise<BaseMessage | undefined>;
+  get(cid: string, options?: Options): Promise<BaseMessage | undefined>;
 
   /**
    * Queries the underlying store for messages that match the query provided.
@@ -33,11 +41,12 @@ export interface MessageStore {
    */
   query(
     exactCriteria: { [key: string]: string },
-    rangeCriteria?: { [key: string]: RangeCriterion }
+    rangeCriteria?: { [key: string]: RangeCriterion },
+    options?: Options
   ): Promise<BaseMessage[]>;
 
   /**
    * Deletes the message associated with the id provided.
    */
-  delete(cid: string): Promise<void>;
+  delete(cid: string, options?: Options): Promise<void>;
 }

--- a/src/utils/abort.ts
+++ b/src/utils/abort.ts
@@ -1,0 +1,29 @@
+/**
+ * Wraps the given `AbortSignal` in a `Promise` that rejects if it is triggered (and will therefore never resolve).
+ */
+function promisifySignal<Type>(signal: AbortSignal): Promise<Type> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+
+    signal.addEventListener('abort', () => {
+      reject(signal.reason);
+    });
+  });
+}
+
+/**
+ * Wraps the given `Promise` such that it will reject if the `AbortSignal` is triggered.
+ */
+export async function abortOr<Type>(signal: AbortSignal, promise: Promise<Type>): Promise<Type> {
+  if (!signal) {
+    return promise;
+  }
+
+  return Promise.race([
+    promise,
+    promisifySignal<Type>(signal),
+  ]);
+}


### PR DESCRIPTION
currently it only contains a `signal: AbortSignal` that can be used to stop the activity of the called method

it's worth noting that this will only go so far, as `search-index`/`level`/etc. do not support anything like this, so ultimately it will only prevent future operations from happening

for example, given the following
```js
abortOr(signal, other())
```
even if the `signal` is already aborted, `other()` has already been called and therefore will not be stopped (unless `other` is changed to accept the `signal` as an argument)