### PR TITLE
#244 - use the same parameter types for `MessageStoreLevel.prototype.query` and `IndexLevel.prototype.query`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.79%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-92.95%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.36%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.79%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.91%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-92.93%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.27%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.91%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -44,3 +44,15 @@ export type DataReferencingMessage = {
 
   encodedData: string;
 };
+
+export type EqualFilter = string | number | boolean;
+
+export type OneOfFilter = EqualFilter[];
+
+type GT = ({ gt: string } & { gte?: never }) | ({ gt?: never } & { gte: string });
+type LT = ({ lt: string } & { lte?: never }) | ({ lt?: never } & { lte: string });
+export type RangeFilter = (GT | LT) & Partial<GT> & Partial<LT>;
+
+export type Filter = {
+  [property: string]: EqualFilter | OneOfFilter | RangeFilter
+};

--- a/src/interfaces/records/handlers/records-query.ts
+++ b/src/interfaces/records/handlers/records-query.ts
@@ -68,16 +68,13 @@ export class RecordsQueryHandler implements MethodHandler {
    */
   private async fetchRecordsAsOwner(tenant: string, recordsQuery: RecordsQuery): Promise<BaseMessage[]> {
     // fetch all published records matching the query
-    const exactCriteria = RecordsQuery.getExactCriteria(recordsQuery.message.descriptor.filter);
-    const completeExactCriteria = {
-      ...exactCriteria,
+    const filter = {
+      ...RecordsQuery.convertFilter(recordsQuery.message.descriptor.filter),
       interface         : DwnInterfaceName.Records,
       method            : DwnMethodName.Write,
       isLatestBaseState : true
     };
-
-    const rangeCriteria = RecordsQuery.getRangeCriteria(recordsQuery.message.descriptor.filter);
-    const records = await StorageController.query(this.messageStore, this.dataStore, tenant, completeExactCriteria, rangeCriteria);
+    const records = await StorageController.query(this.messageStore, this.dataStore, tenant, filter);
     return records;
   }
 
@@ -100,17 +97,14 @@ export class RecordsQueryHandler implements MethodHandler {
    */
   private async fetchPublishedRecords(tenant: string, recordsQuery: RecordsQuery): Promise<BaseMessage[]> {
     // fetch all published records matching the query
-    const exactCriteria = RecordsQuery.getExactCriteria(recordsQuery.message.descriptor.filter);
-    const completeExactCriteria = {
-      ...exactCriteria,
+    const filter = {
+      ...RecordsQuery.convertFilter(recordsQuery.message.descriptor.filter),
       interface         : DwnInterfaceName.Records,
       method            : DwnMethodName.Write,
       published         : true,
       isLatestBaseState : true
     };
-
-    const rangeCriteria = RecordsQuery.getRangeCriteria(recordsQuery.message.descriptor.filter);
-    const publishedRecords = await StorageController.query(this.messageStore, this.dataStore, tenant, completeExactCriteria, rangeCriteria);
+    const publishedRecords = await StorageController.query(this.messageStore, this.dataStore, tenant, filter);
     return publishedRecords;
   }
 
@@ -119,24 +113,15 @@ export class RecordsQueryHandler implements MethodHandler {
    */
   private async fetchUnpublishedRecordsForRequester(tenant: string, recordsQuery: RecordsQuery): Promise<BaseMessage[]> {
   // include records where recipient is requester
-    const exactCriteria = RecordsQuery.getExactCriteria(recordsQuery.message.descriptor.filter);
-    const completeExactCriteria = {
-      ...exactCriteria,
+    const filter = {
+      ...RecordsQuery.convertFilter(recordsQuery.message.descriptor.filter),
       interface         : DwnInterfaceName.Records,
       method            : DwnMethodName.Write,
       recipient         : recordsQuery.author,
       isLatestBaseState : true,
       published         : false
     };
-
-    const rangeCriteria = RecordsQuery.getRangeCriteria(recordsQuery.message.descriptor.filter);
-    const unpublishedRecordsForRequester = await StorageController.query(
-      this.messageStore,
-      this.dataStore,
-      tenant,
-      completeExactCriteria,
-      rangeCriteria
-    );
+    const unpublishedRecordsForRequester = await StorageController.query(this.messageStore, this.dataStore, tenant, filter);
     return unpublishedRecordsForRequester;
   }
 
@@ -145,25 +130,15 @@ export class RecordsQueryHandler implements MethodHandler {
    */
   private async fetchUnpublishedRecordsByRequester(tenant: string, recordsQuery: RecordsQuery): Promise<BaseMessage[]> {
     // include records where recipient is requester
-    const exactCriteria = RecordsQuery.getExactCriteria(recordsQuery.message.descriptor.filter);
-    const completeExactCriteria = {
-      ...exactCriteria,
+    const filter = {
+      ...RecordsQuery.convertFilter(recordsQuery.message.descriptor.filter),
       author            : recordsQuery.author,
       interface         : DwnInterfaceName.Records,
       method            : DwnMethodName.Write,
       isLatestBaseState : true,
       published         : false
     };
-
-    const rangeCriteria = RecordsQuery.getRangeCriteria(recordsQuery.message.descriptor.filter);
-
-    const unpublishedRecordsForRequester = await StorageController.query(
-      this.messageStore,
-      this.dataStore,
-      tenant,
-      completeExactCriteria,
-      rangeCriteria
-    );
+    const unpublishedRecordsForRequester = await StorageController.query(this.messageStore, this.dataStore, tenant, filter);
     return unpublishedRecordsForRequester;
   }
 }

--- a/src/interfaces/records/types.ts
+++ b/src/interfaces/records/types.ts
@@ -56,14 +56,6 @@ export type RecordsQueryFilter = {
   dateCreated?: RangeCriterion;
 };
 
-/**
- * An exact criterion in a query filter.
- */
-export type ExactCriterion = unknown;
-
-/**
- * A range criterion in a query filter.
- */
 export type RangeCriterion = {
   /**
    * Inclusive starting date-time.

--- a/src/store/index-level.ts
+++ b/src/store/index-level.ts
@@ -1,5 +1,6 @@
 import type { LevelDatabase } from './create-level.js';
 import type { AbstractBatchDelOperation, AbstractBatchOperation, AbstractIteratorOptions } from 'abstract-level';
+import type { Filter, RangeFilter } from '../core/types.js';
 
 import { abortOr } from '../utils/abort.js';
 import { createLevelDatabase } from './create-level.js';
@@ -8,18 +9,6 @@ import { flatten } from '../utils/object.js';
 export type Entry = {
   _id: string,
   [property: string]: unknown
-};
-
-export type EqualFilter = string | number | boolean;
-
-export type OneOfFilter = EqualFilter[];
-
-type GT = ({ gt: string } & { gte?: never }) | ({ gt?: never } & { gte: string });
-type LT = ({ lt: string } & { lte?: never }) | ({ lt?: never } & { lte: string });
-export type RangeFilter = (GT | LT) & Partial<GT> & Partial<LT>;
-
-export type Filter = {
-  [property: string]: EqualFilter | OneOfFilter | RangeFilter
 };
 
 export interface IndexLevelOptions {

--- a/src/store/message-store.ts
+++ b/src/store/message-store.ts
@@ -1,5 +1,4 @@
-import type { BaseMessage } from '../core/types.js';
-import type { ExactCriterion, RangeCriterion } from '../interfaces/records/types.js';
+import type { BaseMessage, Filter } from '../core/types.js';
 
 export interface MessageStoreOptions {
   signal?: AbortSignal;
@@ -34,18 +33,9 @@ export interface MessageStore {
   get(tenant: string, cid: string, options?: MessageStoreOptions): Promise<BaseMessage | undefined>;
 
   /**
-   * Queries the underlying store for messages that match the query provided.
-   * The provided criteria are combined to form an AND filter for the query.
-   * Returns an empty array if no messages are found
-   * @param exactCriteria - criteria for exact matches
-   * @param rangeCriteria - criteria for range matches
+   * Queries the underlying store for messages that match the provided filter.
    */
-  query(
-    tenant: string,
-    exactCriteria: { [key: string]: ExactCriterion },
-    rangeCriteria?: { [key: string]: RangeCriterion },
-    options?: MessageStoreOptions
-  ): Promise<BaseMessage[]>;
+  query(tenant: string, filter: Filter, options?: MessageStoreOptions ): Promise<BaseMessage[]>;
 
   /**
    * Deletes the message associated with the id provided.

--- a/src/store/storage-controller.ts
+++ b/src/store/storage-controller.ts
@@ -1,8 +1,7 @@
-import { BaseMessage } from '../core/types.js';
 import { DataStore } from './data-store.js';
 import { MessageStore } from './message-store.js';
 import { Readable } from 'readable-stream';
-import { ExactCriterion, RangeCriterion } from '../interfaces/records/types.js';
+import { BaseMessage, Filter } from '../core/types.js';
 
 import { DataStream, Encoder } from '../index.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
@@ -80,11 +79,10 @@ export class StorageController {
     messageStore: MessageStore,
     dataStore: DataStore,
     tenant: string,
-    exactCriteria: { [key: string]: ExactCriterion },
-    rangeCriteria?: { [key: string]: RangeCriterion }
+    filter: Filter
   ): Promise<BaseMessage[]> {
 
-    const messages = await messageStore.query(tenant, exactCriteria, rangeCriteria);
+    const messages = await messageStore.query(tenant, filter);
 
     for (const message of messages) {
       const dataCid = message.descriptor.dataCid;

--- a/tests/store/message-store.spec.ts
+++ b/tests/store/message-store.spec.ts
@@ -4,85 +4,12 @@ import { expect } from 'chai';
 import { Message } from '../../src/core/message.js';
 import { MessageStoreLevel } from '../../src/store/message-store-level.js';
 import { RecordsWriteMessage } from '../../src/interfaces/records/types.js';
-import { Temporal } from '@js-temporal/polyfill';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { createLevelDatabase, LevelDatabase, LevelDatabaseOptions } from '../../src/store/create-level.js';
 
 let messageStore: MessageStoreLevel;
 
 describe('MessageStoreLevel Tests', () => {
-  describe('buildExactQueryTerms', () => {
-    it('returns the query exactly if it already matches the required structure', () => {
-      const query = {
-        method        : 'RecordsQuery',
-        schema        : 'https://schema.org/MusicPlaylist',
-        objectId      : 'abcd123',
-        published     : true, // boolean type
-        publishedDate : 1234567 // number type
-      };
-
-      const expected = {
-        'method'        : 'RecordsQuery',
-        'schema'        : 'https://schema.org/MusicPlaylist',
-        'objectId'      : 'abcd123',
-        'published'     : true,
-        'publishedDate' : 1234567
-      };
-      const terms = MessageStoreLevel['buildExactQueryTerms'](query);
-
-      expect(terms).to.eql(expected);
-    });
-
-    it('flattens nested objects', () => {
-      const query = {
-        requester : 'AlBorland',
-        ability   : {
-          method : 'RecordsQuery',
-          schema : 'https://schema.org/MusicPlaylist',
-          doo    : {
-            bingo: 'bongo'
-          }
-        }
-      };
-
-      const expected = {
-        'requester'         : 'AlBorland',
-        'ability.method'    : 'RecordsQuery',
-        'ability.schema'    : 'https://schema.org/MusicPlaylist',
-        'ability.doo.bingo' : 'bongo'
-      };
-
-      const terms = MessageStoreLevel['buildExactQueryTerms'](query);
-
-      expect(terms).to.eql(expected);
-    });
-  });
-
-  describe('buildRangeQueryTerms', () => {
-    it('converts from `RangeCriterion` to `RangeFilter`', () => {
-      const lastDayOf2021 = Temporal.PlainDateTime.from({ year: 2021, month: 12, day: 31 }).toString({ smallestUnit: 'microseconds' });
-      const lastDayOf2022 = Temporal.PlainDateTime.from({ year: 2022, month: 12, day: 31 }).toString({ smallestUnit: 'microseconds' });
-
-      const query = {
-        dateCreated: {
-          from : lastDayOf2021,
-          to   : lastDayOf2022
-        }
-      };
-
-      const expected = {
-        'dateCreated': {
-          'gte' : lastDayOf2021,
-          'lte' : lastDayOf2022
-        }
-      };
-
-      const terms = MessageStoreLevel['buildRangeQueryTerms'](query);
-
-      expect(terms).to.eql(expected);
-    });
-  });
-
   describe('put', function () {
     before(async () => {
       messageStore = new MessageStoreLevel({


### PR DESCRIPTION
this makes the API simpler to understand as `ExactCriterion` and `RangeCriterion` are expressed in the types rather than two separate parameters

it also entirely removes any chance of clashing if the same property is provided in both `exactCriteria` and `rangeCriteria`