### PR TITLE
#223 - used import type for type imports and added lint rule enforce it

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -47,6 +47,8 @@ module.exports = {
     'keyword-spacing'                                  : ['error', { 'before': true, 'after': true }],
     '@typescript-eslint/explicit-function-return-type' : ['error'],
     'no-unused-vars'                                   : 'off',
+    // enforce `import type` when an import is not used at runtime, allowing transpilers/bundlers to drop imports as an optimization
+    '@typescript-eslint/consistent-type-imports'       : 'error',
     '@typescript-eslint/no-unused-vars'                : [
       'error',
       {
@@ -57,6 +59,7 @@ module.exports = {
         'varsIgnorePattern'  : '^_'
       }
     ],
+
     'prefer-const' : ['error', { 'destructuring': 'all' }],
     'sort-imports' : ['error', {
       'ignoreCase'            : true,
@@ -65,6 +68,7 @@ module.exports = {
       'memberSyntaxSortOrder' : ['none', 'all', 'single', 'multiple'],
       'allowSeparatedGroups'  : true
     }],
-    'todo-plz/ticket-ref': ['error', { 'commentPattern': '.*github\.com\/TBD54566975\/dwn-sdk-js\/issues\/.*' }]
+    // enforce github issue reference for every TO-DO comment
+    'todo-plz/ticket-ref': ['error', { 'commentPattern': '.*github\.com\/TBD54566975\/dwn-sdk-js\/issues\/.*' }],
   }
 };

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ We plan on including a Docker container to support all local development soon.
 
 ### Running benchmarks
 
-Benchmarks should be run direclty using `node` (e.g. `node benchmarks/store/index/search-index.js`).
+Benchmarks should be run directly using `node` (e.g. `node benchmarks/store/index/search-index.js`).
 
 Note that some benchmarks require that `npm run build` has been run beforehand.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-95.12%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.03%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-94.09%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-95.12%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-95.12%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.04%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-94.09%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-95.12%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-95.12%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.04%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-94.09%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-95.12%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-95.12%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.03%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-94.09%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-95.12%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -1,10 +1,11 @@
 import type { BaseMessage } from './types.js';
-import { CID } from 'multiformats';
-import { DidResolver } from '../did/did-resolver.js';
+import type { CID } from 'multiformats';
+import type { DidResolver } from '../did/did-resolver.js';
 import type { GeneralJws } from '../jose/jws/general/types.js';
+import type { Message } from './message.js';
+
 import { GeneralJwsVerifier } from '../jose/jws/general/verifier.js';
 import { Jws } from '../utils/jws.js';
-import { Message } from './message.js';
 import { computeCid, parseCid } from '../utils/cid.js';
 
 type AuthorizationPayloadConstraints = {

--- a/src/core/message-reply.ts
+++ b/src/core/message-reply.ts
@@ -1,6 +1,5 @@
 import type { QueryResultEntry } from './types.js';
-
-import { Readable } from 'readable-stream';
+import type { Readable } from 'readable-stream';
 
 type Status = {
   code: number

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -1,9 +1,9 @@
-import { MessageStore } from '../store/message-store.js';
-import { RecordsWrite } from '../interfaces/records/messages/records-write.js';
+import type { MessageStore } from '../store/message-store.js';
+import type { RecordsWrite } from '../interfaces/records/messages/records-write.js';
 import type { RecordsWriteMessage } from '../interfaces/records/types.js';
+import type { ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureMessage } from '../interfaces/protocols/types.js';
 
 import { DwnInterfaceName, DwnMethodName, Message } from './message.js';
-import type { ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureMessage } from '../interfaces/protocols/types.js';
 
 const methodToAllowedActionMap = {
   [DwnMethodName.Write]: 'write',

--- a/src/did/did-ion-resolver.ts
+++ b/src/did/did-ion-resolver.ts
@@ -1,5 +1,5 @@
 import crossFetch from 'cross-fetch';
-import { DidMethodResolver } from './did-resolver.js';
+import type { DidMethodResolver } from './did-resolver.js';
 import type { DidResolutionResult } from './did-resolver.js';
 
 // supports fetch in: node, browsers, and browser extensions.

--- a/src/did/did-ion-resolver.ts
+++ b/src/did/did-ion-resolver.ts
@@ -1,7 +1,6 @@
-import crossFetch from 'cross-fetch';
-import type { DidMethodResolver } from './did-resolver.js';
-import type { DidResolutionResult } from './did-resolver.js';
+import type { DidMethodResolver, DidResolutionResult } from './did-resolver.js';
 
+import crossFetch from 'cross-fetch';
 // supports fetch in: node, browsers, and browser extensions.
 // uses native fetch if available in environment or falls back to a ponyfill.
 // 'cross-fetch' is a ponyfill that uses `XMLHTTPRequest` under the hood.

--- a/src/interfaces/hooks/types.ts
+++ b/src/interfaces/hooks/types.ts
@@ -1,5 +1,5 @@
 import type { BaseMessage } from '../../core/types.js';
-import { DwnInterfaceName, DwnMethodName } from '../../core/message.js';
+import type { DwnInterfaceName, DwnMethodName } from '../../core/message.js';
 
 /**
  * Descriptor structure for HooksWrite

--- a/src/interfaces/permissions/handlers/permissions-request.ts
+++ b/src/interfaces/permissions/handlers/permissions-request.ts
@@ -1,10 +1,10 @@
 import type { MethodHandler } from '../../types.js';
 import type { PermissionsRequestMessage } from '../types.js';
+import type { DataStore, DidResolver, MessageStore } from '../../../index.js';
 
 import { canonicalAuth } from '../../../core/auth.js';
 import { MessageReply } from '../../../core/message-reply.js';
 import { PermissionsRequest } from '../messages/permissions-request.js';
-import { DataStore, DidResolver, MessageStore } from '../../../index.js';
 
 export class PermissionsRequestHandler implements MethodHandler {
 

--- a/src/interfaces/permissions/messages/permissions-grant.ts
+++ b/src/interfaces/permissions/messages/permissions-grant.ts
@@ -1,3 +1,4 @@
+import type { PermissionsRequest } from './permissions-request';
 import type { SignatureInput } from '../../../jose/jws/general/types';
 import type { PermissionConditions, PermissionScope } from '../types';
 import type { PermissionsGrantDescriptor, PermissionsGrantMessage } from '../types';
@@ -6,7 +7,7 @@ import { computeCid } from '../../../utils/cid';
 import { getCurrentTimeInHighPrecision } from '../../../utils/time';
 import { v4 as uuidv4 } from 'uuid';
 
-import { DEFAULT_CONDITIONS, PermissionsRequest } from './permissions-request';
+import { DEFAULT_CONDITIONS } from './permissions-request';
 import { DwnInterfaceName, DwnMethodName, Message } from '../../../core/message';
 
 type PermissionsGrantOptions = {

--- a/src/interfaces/permissions/types.ts
+++ b/src/interfaces/permissions/types.ts
@@ -1,5 +1,5 @@
 import type { BaseMessage } from '../../core/types.js';
-import { DwnInterfaceName, DwnMethodName } from '../../index.js';
+import type { DwnInterfaceName, DwnMethodName } from '../../index.js';
 
 export type PermissionScope = {
   method: string

--- a/src/interfaces/protocols/handlers/protocols-configure.ts
+++ b/src/interfaces/protocols/handlers/protocols-configure.ts
@@ -1,12 +1,12 @@
 import type { MethodHandler } from '../../types.js';
 import type { ProtocolsConfigureMessage } from '../types.js';
+import type { DataStore, DidResolver, MessageStore } from '../../../index.js';
 
 import { canonicalAuth } from '../../../core/auth.js';
 import { MessageReply } from '../../../core/message-reply.js';
 import { ProtocolsConfigure } from '../messages/protocols-configure.js';
 import { StorageController } from '../../../store/storage-controller.js';
 
-import { DataStore, DidResolver, MessageStore } from '../../../index.js';
 import { DwnInterfaceName, DwnMethodName, Message } from '../../../core/message.js';
 
 export class ProtocolsConfigureHandler implements MethodHandler {

--- a/src/interfaces/protocols/handlers/protocols-query.ts
+++ b/src/interfaces/protocols/handlers/protocols-query.ts
@@ -1,13 +1,13 @@
 import type { MethodHandler } from '../../types.js';
 import type { ProtocolsQueryMessage } from '../types.js';
 import type { QueryResultEntry } from '../../../core/types.js';
+import type { DataStore, DidResolver, MessageStore } from '../../../index.js';
 
 import { canonicalAuth } from '../../../core/auth.js';
 import { MessageReply } from '../../../core/message-reply.js';
 import { ProtocolsQuery } from '../messages/protocols-query.js';
 import { removeUndefinedProperties } from '../../../utils/object.js';
 
-import { DataStore, DidResolver, MessageStore } from '../../../index.js';
 import { DwnInterfaceName, DwnMethodName } from '../../../core/message.js';
 
 export class ProtocolsQueryHandler implements MethodHandler {

--- a/src/interfaces/protocols/types.ts
+++ b/src/interfaces/protocols/types.ts
@@ -1,5 +1,5 @@
 import type { BaseMessage } from '../../core/types.js';
-import { DwnInterfaceName, DwnMethodName } from '../../core/message.js';
+import type { DwnInterfaceName, DwnMethodName } from '../../core/message.js';
 
 export type ProtocolsConfigureDescriptor = {
   interface : DwnInterfaceName.Protocols;

--- a/src/interfaces/records/handlers/records-delete.ts
+++ b/src/interfaces/records/handlers/records-delete.ts
@@ -1,5 +1,7 @@
 import type { MethodHandler } from '../../types.js';
 import type { RecordsDeleteMessage } from '../types.js';
+import type { TimestampedMessage } from '../../../core/types.js';
+import type { DataStore, DidResolver, MessageStore } from '../../../index.js';
 
 import { authenticate } from '../../../core/auth.js';
 import { deleteAllOlderMessagesButKeepInitialWrite } from '../records-interface.js';
@@ -7,8 +9,6 @@ import { DwnInterfaceName } from '../../../core/message.js';
 import { MessageReply } from '../../../core/message-reply.js';
 import { RecordsDelete } from '../messages/records-delete.js';
 import { RecordsWrite } from '../messages/records-write.js';
-import type { TimestampedMessage } from '../../../core/types.js';
-import { DataStore, DidResolver, MessageStore } from '../../../index.js';
 
 export class RecordsDeleteHandler implements MethodHandler {
 

--- a/src/interfaces/records/handlers/records-query.ts
+++ b/src/interfaces/records/handlers/records-query.ts
@@ -1,5 +1,6 @@
 import type { MethodHandler } from '../../types.js';
 import type { BaseMessage, QueryResultEntry } from '../../../core/types.js';
+import type { DataStore, DidResolver, MessageStore } from '../../../index.js';
 import type { RecordsQueryMessage, RecordsWriteMessage } from '../types.js';
 
 import { authenticate } from '../../../core/auth.js';
@@ -7,7 +8,6 @@ import { lexicographicalCompare } from '../../../utils/string.js';
 import { MessageReply } from '../../../core/message-reply.js';
 import { StorageController } from '../../../store/storage-controller.js';
 
-import { DataStore, DidResolver, MessageStore } from '../../../index.js';
 import { DateSort, RecordsQuery } from '../messages/records-query.js';
 import { DwnInterfaceName, DwnMethodName } from '../../../core/message.js';
 

--- a/src/interfaces/records/handlers/records-write.ts
+++ b/src/interfaces/records/handlers/records-write.ts
@@ -1,5 +1,7 @@
 import type { MethodHandler } from '../../types.js';
 import type { RecordsWriteMessage } from '../types.js';
+import type { TimestampedMessage } from '../../../core/types.js';
+import type { DataStore, DidResolver, MessageStore } from '../../../index.js';
 
 import { authenticate } from '../../../core/auth.js';
 import { deleteAllOlderMessagesButKeepInitialWrite } from '../records-interface.js';
@@ -7,10 +9,7 @@ import { DwnErrorCode } from '../../../core/dwn-error.js';
 import { DwnInterfaceName } from '../../../core/message.js';
 import { MessageReply } from '../../../core/message-reply.js';
 import { RecordsWrite } from '../messages/records-write.js';
-import type { TimestampedMessage } from '../../../core/types.js';
-
 import { StorageController } from '../../../store/storage-controller.js';
-import { DataStore, DidResolver, MessageStore } from '../../../index.js';
 
 export class RecordsWriteHandler implements MethodHandler {
 

--- a/src/interfaces/records/messages/records-read.ts
+++ b/src/interfaces/records/messages/records-read.ts
@@ -1,10 +1,9 @@
+import type { BaseMessage } from '../../../core/types.js';
+import type { SignatureInput } from '../../../jose/jws/general/types.js';
 import type { RecordsReadDescriptor, RecordsReadMessage } from '../types.js';
 
-import { BaseMessage } from '../../../core/types.js';
 import { getCurrentTimeInHighPrecision } from '../../../utils/time.js';
 import { Message } from '../../../core/message.js';
-import { SignatureInput } from '../../../jose/jws/general/types.js';
-
 import { validateAuthorizationIntegrity } from '../../../core/auth.js';
 import { DwnInterfaceName, DwnMethodName } from '../../../core/message.js';
 

--- a/src/interfaces/records/messages/records-write.ts
+++ b/src/interfaces/records/messages/records-write.ts
@@ -1,4 +1,6 @@
 import type { BaseMessage } from '../../../core/types.js';
+import type { MessageStore } from '../../../store/message-store.js';
+import type { GeneralJws, SignatureInput } from '../../../jose/jws/general/types.js';
 import type { RecordsWriteAttestationPayload, RecordsWriteAuthorizationPayload, RecordsWriteDescriptor, RecordsWriteMessage, UnsignedRecordsWriteMessage } from '../types.js';
 
 import { Encoder } from '../../../utils/encoder.js';
@@ -6,14 +8,12 @@ import { GeneralJwsSigner } from '../../../jose/jws/general/signer.js';
 import { getCurrentTimeInHighPrecision } from '../../../utils/time.js';
 import { Jws } from '../../../utils/jws.js';
 import { Message } from '../../../core/message.js';
-import { MessageStore } from '../../../store/message-store.js';
 import { ProtocolAuthorization } from '../../../core/protocol-authorization.js';
 import { removeUndefinedProperties } from '../../../utils/object.js';
 
 import { authorize, validateAuthorizationIntegrity } from '../../../core/auth.js';
 import { Cid, computeCid } from '../../../utils/cid.js';
 import { DwnInterfaceName, DwnMethodName } from '../../../core/message.js';
-import type { GeneralJws, SignatureInput } from '../../../jose/jws/general/types.js';
 
 export type RecordsWriteOptions = {
   recipient?: string;

--- a/src/interfaces/records/types.ts
+++ b/src/interfaces/records/types.ts
@@ -1,7 +1,7 @@
 import type { BaseMessage } from '../../core/types.js';
-import { DateSort } from './messages/records-query.js';
+import type { DateSort } from './messages/records-query.js';
 import type { GeneralJws } from '../../jose/jws/general/types.js';
-import { DwnInterfaceName, DwnMethodName } from '../../core/message.js';
+import type { DwnInterfaceName, DwnMethodName } from '../../core/message.js';
 
 export type RecordsWriteDescriptor = {
   interface: DwnInterfaceName.Records;

--- a/src/jose/jws/general/verifier.ts
+++ b/src/jose/jws/general/verifier.ts
@@ -1,8 +1,7 @@
 import type { Cache } from '../../../utils/types.js';
-import type { DidResolver } from '../../../did/did-resolver.js';
 import type { GeneralJws } from './types.js';
 import type { PublicJwk } from '../../types.js';
-import type { VerificationMethod } from '../../../did/did-resolver.js';
+import type { DidResolver, VerificationMethod } from '../../../did/did-resolver.js';
 
 import { Jws } from '../../../utils/jws.js';
 import { MemoryCache } from '../../../utils/memory-cache.js';

--- a/src/jose/jws/general/verifier.ts
+++ b/src/jose/jws/general/verifier.ts
@@ -1,9 +1,9 @@
 import type { Cache } from '../../../utils/types.js';
+import type { DidResolver } from '../../../did/did-resolver.js';
 import type { GeneralJws } from './types.js';
 import type { PublicJwk } from '../../types.js';
 import type { VerificationMethod } from '../../../did/did-resolver.js';
 
-import { DidResolver } from '../../../did/did-resolver.js';
 import { Jws } from '../../../utils/jws.js';
 import { MemoryCache } from '../../../utils/memory-cache.js';
 import { validateJsonSchema } from '../../../schema-validator.js';

--- a/src/store/blockstore-level.ts
+++ b/src/store/blockstore-level.ts
@@ -1,7 +1,7 @@
+import type { CID } from 'multiformats';
 import type { AwaitIterable, Batch, KeyQuery, Pair, Query } from 'interface-store';
 import type { Blockstore, Options } from 'interface-blockstore';
 
-import { CID } from 'multiformats';
 import { createLevelDatabase, LevelWrapper } from './level-wrapper.js';
 
 // `level` works in Node.js 12+ and Electron 5+ on Linux, Mac OS, Windows and

--- a/src/store/data-store-level.ts
+++ b/src/store/data-store-level.ts
@@ -1,6 +1,5 @@
-import type { DataStore } from './data-store.js';
 import type { ImportResult } from 'ipfs-unixfs-importer';
-import type { PutResult } from './data-store.js';
+import type { DataStore, PutResult } from './data-store.js';
 
 import { BlockstoreLevel } from './blockstore-level.js';
 import { createLevelDatabase } from './level-wrapper.js';

--- a/src/store/data-store-level.ts
+++ b/src/store/data-store-level.ts
@@ -1,9 +1,9 @@
+import type { DataStore } from './data-store.js';
 import type { ImportResult } from 'ipfs-unixfs-importer';
 import type { PutResult } from './data-store.js';
 
 import { BlockstoreLevel } from './blockstore-level.js';
 import { createLevelDatabase } from './level-wrapper.js';
-import { DataStore } from './data-store.js';
 import { exporter } from 'ipfs-unixfs-exporter';
 import { importer } from 'ipfs-unixfs-importer';
 import { Readable } from 'readable-stream';

--- a/tests/core/protocol-authorization.spec.ts
+++ b/tests/core/protocol-authorization.spec.ts
@@ -1,6 +1,7 @@
+import type { ProtocolRuleSet } from '../../src/index.js';
+
 import { expect } from 'chai';
 import { ProtocolAuthorization } from '../../src/core/protocol-authorization.js';
-import { ProtocolRuleSet } from '../../src/index.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 
 describe('Protocol-Based Authorization', async () => {

--- a/tests/dwn.spec.ts
+++ b/tests/dwn.spec.ts
@@ -1,3 +1,5 @@
+import type { TenantGate } from '../src/index.js';
+
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
@@ -7,7 +9,6 @@ import { DidKeyResolver } from '../src/did/did-key-resolver.js';
 import { Dwn } from '../src/dwn.js';
 import { Message } from '../src/core/message.js';
 import { MessageStoreLevel } from '../src/store/message-store-level.js';
-import { TenantGate } from '../src/index.js';
 import { TestDataGenerator } from './utils/test-data-generator.js';
 
 chai.use(chaiAsPromised);

--- a/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
@@ -1,3 +1,5 @@
+import type { GenerateProtocolsConfigureOutput } from '../../../utils/test-data-generator.js';
+
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
@@ -8,8 +10,8 @@ import { GeneralJwsSigner } from '../../../../src/jose/jws/general/signer.js';
 import { lexicographicalCompare } from '../../../../src/utils/string.js';
 import { Message } from '../../../../src/core/message.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
+import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
-import { GenerateProtocolsConfigureOutput, TestDataGenerator } from '../../../utils/test-data-generator.js';
 
 import { DidResolver, Dwn, Encoder, Jws } from '../../../../src/index.js';
 

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -1,3 +1,5 @@
+import type { RecordsWriteMessage } from '../../../../src/index.js';
+
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
@@ -16,7 +18,7 @@ import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
 
 import { constructRecordsWriteIndexes } from '../../../../src/interfaces/records/handlers/records-write.js';
 import { DateSort, RecordsQuery } from '../../../../src/interfaces/records/messages/records-query.js';
-import { DidResolver, Dwn, RecordsWriteMessage } from '../../../../src/index.js';
+import { DidResolver, Dwn } from '../../../../src/index.js';
 
 chai.use(chaiAsPromised);
 

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -4,6 +4,11 @@ import dexProtocolDefinition from '../../../vectors/protocol-definitions/dex.jso
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
 
+import type { GenerateFromRecordsWriteOut } from '../../../utils/test-data-generator.js';
+import type { ProtocolDefinition } from '../../../../src/index.js';
+import type { QueryResultEntry } from '../../../../src/core/types.js';
+import type { RecordsWriteMessage } from '../../../../src/interfaces/records/types.js';
+
 import { base64url } from 'multiformats/bases/base64';
 import { DataStoreLevel } from '../../../../src/store/data-store-level.js';
 import { DataStream } from '../../../../src/utils/data-stream.js';
@@ -16,14 +21,13 @@ import { GeneralJwsSigner } from '../../../../src/jose/jws/general/signer.js';
 import { getCurrentTimeInHighPrecision } from '../../../../src/utils/time.js';
 import { Message } from '../../../../src/core/message.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
-import { QueryResultEntry } from '../../../../src/core/types.js';
 import { RecordsWriteHandler } from '../../../../src/interfaces/records/handlers/records-write.js';
-import { RecordsWriteMessage } from '../../../../src/interfaces/records/types.js';
 import { StorageController } from '../../../../src/store/storage-controller.js';
+import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
+
 import { Cid, computeCid } from '../../../../src/utils/cid.js';
-import { Dwn, Jws, ProtocolDefinition, RecordsWrite } from '../../../../src/index.js';
-import { GenerateFromRecordsWriteOut, TestDataGenerator } from '../../../utils/test-data-generator.js';
+import { Dwn, Jws, RecordsWrite } from '../../../../src/index.js';
 
 chai.use(chaiAsPromised);
 

--- a/tests/interfaces/records/messages/records-write.spec.ts
+++ b/tests/interfaces/records/messages/records-write.spec.ts
@@ -1,3 +1,5 @@
+import type { RecordsWriteMessage } from '../../../../src/interfaces/records/types.js';
+
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
@@ -5,7 +7,6 @@ import chai, { expect } from 'chai';
 import { Jws } from '../../../../src/index.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
 import { RecordsWrite } from '../../../../src/interfaces/records/messages/records-write.js';
-import { RecordsWriteMessage } from '../../../../src/interfaces/records/types.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { getCurrentTimeInHighPrecision, sleep } from '../../../../src/utils/time.js';
 

--- a/tests/store/message-store.spec.ts
+++ b/tests/store/message-store.spec.ts
@@ -1,11 +1,13 @@
+import type { RecordsWriteMessage } from '../../src/interfaces/records/types.js';
+import type { CreateLevelDatabaseOptions, LevelDatabase } from '../../src/store/level-wrapper.js';
+
 import { computeCid } from '../../src/utils/cid.js';
+import { createLevelDatabase } from '../../src/store/level-wrapper.js';
 import { DidKeyResolver } from '../../src/index.js';
 import { expect } from 'chai';
 import { Message } from '../../src/core/message.js';
 import { MessageStoreLevel } from '../../src/store/message-store-level.js';
-import { RecordsWriteMessage } from '../../src/interfaces/records/types.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
-import { createLevelDatabase, CreateLevelDatabaseOptions, LevelDatabase } from '../../src/store/level-wrapper.js';
 
 let messageStore: MessageStoreLevel;
 

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -1,41 +1,45 @@
-import * as cbor from '@ipld/dag-cbor';
-import { BaseMessage } from '../../src/core/types.js';
-import { CID } from 'multiformats/cid';
-import { CreateFromOptions } from '../../src/interfaces/records/messages/records-write.js';
-import { DataStream } from '../../src/utils/data-stream.js';
-import { DidResolutionResult } from '../../src/did/did-resolver.js';
-import { ed25519 } from '../../src/jose/algorithms/signing/ed25519.js';
-import { getCurrentTimeInHighPrecision } from '../../src/utils/time.js';
-import { PermissionsRequest } from '../../src/interfaces/permissions/messages/permissions-request.js';
-import { Readable } from 'readable-stream';
-import { RecordsQueryFilter } from '../../src/interfaces/records/types.js';
-import { removeUndefinedProperties } from '../../src/utils/object.js';
-import { secp256k1 } from '../../src/jose/algorithms/signing/secp256k1.js';
-import { sha256 } from 'multiformats/hashes/sha2';
-import {
+import type { BaseMessage } from '../../src/core/types.js';
+import type { CreateFromOptions } from '../../src/interfaces/records/messages/records-write.js';
+import type { DidResolutionResult } from '../../src/did/did-resolver.js';
+import type { Readable } from 'readable-stream';
+import type { RecordsQueryFilter } from '../../src/interfaces/records/types.js';
+import type {
   DateSort,
-  DidKeyResolver,
-  HooksWrite,
   HooksWriteMessage,
   HooksWriteOptions,
-  Jws,
   ProtocolDefinition,
-  ProtocolsConfigure,
   ProtocolsConfigureMessage,
   ProtocolsConfigureOptions,
-  ProtocolsQuery,
   ProtocolsQueryMessage,
   ProtocolsQueryOptions,
-  RecordsDelete,
   RecordsDeleteMessage,
-  RecordsQuery,
   RecordsQueryMessage,
   RecordsQueryOptions,
-  RecordsWrite,
   RecordsWriteMessage,
   RecordsWriteOptions
 } from '../../src/index.js';
-import { PrivateJwk, PublicJwk } from '../../src/jose/types.js';
+import type { PrivateJwk, PublicJwk } from '../../src/jose/types.js';
+
+import * as cbor from '@ipld/dag-cbor';
+import { CID } from 'multiformats/cid';
+import { DataStream } from '../../src/utils/data-stream.js';
+import { ed25519 } from '../../src/jose/algorithms/signing/ed25519.js';
+import { getCurrentTimeInHighPrecision } from '../../src/utils/time.js';
+import { PermissionsRequest } from '../../src/interfaces/permissions/messages/permissions-request.js';
+import { removeUndefinedProperties } from '../../src/utils/object.js';
+import { secp256k1 } from '../../src/jose/algorithms/signing/secp256k1.js';
+import { sha256 } from 'multiformats/hashes/sha2';
+
+import {
+  DidKeyResolver,
+  HooksWrite,
+  Jws,
+  ProtocolsConfigure,
+  ProtocolsQuery,
+  RecordsDelete,
+  RecordsQuery,
+  RecordsWrite
+} from '../../src/index.js';
 
 /**
  * A logical grouping of user data used to generate test messages.

--- a/tests/utils/test-stub-generator.ts
+++ b/tests/utils/test-stub-generator.ts
@@ -1,6 +1,10 @@
+import type { DidResolutionResult } from '../../src/did/did-resolver.js';
+import type { Persona } from './test-data-generator.js';
+
 import sinon from 'sinon';
-import { DidResolutionResult, DidResolver } from '../../src/did/did-resolver.js';
-import { Persona, TestDataGenerator } from './test-data-generator.js';
+
+import { DidResolver } from '../../src/did/did-resolver.js';
+import { TestDataGenerator } from './test-data-generator.js';
 
 /**
  * Utility class for generating stub for testing.


### PR DESCRIPTION
The community contribution #235 for issue #223 was incomplete:

1. there are still lingering type imports not using `import type`
1. no lint rule added

Fixed the above and also grouped `import type` for neatness