### PR TITLE
#84 - implement a reference counting system for data management to avoid duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-95.06%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-92.97%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.53%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-95.06%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-95.12%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.04%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-94.09%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-95.12%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/src/interfaces/protocols/handlers/protocols-configure.ts
+++ b/src/interfaces/protocols/handlers/protocols-configure.ts
@@ -76,8 +76,7 @@ export class ProtocolsConfigureHandler implements MethodHandler {
     // delete all existing records that are smaller
     for (const message of existingMessages) {
       if (await Message.isCidLarger(newestMessage, message)) {
-        const cid = await Message.getCid(message);
-        await this.messageStore.delete(tenant, cid);
+        await StorageController.delete(this.messageStore, this.dataStore, tenant, message);
       }
     }
 

--- a/src/interfaces/records/handlers/records-delete.ts
+++ b/src/interfaces/records/handlers/records-delete.ts
@@ -75,7 +75,7 @@ export class RecordsDeleteHandler implements MethodHandler {
     }
 
     // delete all existing messages that are not newest, except for the initial write
-    await deleteAllOlderMessagesButKeepInitialWrite(tenant, existingMessages, newestMessage, this.messageStore);
+    await deleteAllOlderMessagesButKeepInitialWrite(tenant, existingMessages, newestMessage, this.messageStore, this.dataStore);
 
     return messageReply;
   };

--- a/src/interfaces/records/handlers/records-read.ts
+++ b/src/interfaces/records/handlers/records-read.ts
@@ -1,13 +1,13 @@
 import type { MethodHandler } from '../../types.js';
+import type { TimestampedMessage } from '../../../core/types.js';
+import type { DataStore, DidResolver, MessageStore } from '../../../index.js';
 import type { RecordsReadMessage, RecordsWriteMessage } from '../types.js';
 
 import { authenticate } from '../../../core/auth.js';
+import { Message } from '../../../core/message.js';
 import { MessageReply } from '../../../core/message-reply.js';
 import { RecordsRead } from '../messages/records-read.js';
 import { RecordsWrite } from '../messages/records-write.js';
-import { TimestampedMessage } from '../../../core/types.js';
-
-import { DataStore, DidResolver, MessageStore } from '../../../index.js';
 import { DwnInterfaceName, DwnMethodName } from '../../../core/message.js';
 
 export class RecordsReadHandler implements MethodHandler {
@@ -71,7 +71,8 @@ export class RecordsReadHandler implements MethodHandler {
       }
     }
 
