### PR TITLE
#244 - add a `createLevelDatabase` to allow customizing the `Level` used by `BlockstoreLevel`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.77%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.04%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.68%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.77%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.83%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.05%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.71%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.83%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/node": "^18.13.0",
         "@types/readable-stream": "^2.3.15",
         "@types/search-index": "3.2.0",
+        "abstract-level": "1.0.3",
         "ajv": "8.11.0",
         "blockstore-core": "3.0.0",
         "cross-fetch": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/node": "^18.13.0",
     "@types/readable-stream": "^2.3.15",
     "@types/search-index": "3.2.0",
+    "abstract-level": "1.0.3",
     "ajv": "8.11.0",
     "blockstore-core": "3.0.0",
     "cross-fetch": "3.1.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export type { RecordsDeleteMessage, RecordsQueryMessage, RecordsWriteMessage } f
 export { AllowAllTenantGate, TenantGate } from './core/tenant-gate.js';
 export { Cid } from './utils/cid.js';
 export { DataStore } from './store/data-store.js';
+export { DataStoreLevel } from './store/data-store-level.js';
 export { DateSort } from './interfaces/records/messages/records-query.js';
 export { DataStream } from './utils/data-stream.js';
 export { DidKeyResolver } from './did/did-key-resolver.js';

--- a/src/store/create-level.ts
+++ b/src/store/create-level.ts
@@ -1,0 +1,11 @@
+import type { AbstractDatabaseOptions, AbstractLevel } from 'abstract-level';
+
+import { Level } from 'level';
+
+export type LevelDatabase<K, V> = AbstractLevel<string | Buffer | Uint8Array, K, V>;
+
+export type LevelDatabaseOptions<K, V> = AbstractDatabaseOptions<K, V>;
+
+export function createLevelDatabase<K, V>(location: string, options?: LevelDatabaseOptions<K, V>): LevelDatabase<K, V> {
+  return new Level(location, options);
+}

--- a/src/store/data-store-level.ts
+++ b/src/store/data-store-level.ts
@@ -1,5 +1,6 @@
 import { BlockstoreLevel } from './blockstore-level.js';
 import { CID } from 'multiformats/cid';
+import { createLevelDatabase } from './create-level.js';
 import { DataStore } from './data-store.js';
 import { exporter } from 'ipfs-unixfs-exporter';
 import { importer } from 'ipfs-unixfs-importer';
@@ -10,10 +11,20 @@ import { Readable } from 'readable-stream';
  * Leverages LevelDB under the hood.
  */
 export class DataStoreLevel implements DataStore {
+  config: DataStoreLevelConfig;
+
   blockstore: BlockstoreLevel;
 
-  constructor(blockstoreLocation: string = 'DATASTORE') {
-    this.blockstore = new BlockstoreLevel(blockstoreLocation);
+  constructor(config: DataStoreLevelConfig = {}) {
+    this.config = {
+      blockstoreLocation: 'DATASTORE',
+      createLevelDatabase,
+      ...config
+    };
+
+    this.blockstore = new BlockstoreLevel(this.config.blockstoreLocation, {
+      createLevelDatabase: this.config.createLevelDatabase,
+    });
   }
 
   public async open(): Promise<void> {
@@ -82,3 +93,8 @@ export class DataStoreLevel implements DataStore {
     await this.blockstore.clear();
   }
 }
+
+type DataStoreLevelConfig = {
+  blockstoreLocation?: string,
+  createLevelDatabase?: typeof createLevelDatabase,
+};

--- a/src/store/message-store-level.ts
+++ b/src/store/message-store-level.ts
@@ -9,6 +9,7 @@ import searchIndex from 'search-index';
 import { abortOr } from '../utils/abort.js';
 import { BlockstoreLevel } from './blockstore-level.js';
 import { CID } from 'multiformats/cid';
+import { createLevelDatabase } from './create-level.js';
 import { RangeCriterion } from '../interfaces/records/types.js';
 import { sha256 } from 'multiformats/hashes/sha2';
 
@@ -19,7 +20,7 @@ import { sha256 } from 'multiformats/hashes/sha2';
 export class MessageStoreLevel implements MessageStore {
   config: MessageStoreLevelConfig;
 
-  public readonly blockstore: BlockstoreLevel;
+  blockstore: BlockstoreLevel;
 
   // levelDB doesn't natively provide the querying capabilities needed for DWN,
   // to accommodate, we're leveraging a level-backed inverted index.
@@ -36,10 +37,13 @@ export class MessageStoreLevel implements MessageStore {
     this.config = {
       blockstoreLocation : 'BLOCKSTORE',
       indexLocation      : 'INDEX',
+      createLevelDatabase,
       ...config
     };
 
-    this.blockstore = new BlockstoreLevel(this.config.blockstoreLocation);
+    this.blockstore = new BlockstoreLevel(this.config.blockstoreLocation, {
+      createLevelDatabase: this.config.createLevelDatabase,
+    });
   }
 
   async open(): Promise<void> {
@@ -242,4 +246,5 @@ type RangeSearchIndexTerm = {
 type MessageStoreLevelConfig = {
   blockstoreLocation?: string,
   indexLocation?: string,
+  createLevelDatabase?: typeof createLevelDatabase,
 };

--- a/tests/dwn.spec.ts
+++ b/tests/dwn.spec.ts
@@ -25,7 +25,9 @@ describe('DWN', () => {
       indexLocation      : 'TEST-INDEX'
     });
 
-    dataStore = new DataStoreLevel('TEST-DATASTORE');
+    dataStore = new DataStoreLevel({
+      blockstoreLocation: 'TEST-DATASTORE'
+    });
 
     dwn = await Dwn.create({ messageStore, dataStore });
   });

--- a/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
@@ -32,7 +32,9 @@ describe('ProtocolsConfigureHandler.handle()', () => {
         indexLocation      : 'TEST-INDEX'
       });
 
-      dataStore = new DataStoreLevel('TEST-DATASTORE');
+      dataStore = new DataStoreLevel({
+        blockstoreLocation: 'TEST-DATASTORE'
+      });
 
       dwn = await Dwn.create({ didResolver, messageStore, dataStore });
     });

--- a/tests/interfaces/protocols/handlers/protocols-query.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-query.spec.ts
@@ -30,7 +30,9 @@ describe('ProtocolsQueryHandler.handle()', () => {
         indexLocation      : 'TEST-INDEX'
       });
 
-      dataStore = new DataStoreLevel('TEST-DATASTORE');
+      dataStore = new DataStoreLevel({
+        blockstoreLocation: 'TEST-DATASTORE'
+      });
 
       dwn = await Dwn.create({ didResolver, messageStore, dataStore });
     });

