### PR TITLE
#84 - deleting a `dataCid` should delete all blocks, not just the root

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-93.95%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.03%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-90.28%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.95%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-93.59%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.3%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-90.28%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.59%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/src/interfaces/records/handlers/records-read.ts
+++ b/src/interfaces/records/handlers/records-read.ts
@@ -72,9 +72,9 @@ export class RecordsReadHandler implements MethodHandler {
     }
 
     const messageCid = await Message.getCid(newestRecordsWrite);
-    const readableStream = await this.dataStore.get(tenant, messageCid, newestRecordsWrite.descriptor.dataCid);
+    const result = await this.dataStore.get(tenant, messageCid, newestRecordsWrite.descriptor.dataCid);
 
-    if (readableStream === undefined) {
+    if (result?.dataStream === undefined) {
       return new MessageReply({
         status: { code: 404, detail: 'Not Found' }
       });
@@ -82,7 +82,7 @@ export class RecordsReadHandler implements MethodHandler {
 
     const messageReply = new MessageReply({
       status : { code: 200, detail: 'OK' },
-      data   : readableStream
+      data   : result.dataStream
     });
     return messageReply;
   };

--- a/src/store/data-store.ts
+++ b/src/store/data-store.ts
@@ -16,25 +16,29 @@ export interface DataStore {
 
   /**
    * Puts the given data in store.
+   * It is expected that the CID of the dataStream matches the given dataCid.
+   * The returned dataCid and returned dataSize will be verified against the given dataCid (and inferred dataSize).
    * @param messageCid CID of the message that references the data.
    * @returns The CID and size in number of bytes of the data stored.
    */
-  put(tenant: string, messageCid: string, dataStream: Readable): Promise<PutResult>;
+  put(tenant: string, messageCid: string, dataCid: string, dataStream: Readable): Promise<PutResult>;
 
   /**
    * Fetches the specified data.
+   * The returned dataCid and returned dataSize will be verified against the given dataCid (and inferred dataSize).
    * @param messageCid CID of the message that references the data.
    */
-  get(tenant: string, messageCid: string, dataCid: string): Promise<Readable | undefined>;
+  get(tenant: string, messageCid: string, dataCid: string): Promise<GetResult | undefined>;
 
   /**
    * Associates existing data.
+   * The returned dataCid and returned dataSize will be verified against the given dataCid (and inferred dataSize).
    * @param tenant The tenant in which the data must exist under for the association to occur.
    * @param messageCid CID of the message that references the data.
    * @param dataCid The CID of the data stored.
    * @returns Whether data for the given CID was found under the tenant scope in the store.
    */
-  associate(tenant: string, messageCid: string, dataCid: string): Promise<boolean>;
+  associate(tenant: string, messageCid: string, dataCid: string): Promise<AssociateResult | undefined>;
 
   /**
    * Deletes the specified data.
@@ -47,6 +51,23 @@ export interface DataStore {
  * Result of a data store `put()` method call.
  */
 export type PutResult = {
+  dataCid: string;
+  dataSize: number;
+};
+
+/**
+ * Result of a data store `get()` method call.
+ */
+export type GetResult = {
+  dataCid: string;
+  dataSize: number;
+  dataStream: Readable;
+};
+
+/**
+ * Result of a data store `associate()` method call.
+ */
+export type AssociateResult = {
   dataCid: string;
   dataSize: number;
 };

--- a/tests/store/data-store.spec.ts
+++ b/tests/store/data-store.spec.ts
@@ -1,7 +1,13 @@
+import chaiAsPromised from 'chai-as-promised';
+import chai, { expect } from 'chai';
+
+import { asyncGeneratorToArray } from '../../src/utils/array.js';
+import { Cid } from '../../src/utils/cid.js';
 import { DataStoreLevel } from '../../src/store/data-store-level.js';
 import { DataStream } from '../../src/index.js';
-import { expect } from 'chai';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
+
+chai.use(chaiAsPromised);
 
 let store: DataStoreLevel;
 
@@ -21,15 +27,25 @@ describe('DataStore Test Suite', () => {
 
   describe('put', function () {
     it('should return the correct size of the data stored', async () => {
+      const tenant = await TestDataGenerator.randomCborSha256Cid();
+      const messageCid = await TestDataGenerator.randomCborSha256Cid();
+
       let dataSizeInBytes = 10;
 
       // iterate through order of magnitude in size until hitting 10MB
       while (dataSizeInBytes <= 10_000_000) {
         const dataBytes = TestDataGenerator.randomBytes(dataSizeInBytes);
         const dataStream = DataStream.fromBytes(dataBytes);
-        const { dataSize } = await store.put('anyTenant', 'anyRecordId', dataStream);
+        const dataCid = await Cid.computeDagPbCidFromBytes(dataBytes);
+
+        const { dataSize } = await store.put(tenant, messageCid, dataCid, dataStream);
 
         expect(dataSize).to.equal(dataSizeInBytes);
+
+        const result = await store.get(tenant, messageCid, dataCid);
+        const storedDataBytes = await DataStream.toBytes(result.dataStream);
+
+        expect(storedDataBytes).to.eql(dataBytes);
 
         dataSizeInBytes *= 10;
       }
@@ -38,10 +54,111 @@ describe('DataStore Test Suite', () => {
 
   describe('get', function () {
     it('should return `undefined if unable to find the data specified`', async () => {
-      const randomCid = await TestDataGenerator.randomCborSha256Cid();
-      const data = await store.get('anyTenant', 'anyRecordId', randomCid);
+      const tenant = await TestDataGenerator.randomCborSha256Cid();
+      const messageCid = await TestDataGenerator.randomCborSha256Cid();
 
-      expect(data).to.be.undefined;
+      const randomCid = await TestDataGenerator.randomCborSha256Cid();
+      const result = await store.get(tenant, messageCid, randomCid);
+
+      expect(result).to.be.undefined;
+    });
+
+    it('should return `undefined if the dataCid is different than the dataStream`', async () => {
+      const tenant = await TestDataGenerator.randomCborSha256Cid();
+      const messageCid = await TestDataGenerator.randomCborSha256Cid();
+
+      const randomCid = await TestDataGenerator.randomCborSha256Cid();
+
+      const dataBytes = TestDataGenerator.randomBytes(10_000_000);
+      const dataStream = DataStream.fromBytes(dataBytes);
+
+      const { dataCid } = await store.put(tenant, messageCid, randomCid, dataStream);
+
+      expect(dataCid).to.not.equal(randomCid);
+
+      const result = await store.get(tenant, messageCid, randomCid);
+
+      expect(result).to.be.undefined;
+    });
+  });
+
+  describe('associate', function () {
+    it('should return `false` if tenant missing', async () => {
+      const tenant = await TestDataGenerator.randomCborSha256Cid();
+      const messageCid = await TestDataGenerator.randomCborSha256Cid();
+      const randomCid = await TestDataGenerator.randomCborSha256Cid();
+
+      const keysBeforeAssociate = await asyncGeneratorToArray(store.blockstore.db.keys());
+      expect(keysBeforeAssociate.length).to.equal(0);
+
+      const result = await store.associate(tenant, messageCid, randomCid);
+      expect(result).to.be.undefined;
+
+      const keysAfterAssociate = await asyncGeneratorToArray(store.blockstore.db.keys());
+      expect(keysAfterAssociate.length).to.equal(0);
+    });
+
+    it('should return `false` if data missing', async () => {
+      const tenant = await TestDataGenerator.randomCborSha256Cid();
+      const messageCid = await TestDataGenerator.randomCborSha256Cid();
+      const randomCid = await TestDataGenerator.randomCborSha256Cid();
+
+      const dataBytes = TestDataGenerator.randomBytes(10);
+      const dataStream = DataStream.fromBytes(dataBytes);
+
+      const { dataCid } = await store.put(tenant, messageCid, randomCid, dataStream);
+      expect(dataCid).to.not.equal(randomCid);
+
+      const keysBeforeAssociate = await asyncGeneratorToArray(store.blockstore.db.keys());
+      expect(keysBeforeAssociate.length).to.equal(2);
+
+      const result = await store.associate(tenant, messageCid, randomCid);
+      expect(result).to.be.undefined;
+
+      const keysAfterAssociate = await asyncGeneratorToArray(store.blockstore.db.keys());
+      expect(keysAfterAssociate.length).to.equal(2);
+    });
+
+    it('should return the root CID', async () => {
+      const tenant = await TestDataGenerator.randomCborSha256Cid();
+      const messageCid = await TestDataGenerator.randomCborSha256Cid();
+
+      const dataBytes = TestDataGenerator.randomBytes(10_000_000);
+      const dataStream = DataStream.fromBytes(dataBytes);
+      const dataCid = await Cid.computeDagPbCidFromBytes(dataBytes);
+
+      await store.put(tenant, messageCid, dataCid, dataStream);
+
+      const keysBeforeDelete = await asyncGeneratorToArray(store.blockstore.db.keys());
+      expect(keysBeforeDelete.length).to.equal(41);
+
+      const result = await store.associate(tenant, messageCid, dataCid);
+      expect(result.dataCid).to.equal(dataCid);
+      expect(result.dataSize).to.equal(10_000_000);
+
+      const keysAfterDelete = await asyncGeneratorToArray(store.blockstore.db.keys());
+      expect(keysAfterDelete.length).to.equal(41);
+    });
+  });
+
+  describe('delete', function () {
+    it('should not leave anything behind when deleting a the root CID', async () => {
+      const tenant = await TestDataGenerator.randomCborSha256Cid();
+      const messageCid = await TestDataGenerator.randomCborSha256Cid();
+
+      const dataBytes = TestDataGenerator.randomBytes(10_000_000);
+      const dataStream = DataStream.fromBytes(dataBytes);
+      const dataCid = await Cid.computeDagPbCidFromBytes(dataBytes);
+
+      await store.put(tenant, messageCid, dataCid, dataStream);
+
+      const keysBeforeDelete = await asyncGeneratorToArray(store.blockstore.db.keys());
+      expect(keysBeforeDelete.length).to.equal(41);
+
+      await store.delete(tenant, messageCid, dataCid);
+
+      const keysAfterDelete = await asyncGeneratorToArray(store.blockstore.db.keys());
+      expect(keysAfterDelete.length).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
`ipfs-unixfs-importer` will split the `DataStream` into blocks, storing each in the `Blockstore` under a separate `CID`

unfortunately, we can only get the `CID` of the root block, so instead just leverage `level` to create a separate `partition` for the given `dataCid` and use that to delete everything in one go

ideally we'd have a way to get the `CID` of every block so that we can have the same `tenant`+`messageCid` association logic with each block instead of just the root (though this could result in a much larger metadata storage cost, but could also allow for deduplication of individual blocks)