-    const readableStream = await this.dataStore.get(tenant, newestRecordsWrite.recordId, newestRecordsWrite.descriptor.dataCid);
+    const messageCid = await Message.getCid(newestRecordsWrite);
+    const readableStream = await this.dataStore.get(tenant, messageCid, newestRecordsWrite.descriptor.dataCid);
 
     if (readableStream === undefined) {
       return new MessageReply({

--- a/src/interfaces/records/handlers/records-write.ts
+++ b/src/interfaces/records/handlers/records-write.ts
@@ -106,7 +106,7 @@ export class RecordsWriteHandler implements MethodHandler {
     }
 
     // delete all existing messages that are not newest, except for the initial write
-    await deleteAllOlderMessagesButKeepInitialWrite(tenant, existingMessages, newestMessage, this.messageStore);
+    await deleteAllOlderMessagesButKeepInitialWrite(tenant, existingMessages, newestMessage, this.messageStore, this.dataStore);
 
     return messageReply;
   };

--- a/src/store/blockstore-level.ts
+++ b/src/store/blockstore-level.ts
@@ -40,20 +40,24 @@ export class BlockstoreLevel implements Blockstore {
     return new BlockstoreLevel({ ...this.config, location: '' }, db);
   }
 
-  async put(key: CID, val: Uint8Array, options?: Options): Promise<void> {
-    return this.db.put(key.toString(), val, options);
+  async put(key: CID | string, val: Uint8Array, options?: Options): Promise<void> {
+    return this.db.put(String(key), val, options);
   }
 
-  async get(key: CID, options?: Options): Promise<Uint8Array> {
-    return this.db.get(key.toString(), options);
+  async get(key: CID | string, options?: Options): Promise<Uint8Array> {
+    return this.db.get(String(key), options);
   }
 
-  async has(key: CID, options?: Options): Promise<boolean> {
-    return !! await this.get(key, options);
+  async has(key: CID | string, options?: Options): Promise<boolean> {
+    return this.db.has(String(key), options);
   }
 
-  async delete(key: CID, options?: Options): Promise<void> {
-    return this.db.delete(key.toString(), options);
+  async delete(key: CID | string, options?: Options): Promise<void> {
+    return this.db.delete(String(key), options);
+  }
+
+  async isEmpty(options?: Options): Promise<boolean> {
+    return this.db.isEmpty(options);
   }
 
   async * putMany(source: AwaitIterable<Pair<CID, Uint8Array>>, options?: Options):

--- a/src/store/data-store.ts
+++ b/src/store/data-store.ts
@@ -16,28 +16,30 @@ export interface DataStore {
 
   /**
    * Puts the given data in store.
-   * @param logicalId This may be the ID of a record, or the ID of a protocol definition etc.
+   * @param messageCid This may be the ID of a record, or the ID of a protocol definition etc.
    * @returns The CID and size in number of bytes of the data stored.
    */
-  put(tenant: string, logicalId: string, dataStream: Readable): Promise<PutResult>;
+  put(tenant: string, messageCid: string, dataStream: Readable): Promise<PutResult>;
 
   /**
    * Fetches the specified data.
-   * @param logicalId This may be the ID of a record, or the ID of a protocol definition etc.
+   * @param messageCid This may be the ID of a record, or the ID of a protocol definition etc.
    */
-  get(tenant: string, logicalId: string, dataCid: string): Promise<Readable | undefined>;
+  get(tenant: string, messageCid: string, dataCid: string): Promise<Readable | undefined>;
 
   /**
-   * Checks to see if the store has the specified data.
-   * @param logicalId This may be the ID of a record, or the ID of a protocol definition etc.
+   * Associates existing data.
+   * @param messageCid This may be the ID of a record, or the ID of a protocol definition etc.
+   * @param The CID of the data stored.
+   * @returns Whether data for the given CID was found in the store.
    */
-  has(tenant: string, logicalId: string, dataCid: string): Promise<boolean>;
+  associate(tenant: string, messageCid: string, dataCid: string): Promise<boolean>;
 
   /**
    * Deletes the specified data;
-   * @param logicalId This may be the ID of a record, or the ID of a protocol definition etc.
+   * @param messageCid This may be the ID of a record, or the ID of a protocol definition etc.
    */
-  delete(tenant: string, logicalId: string, dataCid: string): Promise<void>;
+  delete(tenant: string, messageCid: string, dataCid: string): Promise<void>;
 }
 
 /**

--- a/src/store/level-wrapper.ts
+++ b/src/store/level-wrapper.ts
@@ -105,6 +105,10 @@ export class LevelWrapper<V> {
     }
   }
 
+  async has(key: string, options?: LevelWrapperOptions): Promise<boolean> {
+    return !! await this.get(key, options);
+  }
+
   async * keys(options?: LevelWrapperOptions): AsyncGenerator<string> {
     options?.signal?.throwIfAborted();
 
@@ -143,6 +147,13 @@ export class LevelWrapper<V> {
     await abortOr(options?.signal, this.createLevelDatabase());
 
     return abortOr(options?.signal, this.db.del(String(key)));
+  }
+
+  async isEmpty(options?: LevelWrapperOptions): Promise<boolean> {
+    for await (const _key of this.keys(options)) {
+      return false;
+    }
+    return true;
   }
 
   async clear(): Promise<void> {

--- a/src/store/message-store-level.ts
+++ b/src/store/message-store-level.ts
@@ -96,12 +96,9 @@ export class MessageStoreLevel implements MessageStore {
 
     const partition = await abortOr(options?.signal, this.blockstore.partition(tenant));
 
-    // TODO: Implement data deletion in Records - https://github.com/TBD54566975/dwn-sdk-js/issues/84
     const cid = CID.parse(cidString);
     await partition.delete(cid, options);
     await this.index.delete(cidString, options);
-
-    return;
   }
 
   async put(

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,7 @@
+export async function fromAsync<T>(iterator: AsyncGenerator<T>): Promise<Array<T>> {
+  const array = [ ];
+  for await (const value of iterator) {
+    array.push(value);
+  }
+  return array;
+}

--- a/tests/interfaces/records/handlers/records-delete.spec.ts
+++ b/tests/interfaces/records/handlers/records-delete.spec.ts
@@ -2,13 +2,15 @@ import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
 
+import { Cid } from '../../../../src/utils/cid.js';
 import { DataStoreLevel } from '../../../../src/store/data-store-level.js';
 import { DidKeyResolver } from '../../../../src/did/did-key-resolver.js';
+import { DwnErrorCode } from '../../../../src/core/dwn-error.js';
+import { fromAsync } from '../../../../src/utils/array.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
 import { RecordsDeleteHandler } from '../../../../src/interfaces/records/handlers/records-delete.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
-
 import { DidResolver, Dwn, Encoder, Jws, RecordsDelete } from '../../../../src/index.js';
 
 chai.use(chaiAsPromised);
@@ -119,6 +121,377 @@ describe('RecordsDeleteHandler.handle()', () => {
       expect(reply.status.code).to.equal(200);
       expect(reply.entries?.length).to.equal(1);
       expect(reply.entries[0].encodedData).to.equal(expectedEncodedData);
+    });
+
+    it('should only write the data once even if written by multiple messages', async () => {
+      const dataPartition = await dataStore.blockstore.partition('data');
+
+      const data = Encoder.stringToBytes('test');
+      const dataCid = await Cid.computeDagPbCidFromBytes(data);
+      const encodedData = Encoder.bytesToBase64Url(data);
+
+      const alice = await DidKeyResolver.generate();
+
+      const aliceWrite1Data = await TestDataGenerator.generateRecordsWrite({
+        requester: alice,
+        data
+      });
+      const aliceWrite1Reply = await dwn.processMessage(alice.did, aliceWrite1Data.message, aliceWrite1Data.dataStream);
+      expect(aliceWrite1Reply.status.code).to.equal(202);
+
+      const aliceQueryWrite1AfterAliceWrite1Data = await TestDataGenerator.generateRecordsQuery({
+        requester : alice,
+        filter    : { recordId: aliceWrite1Data.message.recordId }
+      });
+      const aliceQueryWrite1AfterAliceWrite1Reply = await dwn.processMessage(alice.did, aliceQueryWrite1AfterAliceWrite1Data.message);
+      expect(aliceQueryWrite1AfterAliceWrite1Reply.status.code).to.equal(200);
+      expect(aliceQueryWrite1AfterAliceWrite1Reply.entries.length).to.equal(1);
+      expect(aliceQueryWrite1AfterAliceWrite1Reply.entries[0].encodedData).to.equal(encodedData);
+
+      await expect(fromAsync(dataPartition.db.keys())).to.eventually.eql([ dataCid ]);
+
+      const aliceWrite2Data = await TestDataGenerator.generateRecordsWrite({
+        requester: alice,
+        data
+      });
+      const aliceWrite2Reply = await dwn.processMessage(alice.did, aliceWrite2Data.message, aliceWrite2Data.dataStream);
+      expect(aliceWrite2Reply.status.code).to.equal(202);
+
+      const aliceQueryWrite1AfterAliceWrite2Data = await TestDataGenerator.generateRecordsQuery({
+        requester : alice,
+        filter    : { recordId: aliceWrite1Data.message.recordId }
+      });
+      const aliceQueryWrite1AfterAliceWrite2Reply = await dwn.processMessage(alice.did, aliceQueryWrite1AfterAliceWrite2Data.message);
+      expect(aliceQueryWrite1AfterAliceWrite2Reply.status.code).to.equal(200);
+      expect(aliceQueryWrite1AfterAliceWrite2Reply.entries.length).to.equal(1);
+      expect(aliceQueryWrite1AfterAliceWrite2Reply.entries[0].encodedData).to.equal(encodedData);
+
+      const aliceQueryWrite2AfterAliceWrite2Data = await TestDataGenerator.generateRecordsQuery({
+        requester : alice,
+        filter    : { recordId: aliceWrite2Data.message.recordId }
+      });
+      const aliceQueryWrite2AfterAliceWrite2Reply = await dwn.processMessage(alice.did, aliceQueryWrite2AfterAliceWrite2Data.message);
+      expect(aliceQueryWrite2AfterAliceWrite2Reply.status.code).to.equal(200);
+      expect(aliceQueryWrite2AfterAliceWrite2Reply.entries.length).to.equal(1);
+      expect(aliceQueryWrite2AfterAliceWrite2Reply.entries[0].encodedData).to.equal(encodedData);
+
+      await expect(fromAsync(dataPartition.db.keys())).to.eventually.eql([ dataCid ]);
+    });
+
+    it('should only write the data once even if referenced by multiple messages', async () => {
+      const dataPartition = await dataStore.blockstore.partition('data');
+
+      const data = Encoder.stringToBytes('test');
+      const dataCid = await Cid.computeDagPbCidFromBytes(data);
+      const encodedData = Encoder.bytesToBase64Url(data);
+
+      const alice = await DidKeyResolver.generate();
+
+      const aliceWriteData = await TestDataGenerator.generateRecordsWrite({
+        requester: alice,
+        data
+      });
+      const aliceWriteReply = await dwn.processMessage(alice.did, aliceWriteData.message, aliceWriteData.dataStream);
+      expect(aliceWriteReply.status.code).to.equal(202);
+
+      const aliceQueryWriteAfterAliceWriteData = await TestDataGenerator.generateRecordsQuery({
+        requester : alice,
+        filter    : { recordId: aliceWriteData.message.recordId }
+      });
+      const aliceQueryWriteAfterAliceWriteReply = await dwn.processMessage(alice.did, aliceQueryWriteAfterAliceWriteData.message);
+      expect(aliceQueryWriteAfterAliceWriteReply.status.code).to.equal(200);
+      expect(aliceQueryWriteAfterAliceWriteReply.entries.length).to.equal(1);
+      expect(aliceQueryWriteAfterAliceWriteReply.entries[0].encodedData).to.equal(encodedData);
+
+      await expect(fromAsync(dataPartition.db.keys())).to.eventually.eql([ dataCid ]);
+
+      const aliceAssociateData = await TestDataGenerator.generateRecordsWrite({
+        requester : alice,
+        dataCid,
+        dataSize  : 4
+      });
+      const aliceAssociateReply = await dwn.processMessage(alice.did, aliceAssociateData.message, aliceAssociateData.dataStream);
+      expect(aliceAssociateReply.status.code).to.equal(202);
+
+      const aliceQueryWriteAfterAliceAssociateData = await TestDataGenerator.generateRecordsQuery({
+        requester : alice,
+        filter    : { recordId: aliceWriteData.message.recordId }
+      });
+      const aliceQueryWriteAfterAliceAssociateReply = await dwn.processMessage(alice.did, aliceQueryWriteAfterAliceAssociateData.message);
+      expect(aliceQueryWriteAfterAliceAssociateReply.status.code).to.equal(200);
+      expect(aliceQueryWriteAfterAliceAssociateReply.entries.length).to.equal(1);
+      expect(aliceQueryWriteAfterAliceAssociateReply.entries[0].encodedData).to.equal(encodedData);
+
+      const aliceQueryAssociateAfterAliceAssociateData = await TestDataGenerator.generateRecordsQuery({
+        requester : alice,
+        filter    : { recordId: aliceAssociateData.message.recordId }
+      });
+      const aliceQueryAssociateAfterAliceAssociateReply = await dwn.processMessage(alice.did, aliceQueryAssociateAfterAliceAssociateData.message);
+      expect(aliceQueryAssociateAfterAliceAssociateReply.status.code).to.equal(200);
+      expect(aliceQueryAssociateAfterAliceAssociateReply.entries.length).to.equal(1);
+      expect(aliceQueryAssociateAfterAliceAssociateReply.entries[0].encodedData).to.equal(encodedData);
+
+      await expect(fromAsync(dataPartition.db.keys())).to.eventually.eql([ dataCid ]);
+    });
+
+    it('should only write the data once even if written by multiple tenants', async () => {
+      const dataPartition = await dataStore.blockstore.partition('data');
+
+      const data = Encoder.stringToBytes('test');
+      const dataCid = await Cid.computeDagPbCidFromBytes(data);
+      const encodedData = Encoder.bytesToBase64Url(data);
+
+      const alice = await DidKeyResolver.generate();
+      const bob = await DidKeyResolver.generate();
+
+      const aliceWriteData = await TestDataGenerator.generateRecordsWrite({
+        requester: alice,
+        data
+      });
+      const aliceWriteReply = await dwn.processMessage(alice.did, aliceWriteData.message, aliceWriteData.dataStream);
+      expect(aliceWriteReply.status.code).to.equal(202);
+
+      const aliceQueryWriteAfterAliceWriteData = await TestDataGenerator.generateRecordsQuery({
+        requester : alice,
+        filter    : { recordId: aliceWriteData.message.recordId }
+      });
+      const aliceQueryWriteAfterAliceWriteReply = await dwn.processMessage(alice.did, aliceQueryWriteAfterAliceWriteData.message);
+      expect(aliceQueryWriteAfterAliceWriteReply.status.code).to.equal(200);
+      expect(aliceQueryWriteAfterAliceWriteReply.entries.length).to.equal(1);
+      expect(aliceQueryWriteAfterAliceWriteReply.entries[0].encodedData).to.equal(encodedData);
+
+      await expect(fromAsync(dataPartition.db.keys())).to.eventually.eql([ dataCid ]);
+
+      const bobWriteData = await TestDataGenerator.generateRecordsWrite({
+        requester: bob,
+        data
+      });
+      const bobWriteReply = await dwn.processMessage(bob.did, bobWriteData.message, bobWriteData.dataStream);
+      expect(bobWriteReply.status.code).to.equal(202);
+
+      const aliceQueryWriteAfterBobWriteData = await TestDataGenerator.generateRecordsQuery({
+        requester : alice,
+        filter    : { recordId: aliceWriteData.message.recordId }
+      });
+      const aliceQueryWriteAfterBobWriteReply = await dwn.processMessage(alice.did, aliceQueryWriteAfterBobWriteData.message);
+      expect(aliceQueryWriteAfterBobWriteReply.status.code).to.equal(200);
+      expect(aliceQueryWriteAfterBobWriteReply.entries.length).to.equal(1);
+      expect(aliceQueryWriteAfterBobWriteReply.entries[0].encodedData).to.equal(encodedData);
+
+      const bobQueryWriteAfterBobWriteData = await TestDataGenerator.generateRecordsQuery({
+        requester : bob,
+        filter    : { recordId: bobWriteData.message.recordId }
+      });
+      const bobQueryWriteAfterBobWriteReply = await dwn.processMessage(bob.did, bobQueryWriteAfterBobWriteData.message);
+      expect(bobQueryWriteAfterBobWriteReply.status.code).to.equal(200);
+      expect(bobQueryWriteAfterBobWriteReply.entries.length).to.equal(1);
+      expect(bobQueryWriteAfterBobWriteReply.entries[0].encodedData).to.equal(encodedData);
+
+      await expect(fromAsync(dataPartition.db.keys())).to.eventually.eql([ dataCid ]);
+    });
+
+    it('should not allow referencing data across tenants', async () => {
+      const dataPartition = await dataStore.blockstore.partition('data');
+
+      const data = Encoder.stringToBytes('test');
+      const dataCid = await Cid.computeDagPbCidFromBytes(data);
+      const encodedData = Encoder.bytesToBase64Url(data);
+
+      const alice = await DidKeyResolver.generate();
+      const bob = await DidKeyResolver.generate();
+
+      const aliceWriteData = await TestDataGenerator.generateRecordsWrite({
+        requester: alice,
+        data
+      });
+      const aliceWriteReply = await dwn.processMessage(alice.did, aliceWriteData.message, aliceWriteData.dataStream);
+      expect(aliceWriteReply.status.code).to.equal(202);
+
+      const aliceQueryWriteAfterAliceWriteData = await TestDataGenerator.generateRecordsQuery({
+        requester : alice,
+        filter    : { recordId: aliceWriteData.message.recordId }
+      });
+      const aliceQueryWriteAfterAliceWriteReply = await dwn.processMessage(alice.did, aliceQueryWriteAfterAliceWriteData.message);
+      expect(aliceQueryWriteAfterAliceWriteReply.status.code).to.equal(200);
+      expect(aliceQueryWriteAfterAliceWriteReply.entries.length).to.equal(1);
+      expect(aliceQueryWriteAfterAliceWriteReply.entries[0].encodedData).to.equal(encodedData);
+
+      await expect(fromAsync(dataPartition.db.keys())).to.eventually.eql([ dataCid ]);
+
+      const bobAssociateData = await TestDataGenerator.generateRecordsWrite({
+        requester : bob,
+        dataCid,
+        dataSize  : 4
+      });
+      const bobAssociateReply = await dwn.processMessage(bob.did, bobAssociateData.message, bobAssociateData.dataStream);
+      expect(bobAssociateReply.status.code).to.equal(400);
+      expect(bobAssociateReply.status.detail).to.contain(DwnErrorCode.MessageStoreDataNotFound);
+
+      const aliceQueryWriteAfterBobAssociateData = await TestDataGenerator.generateRecordsQuery({
+        requester : alice,
+        filter    : { recordId: aliceWriteData.message.recordId }
+      });
+      const aliceQueryWriteAfterBobAssociateReply = await dwn.processMessage(alice.did, aliceQueryWriteAfterBobAssociateData.message);
+      expect(aliceQueryWriteAfterBobAssociateReply.status.code).to.equal(200);
+      expect(aliceQueryWriteAfterBobAssociateReply.entries.length).to.equal(1);
+      expect(aliceQueryWriteAfterBobAssociateReply.entries[0].encodedData).to.equal(encodedData);
+
+      const bobQueryAssociateAfterBobAssociateData = await TestDataGenerator.generateRecordsQuery({
+        requester : bob,
+        filter    : { recordId: bobAssociateData.message.recordId }
+      });
+      const bobQueryAssociateAfterBobAssociateReply = await dwn.processMessage(bob.did, bobQueryAssociateAfterBobAssociateData.message);
+      expect(bobQueryAssociateAfterBobAssociateReply.status.code).to.equal(200);
+      expect(bobQueryAssociateAfterBobAssociateReply.entries.length).to.equal(0);
+
+      await expect(fromAsync(dataPartition.db.keys())).to.eventually.eql([ dataCid ]);
+    });
+
+    it('should be able to rewrite the data', async () => {
+      const dataPartition = await dataStore.blockstore.partition('data');
+
+      const data = Encoder.stringToBytes('test');
+      const dataCid = await Cid.computeDagPbCidFromBytes(data);
+      const encodedData = Encoder.bytesToBase64Url(data);
+
+      const alice = await DidKeyResolver.generate();
+
+      const aliceWriteData = await TestDataGenerator.generateRecordsWrite({
+        requester: alice,
+        data
+      });
+      const aliceWriteReply = await dwn.processMessage(alice.did, aliceWriteData.message, aliceWriteData.dataStream);
+      expect(aliceWriteReply.status.code).to.equal(202);
+
+      const aliceQueryWriteAfterAliceWriteData = await TestDataGenerator.generateRecordsQuery({
+        requester : alice,
+        filter    : { recordId: aliceWriteData.message.recordId }
+      });
+      const aliceQueryWriteAfterAliceWriteReply = await dwn.processMessage(alice.did, aliceQueryWriteAfterAliceWriteData.message);
+      expect(aliceQueryWriteAfterAliceWriteReply.status.code).to.equal(200);
+      expect(aliceQueryWriteAfterAliceWriteReply.entries.length).to.equal(1);
+      expect(aliceQueryWriteAfterAliceWriteReply.entries[0].encodedData).to.equal(encodedData);
+
+      await expect(fromAsync(dataPartition.db.keys())).to.eventually.eql([ dataCid ]);
+
+      const aliceDeleteWriteData = await TestDataGenerator.generateRecordsDelete({
+        requester : alice,
+        recordId  : aliceWriteData.message.recordId
+      });
+      const aliceDeleteWriteReply = await dwn.processMessage(alice.did, aliceDeleteWriteData.message);
+      expect(aliceDeleteWriteReply.status.code).to.equal(202);
+
+      const aliceQueryWriteAfterAliceDeleteData = await TestDataGenerator.generateRecordsQuery({
+        requester : alice,
+        filter    : { recordId: aliceWriteData.message.recordId }
+      });
+      const aliceQueryWriteAfterAliceDeleteReply = await dwn.processMessage(alice.did, aliceQueryWriteAfterAliceDeleteData.message);
+      expect(aliceQueryWriteAfterAliceDeleteReply.status.code).to.equal(200);
+      expect(aliceQueryWriteAfterAliceDeleteReply.entries.length).to.equal(0);
+
+      await expect(fromAsync(dataPartition.db.keys())).to.eventually.eql([ ]);
+
+      const aliceRewriteData = await TestDataGenerator.generateRecordsWrite({
+        requester: alice,
+        data
+      });
+      const aliceRewriteReply = await dwn.processMessage(alice.did, aliceRewriteData.message, aliceRewriteData.dataStream);
+      expect(aliceRewriteReply.status.code).to.equal(202);
+
+      const aliceQueryWriteAfterAliceRewriteData = await TestDataGenerator.generateRecordsQuery({
+        requester : alice,
+        filter    : { recordId: aliceRewriteData.message.recordId }
+      });
+      const aliceQueryWriteAfterAliceRewriteReply = await dwn.processMessage(alice.did, aliceQueryWriteAfterAliceRewriteData.message);
+      expect(aliceQueryWriteAfterAliceRewriteReply.status.code).to.equal(200);
+      expect(aliceQueryWriteAfterAliceRewriteReply.entries.length).to.equal(1);
+      expect(aliceQueryWriteAfterAliceRewriteReply.entries[0].encodedData).to.equal(encodedData);
+
+      await expect(fromAsync(dataPartition.db.keys())).to.eventually.eql([ dataCid ]);
+    });
+
+    it('should only delete data after all messages referencing it are deleted', async () => {
+      const dataPartition = await dataStore.blockstore.partition('data');
+
+      const data = Encoder.stringToBytes('test');
+      const dataCid = await Cid.computeDagPbCidFromBytes(data);
+
+      const alice = await DidKeyResolver.generate();
+      const bob = await DidKeyResolver.generate();
+
+      const aliceWriteData = await TestDataGenerator.generateRecordsWrite({
+        requester: alice,
+        data
+      });
+      const aliceWriteReply = await dwn.processMessage(alice.did, aliceWriteData.message, aliceWriteData.dataStream);
+      expect(aliceWriteReply.status.code).to.equal(202);
+
+      await expect(fromAsync(dataPartition.db.keys())).to.eventually.eql([ dataCid ]);
+
+      const aliceAssociateData = await TestDataGenerator.generateRecordsWrite({
+        requester : alice,
+        dataCid,
+        dataSize  : 4
+      });
+      const aliceAssociateReply = await dwn.processMessage(alice.did, aliceAssociateData.message, aliceAssociateData.dataStream);
+      expect(aliceAssociateReply.status.code).to.equal(202);
+
+      await expect(fromAsync(dataPartition.db.keys())).to.eventually.eql([ dataCid ]);
+
+      const bobWriteData = await TestDataGenerator.generateRecordsWrite({
+        requester: bob,
+        data
+      });
+      const bobWriteReply = await dwn.processMessage(bob.did, bobWriteData.message, bobWriteData.dataStream);
+      expect(bobWriteReply.status.code).to.equal(202);
+
+      await expect(fromAsync(dataPartition.db.keys())).to.eventually.eql([ dataCid ]);
+
+      const bobAssociateData = await TestDataGenerator.generateRecordsWrite({
+        requester : bob,
+        dataCid,
+        dataSize  : 4
+      });
+      const bobAssociateReply = await dwn.processMessage(bob.did, bobAssociateData.message, bobAssociateData.dataStream);
+      expect(bobAssociateReply.status.code).to.equal(202);
+
+      await expect(fromAsync(dataPartition.db.keys())).to.eventually.eql([ dataCid ]);
+
+      const aliceDeleteWriteData = await TestDataGenerator.generateRecordsDelete({
+        requester : alice,
+        recordId  : aliceWriteData.message.recordId
+      });
+      const aliceDeleteWriteReply = await dwn.processMessage(alice.did, aliceDeleteWriteData.message);
+      expect(aliceDeleteWriteReply.status.code).to.equal(202);
+
+      await expect(fromAsync(dataPartition.db.keys())).to.eventually.eql([ dataCid ]);
+
+      const bobDeleteWriteData = await TestDataGenerator.generateRecordsDelete({
+        requester : bob,
+        recordId  : bobWriteData.message.recordId
+      });
+      const bobDeleteWriteReply = await dwn.processMessage(bob.did, bobDeleteWriteData.message);
+      expect(bobDeleteWriteReply.status.code).to.equal(202);
+
+      await expect(fromAsync(dataPartition.db.keys())).to.eventually.eql([ dataCid ]);
+
+      const aliceDeleteAssociateData = await TestDataGenerator.generateRecordsDelete({
+        requester : alice,
+        recordId  : aliceAssociateData.message.recordId
+      });
+      const aliceDeleteAssociateReply = await dwn.processMessage(alice.did, aliceDeleteAssociateData.message);
+      expect(aliceDeleteAssociateReply.status.code).to.equal(202);
+
+      await expect(fromAsync(dataPartition.db.keys())).to.eventually.eql([ dataCid ]);
+
+      const bobDeleteAssociateData = await TestDataGenerator.generateRecordsDelete({
+        requester : bob,
+        recordId  : bobAssociateData.message.recordId
+      });
+      const bobDeleteAssociateReply = await dwn.processMessage(bob.did, bobDeleteAssociateData.message);
+      expect(bobDeleteAssociateReply.status.code).to.equal(202);
+
+      await expect(fromAsync(dataPartition.db.keys())).to.eventually.eql([ ]);
     });
   });
 

--- a/tests/store/index-level.spec.ts
+++ b/tests/store/index-level.spec.ts
@@ -1,4 +1,5 @@
 import chaiAsPromised from 'chai-as-promised';
+import { fromAsync } from '../../src/utils/array.js';
 import { IndexLevel } from '../../src/store/index-level.js';
 import { Temporal } from '@js-temporal/polyfill';
 import { v4 as uuid } from 'uuid';
@@ -30,10 +31,7 @@ describe('Index Level', () => {
         'c'         : 'd'
       });
 
-      const keys = [ ];
-      for await (const key of index.db.keys()) {
-        keys.push(key);
-      }
+      const keys = await fromAsync(index.db.keys());
       expect(keys.length).to.equal(4);
     });
 


### PR DESCRIPTION
this is done by reworking how data is stored inside `DataStoreLevel`

it has the following structure (`+` represents a sublevel and `->` represents a key->value pair):
```
'data' + <dataCid> -> <data>
'host' + <dataCid> + <tenant> + <messageCid> -> PLACEHOLDER_VALUE
```
this allows for the `<data>` to be shared for everything that uses the same `<dataCid>` while also making sure that the `<data>` can only be deleted if there are no `<messageCid>` for any `<tenant>` still using it

note we are currently doing this using `sublevel`, but that has the restriction of only allowing keys to contain characters after `34` and before `127`, meaning that if `<dataCid>`/`<tenant>`/`<messageCid>` ever allow for characters outside that range we will need to adjust

also switch from `logicalId`/`recordId` to `messageCid` as the former can be reused by multiple things (e.g. two different `RecordsWrite` having the same `recordId`) whereas the latter is derived from the entire message