--- a/tests/interfaces/records/handlers/records-delete.spec.ts
+++ b/tests/interfaces/records/handlers/records-delete.spec.ts
@@ -30,7 +30,9 @@ describe('RecordsDeleteHandler.handle()', () => {
         indexLocation      : 'TEST-INDEX'
       });
 
-      dataStore = new DataStoreLevel('TEST-DATASTORE');
+      dataStore = new DataStoreLevel({
+        blockstoreLocation: 'TEST-DATASTORE'
+      });
 
       dwn = await Dwn.create({ didResolver, messageStore, dataStore });
     });

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -36,7 +36,9 @@ describe('RecordsQueryHandler.handle()', () => {
         indexLocation      : 'TEST-INDEX'
       });
 
-      dataStore = new DataStoreLevel('TEST-DATASTORE');
+      dataStore = new DataStoreLevel({
+        blockstoreLocation: 'TEST-DATASTORE'
+      });
 
       dwn = await Dwn.create({ didResolver, messageStore, dataStore });
     });

--- a/tests/interfaces/records/handlers/records-read.spec.ts
+++ b/tests/interfaces/records/handlers/records-read.spec.ts
@@ -31,7 +31,9 @@ describe('RecordsReadHandler.handle()', () => {
         indexLocation      : 'TEST-INDEX'
       });
 
-      dataStore = new DataStoreLevel('TEST-DATASTORE');
+      dataStore = new DataStoreLevel({
+        blockstoreLocation: 'TEST-DATASTORE'
+      });
 
       dwn = await Dwn.create({ didResolver, messageStore, dataStore });
     });

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -43,7 +43,9 @@ describe('RecordsWriteHandler.handle()', () => {
         indexLocation      : 'TEST-INDEX'
       });
 
-      dataStore = new DataStoreLevel('TEST-DATASTORE');
+      dataStore = new DataStoreLevel({
+        blockstoreLocation: 'TEST-DATASTORE'
+      });
 
       dwn = await Dwn.create({ didResolver, messageStore, dataStore });
     });

--- a/tests/store/message-store.spec.ts
+++ b/tests/store/message-store.spec.ts
@@ -5,6 +5,7 @@ import { Message } from '../../src/core/message.js';
 import { MessageStoreLevel } from '../../src/store/message-store-level.js';
 import { RecordsWriteMessage } from '../../src/interfaces/records/types.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
+import { createLevelDatabase, LevelDatabase, LevelDatabaseOptions } from '../../src/store/create-level.js';
 
 let messageStore: MessageStoreLevel;
 
@@ -159,6 +160,24 @@ describe('MessageStoreLevel Tests', () => {
 
       const results = await messageStore.query({ schema });
       expect(results.length).to.equal(0);
+    });
+  });
+
+  describe('createLevelDatabase', function () {
+    it('should be called if provided', async () => {
+      let called = 0;
+
+      new MessageStoreLevel({
+        blockstoreLocation : 'TEST-BLOCKSTORE',
+        indexLocation      : 'TEST-INDEX',
+        createLevelDatabase<K, V>(location, options?: LevelDatabaseOptions<K, V>): LevelDatabase<K, V> {
+          ++called;
+          expect(location).to.equal('TEST-BLOCKSTORE');
+          return createLevelDatabase(location, options);
+        }
+      });
+
+      expect(called).to.equal(1);
     });
   });
 });


### PR DESCRIPTION
this will also be passed down when creating a `Dwn`, `MessageStoreLevel`, and `DataStoreLevel`