### PR TITLE
#250 and #257 - change `to` of query JSON schema to represent `lt` instead of `lte`

### DIFF
--- a/src/interfaces/records/messages/records-query.ts
+++ b/src/interfaces/records/messages/records-query.ts
@@ -78,13 +78,13 @@ export class RecordsQuery extends Message {
       case 'dateCreated':
         var rangeFilter: RangeFilter = {
           gte : filter.dateCreated.from,
-          lte : filter.dateCreated.to
+          lt  : filter.dateCreated.to
         };
         if (rangeFilter.gte === undefined) {
           delete rangeFilter.gte;
         }
-        if (rangeFilter.lte === undefined) {
-          delete rangeFilter.lte;
+        if (rangeFilter.lt === undefined) {
+          delete rangeFilter.lt;
         }
         result.dateCreated = rangeFilter;
         break;

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -195,9 +195,8 @@ describe('RecordsQueryHandler.handle()', () => {
         dateSort  : DateSort.CreatedAscending
       });
       const reply4 = await dwn.processMessage(alice.did, recordsQuery4.message);
-      expect(reply4.entries?.length).to.equal(2);
+      expect(reply4.entries?.length).to.equal(1);
       expect((reply4.entries[0] as any).encodedData).to.equal(Encoder.bytesToBase64Url(write2.dataBytes));
-      expect((reply4.entries[1] as any).encodedData).to.equal(Encoder.bytesToBase64Url(write3.dataBytes));
     });
 
     it('should be able use range and exact match queries at the same time', async () => {


### PR DESCRIPTION
this better matches many other APIs that operate with a [inclusive, exclusive) system (e.g. `String.prototype.slice`)