### PR TITLE
add a way to do chunked file uploading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,11 +11,13 @@ try.ts
 try.js
 
 # default location for levelDB data storage in a non-browser env
-MESSAGESTORE
 DATASTORE
+MESSAGESTORE
+UPLOADSTORE
 # location for levelDB data storage for non-browser tests
 TEST-DATASTORE
 TEST-MESSAGESTORE
+TEST-UPLOADSTORE
 
 # default location for index specific levelDB data storage in a non-browser env
 INDEX

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-93.73%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-92.9%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-90.55%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.73%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-84.78%25-yellow.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-88.6%25-yellow.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-82.49%25-yellow.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-84.78%25-yellow.svg?style=flat)
 
 ## Introduction
 

--- a/json-schemas/records/records-upload-complete.json
+++ b/json-schemas/records/records-upload-complete.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/dwn/json-schemas/records-upload-complete.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "authorization",
+    "descriptor",
+    "recordId"
+  ],
+  "properties": {
+    "recordId": {
+      "type": "string"
+    },
+    "attestation": {
+      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+    },
+    "authorization": {
+      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+    },
+    "descriptor": {
+      "type": "object",
+      "properties": {
+        "interface": {
+          "enum": [
+            "Records"
+          ],
+          "type": "string"
+        },
+        "method": {
+          "enum": [
+            "Upload"
+          ],
+          "type": "string"
+        },
+        "state": {
+          "enum": [
+            "Complete",
+          ],
+          "type": "string"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "schema": {
+          "type": "string"
+        },
+        "recipient": {
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/did"
+        },
+        "count": {
+          "type": "number"
+        },
+        "dataCid": {
+          "type": "string"
+        },
+        "dataSize": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "interface",
+        "method",
+        "state",
+        "count",
+        "dataCid",
+        "dataSize"
+      ]
+    }
+  }
+}

--- a/json-schemas/records/records-upload-part.json
+++ b/json-schemas/records/records-upload-part.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/dwn/json-schemas/records-upload-part.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "authorization",
+    "descriptor",
+    "recordId"
+  ],
+  "properties": {
+    "recordId": {
+      "type": "string"
+    },
+    "attestation": {
+      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+    },
+    "authorization": {
+      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+    },
+    "descriptor": {
+      "type": "object",
+      "properties": {
+        "interface": {
+          "enum": [
+            "Records"
+          ],
+          "type": "string"
+        },
+        "method": {
+          "enum": [
+            "Upload"
+          ],
+          "type": "string"
+        },
+        "state": {
+          "enum": [
+            "Part",
+          ],
+          "type": "string"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "schema": {
+          "type": "string"
+        },
+        "recipient": {
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/did"
+        },
+        "index": {
+          "type": "number"
+        },
+        "dataCid": {
+          "type": "string"
+        },
+        "dataSize": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "interface",
+        "method",
+        "state",
+        "index",
+        "dataCid",
+        "dataSize"
+      ]
+    }
+  }
+}

--- a/json-schemas/records/records-upload-start.json
+++ b/json-schemas/records/records-upload-start.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/dwn/json-schemas/records-upload-start.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "authorization",
+    "descriptor",
+    "recordId"
+  ],
+  "properties": {
+    "recordId": {
+      "type": "string"
+    },
+    "attestation": {
+      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+    },
+    "authorization": {
+      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+    },
+    "descriptor": {
+      "type": "object",
+      "properties": {
+        "interface": {
+          "enum": [
+            "Records"
+          ],
+          "type": "string"
+        },
+        "method": {
+          "enum": [
+            "Upload"
+          ],
+          "type": "string"
+        },
+        "state": {
+          "enum": [
+            "Start",
+          ],
+          "type": "string"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "schema": {
+          "type": "string"
+        },
+        "recipient": {
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/did"
+        },
+        "dataFormat": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "interface",
+        "method",
+        "state",
+        "dataFormat"
+      ]
+    }
+  }
+}

--- a/src/core/message.ts
+++ b/src/core/message.ts
@@ -17,12 +17,19 @@ export enum DwnInterfaceName {
 
 export enum DwnMethodName {
   Configure = 'Configure',
+  Delete = 'Delete',
   Grant = 'Grant',
   Query = 'Query',
   Read = 'Read',
   Request = 'Request',
-  Write = 'Write',
-  Delete = 'Delete'
+  Upload = 'Upload',
+  Write = 'Write'
+}
+
+export enum DwnStateName {
+  Complete = 'Complete',
+  Part = 'Part',
+  Start = 'Start'
 }
 
 export abstract class Message {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -21,6 +21,7 @@ export type BaseDecodedAuthorizationPayload = {
 export type Descriptor = {
   interface: string;
   method: string;
+  state?: string;
   dataCid?: string;
   dataSize?: number;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,3 +41,5 @@ export { RecordsQuery, RecordsQueryOptions } from './interfaces/records/messages
 export { RecordsRead, RecordsReadOptions } from './interfaces/records/messages/records-read.js';
 export { RecordsWrite, RecordsWriteOptions, CreateFromOptions } from './interfaces/records/messages/records-write.js';
 export { SignatureInput } from './jose/jws/general/types.js';
+export { UploadStore } from './store/upload-store.js';
+export { UploadStoreLevel } from './store/upload-store-level.js';

--- a/src/interfaces/records/handlers/records-upload.ts
+++ b/src/interfaces/records/handlers/records-upload.ts
@@ -1,0 +1,208 @@
+import type { MethodHandler } from '../../types.js';
+import type { DidResolver, MessageStore, UploadStore } from '../../../index.js';
+import type { RecordsUploadCompleteMessage, RecordsUploadPartMessage, RecordsUploadStartMessage } from '../types.js';
+
+import { authenticate } from '../../../core/auth.js';
+import { MessageReply } from '../../../core/message-reply.js';
+import { RecordsUpload } from '../messages/records-upload.js';
+import { DwnInterfaceName, DwnMethodName, DwnStateName } from '../../../core/message.js';
+
+type RecordsUploadMessageVariant = RecordsUploadCompleteMessage | RecordsUploadPartMessage | RecordsUploadStartMessage;
+
+export class RecordsUploadHandler implements MethodHandler {
+
+  constructor(private didResolver: DidResolver, private messageStore: MessageStore, private uploadStore: UploadStore) { }
+
+  public async handle({
+    tenant,
+    message,
+    dataStream
+  }): Promise<MessageReply> {
+    const incomingMessage = message as RecordsUploadMessageVariant;
+
+    let recordsUpload: RecordsUpload;
+    try {
+      recordsUpload = await RecordsUpload.parse(incomingMessage);
+    } catch (e) {
+      return new MessageReply({
+        status: { code: 400, detail: e.message }
+      });
+    }
+
+    // authentication & authorization
+    try {
+      await authenticate(incomingMessage.authorization, this.didResolver);
+      await recordsUpload.authorize(tenant, this.messageStore);
+    } catch (e) {
+      return new MessageReply({
+        status: { code: 401, detail: e.message }
+      });
+    }
+
+    // get existing upload messages matching the `recordId`
+    const query = {
+      interface : DwnInterfaceName.Records,
+      method    : DwnMethodName.Upload,
+      recordId  : incomingMessage.recordId
+    };
+    const existingMessages = await this.messageStore.query(tenant, query) as RecordsUploadMessageVariant[];
+
+    try {
+      const existingUploadComplete = await RecordsUpload.getUploadComplete(existingMessages);
+      if (existingUploadComplete) {
+        return new MessageReply({
+          status: { code: 400, detail: 'upload already complete' }
+        });
+      }
+    } catch (e) {
+      // ignore error if upload complete cannot be found
+    }
+
+    const newMessageIsUploadStart = await recordsUpload.isUploadStart();
+
+    try {
+      const existingUploadStart = await RecordsUpload.getUploadStart(existingMessages);
+      if (existingUploadStart) {
+        if (newMessageIsUploadStart) {
+          return new MessageReply({
+            status: { code: 400, detail: 'cannot start an upload more than once' }
+          });
+        }
+
+        RecordsUpload.verifyEqualityOfImmutableProperties(existingUploadStart, incomingMessage);
+      }
+    } catch (e) {
+      // it's ok to not find the upload start if the new message is the upload start
+      if (!newMessageIsUploadStart) {
+        return new MessageReply({
+          status: { code: 400, detail: e.message }
+        });
+      }
+    }
+
+    try {
+      for (const existingMessage of existingMessages) {
+        RecordsUpload.verifyExclusivityOfUniqueProperties(existingMessage, incomingMessage);
+      }
+    } catch (e) {
+      return new MessageReply({
+        status: { code: 400, detail: e.message }
+      });
+    }
+
+    const newMessageIsUploadComplete = await recordsUpload.isUploadComplete();
+    if (newMessageIsUploadComplete) {
+      const uploadComplete = incomingMessage as RecordsUploadCompleteMessage;
+
+      const indexes = new Set<number>();
+
+      for (const existingMessage of existingMessages) {
+        if (existingMessage.descriptor.state === DwnStateName.Part) {
+          const uploadPart = existingMessage as RecordsUploadPartMessage;
+
+          // we already checked above that each index is unique
+          indexes.add(uploadPart.descriptor.index);
+        }
+      }
+
+      // make sure we have all the parts
+      for (let index = 0; index < uploadComplete.descriptor.count; ++index) {
+        if (!indexes.has(index)) {
+          return new MessageReply({
+            status: { code: 400, detail: `missing index '${index}'` }
+          });
+        }
+
+        indexes.delete(index);
+      }
+
+      // make sure we don't have any extra parts
+      for (const index of indexes) {
+        return new MessageReply({
+          status: { code: 400, detail: `extra index '${index}'` }
+        });
+      }
+    }
+
+    let result;
+
+    switch (incomingMessage.descriptor.state) {
+    case DwnStateName.Complete:
+      var uploadComplete = incomingMessage as RecordsUploadCompleteMessage;
+      result = await this.uploadStore.complete(tenant, uploadComplete.recordId, uploadComplete.descriptor.count);
+      break;
+
+    case DwnStateName.Part:
+      var uploadPart = incomingMessage as RecordsUploadPartMessage;
+      result = await this.uploadStore.part(tenant, uploadPart.recordId, uploadPart.descriptor.index, dataStream);
+      break;
+
+    case DwnStateName.Start:
+      var uploadStart = incomingMessage as RecordsUploadStartMessage;
+      result = await this.uploadStore.start(tenant, uploadStart.recordId, uploadStart.descriptor.dataFormat);
+      break;
+    }
+
+    if (!result) {
+      return new MessageReply({
+        status: { code: 400, detail: 'cannot start upload' }
+      });
+    }
+
+    // MUST verify that the size of the actual data matches with the given `dataSize`
+    // if data size is wrong, delete the data we just stored
+    if (message.descriptor.dataSize !== result.dataSize) {
+      // there is an opportunity to improve here: handle the edge case of if the delete fails...
+      await this.uploadStore.delete(tenant, incomingMessage.recordId);
+
+      return new MessageReply({
+        status: {
+          code   : 400,
+          detail : `actual data size ${result.dataSize} bytes does not match dataSize in descriptor: ${message.descriptor.dataSize}`
+        }
+      });
+    }
+
+    // MUST verify that the CID of the actual data matches with the given `dataCid`
+    // if data CID is wrong, delete the data we just stored
+    if (message.descriptor.dataCid !== result.dataCid) {
+      // there is an opportunity to improve here: handle the edge case of if the delete fails...
+      await this.uploadStore.delete(tenant, incomingMessage.recordId);
+
+      return new MessageReply({
+        status: {
+          code   : 400,
+          detail : `actual data CID ${result.dataCid} does not match dataCid in descriptor: ${message.descriptor.dataCid}`
+        }
+      });
+    }
+
+    const indexes = await constructRecordsUploadIndexes(recordsUpload);
+
+    await this.messageStore.put(tenant, incomingMessage, indexes);
+
+    return new MessageReply({
+      status: { code: 202, detail: 'Accepted' }
+    });
+  }
+}
+
+export async function constructRecordsUploadIndexes(
+  recordsUpload: RecordsUpload
+): Promise<{ [key: string]: string }> {
+  const message = recordsUpload.message;
+  const descriptor = { ...message.descriptor };
+
+  const indexes: { [key: string]: any } = {
+    ...descriptor,
+    author   : recordsUpload.author,
+    recordId : message.recordId,
+    entryId  : await RecordsUpload.getEntryId(recordsUpload.author, recordsUpload.message.descriptor)
+  };
+
+  // add additional indexes to optional values if given
+  // TODO: index multi-attesters to be unblocked by #205 - Revisit database interfaces (https://github.com/TBD54566975/dwn-sdk-js/issues/205)
+  if (recordsUpload.attesters.length > 0) { indexes.attester = recordsUpload.attesters[0]; }
+
+  return indexes;
+}

--- a/src/interfaces/records/messages/records-upload.ts
+++ b/src/interfaces/records/messages/records-upload.ts
@@ -1,0 +1,516 @@
+import type { BaseMessage } from '../../../core/types.js';
+import type { MessageStore } from '../../../store/message-store.js';
+import type { GeneralJws, SignatureInput } from '../../../jose/jws/general/types.js';
+import type { RecordsAttestationPayload, RecordsAuthorizationPayload, RecordsUploadCompleteDescriptor, RecordsUploadCompleteMessage, RecordsUploadPartDescriptor, RecordsUploadPartMessage, RecordsUploadStartDescriptor, RecordsUploadStartMessage } from '../types.js';
+
+import { Encoder } from '../../../utils/encoder.js';
+import { GeneralJwsSigner } from '../../../jose/jws/general/signer.js';
+import { Jws } from '../../../utils/jws.js';
+import { Message } from '../../../core/message.js';
+import { ProtocolAuthorization } from '../../../core/protocol-authorization.js';
+import { removeUndefinedProperties } from '../../../utils/object.js';
+
+import { authorize, validateAuthorizationIntegrity } from '../../../core/auth.js';
+import { Cid, computeCid } from '../../../utils/cid.js';
+import { DwnInterfaceName, DwnMethodName, DwnStateName } from '../../../core/message.js';
+
+type RecordsUploadMessageVariant = RecordsUploadCompleteMessage | RecordsUploadPartMessage | RecordsUploadStartMessage;
+
+type RecordsUploadDescriptorVariant = RecordsUploadCompleteDescriptor | RecordsUploadPartDescriptor | RecordsUploadStartDescriptor;
+
+type RecordsUploadOptions = {
+  protocol?: string;
+  schema?: string;
+  recipient?: string;
+  authorizationSignatureInput: SignatureInput;
+  attestationSignatureInputs?: SignatureInput[];
+};
+
+export type RecordsUploadStartOptions = RecordsUploadOptions & {
+  recordId?: string;
+  dataFormat: string;
+};
+
+export type RecordsUploadPartOptions = RecordsUploadOptions & {
+  recordId: string;
+  index: number;
+  data?: Uint8Array;
+  dataCid?: string;
+  dataSize?: number;
+};
+
+export type RecordsUploadCompleteOptions = RecordsUploadOptions & {
+  recordId: string;
+  count: number;
+  dataCid: string;
+  dataSize: number;
+};
+
+export class RecordsUpload extends Message {
+  /**
+   * RecordsUpload message adhering to the DWN specification.
+   */
+  readonly message: RecordsUploadMessageVariant;
+  readonly attesters: string[];
+
+  private constructor(message: RecordsUploadMessageVariant) {
+    super(message);
+
+    this.attesters = RecordsUpload.getAttesters(message);
+
+    // consider converting isUploadStart() & isUploadComplete() & getEntryId() into properties for performance and convenience
+  }
+
+  public static async parse(message: RecordsUploadMessageVariant): Promise<RecordsUpload> {
+    // asynchronous checks that are required by the constructor to initialize members properly
+    await validateAuthorizationIntegrity(message, { allowedProperties: new Set([ 'recordId', 'attestationCid' ]) });
+    await RecordsUpload.validateAttestationIntegrity(message);
+
+    const recordsUpload = new RecordsUpload(message);
+
+    await recordsUpload.validateIntegrity(); // RecordsUpload specific data integrity check
+
+    return recordsUpload;
+  }
+
+  /**
+   * Creates a RecordsUpload start message.
+   * @param options.recordId If `undefined`, will be auto-filled as a originating message as convenience for developer.
+   * @param options.dataFormat Format of the data. Must be provided.
+   */
+  public static async createStart(options: RecordsUploadStartOptions): Promise<RecordsUpload> {
+    const descriptor: RecordsUploadStartDescriptor = {
+      interface  : DwnInterfaceName.Records,
+      method     : DwnMethodName.Upload,
+      state      : DwnStateName.Start,
+      protocol   : options.protocol,
+      schema     : options.schema,
+      recipient  : options.recipient,
+      dataFormat : options.dataFormat
+    };
+
+    // delete all descriptor properties that are `undefined` else the code will encounter the following IPLD issue when attempting to generate CID:
+    // Error: `undefined` is not supported by the IPLD Data Model and cannot be encoded
+    removeUndefinedProperties(descriptor);
+
+    const author = Jws.extractDid(options.authorizationSignatureInput.protectedHeader.kid);
+
+    // `recordId` computation
+    const recordId = options.recordId ?? await RecordsUpload.getEntryId(author, descriptor);
+
+    // `attestation` generation
+    const descriptorCid = await computeCid(descriptor);
+    const attestation = await RecordsUpload.createAttestation(descriptorCid, options.attestationSignatureInputs);
+
+    // `authorization` generation
+    const authorization = await RecordsUpload.createAuthorization(
+      recordId,
+      descriptorCid,
+      attestation,
+      options.authorizationSignatureInput
+    );
+
+    const message: RecordsUploadStartMessage = {
+      recordId,
+      descriptor,
+      authorization
+    };
+
+    if (attestation !== undefined) { message.attestation = attestation; } // assign `attestation` only if it is defined
+
+    Message.validateJsonSchema(message);
+
+    return new RecordsUpload(message);
+  }
+
+  /**
+   * Creates a RecordsUpload part message.
+   * @param options.recordId The ID of the upload. Must be provided.
+   * @param options.index Where this part exists in the overall data. Must be provided.
+   * @param options.data Data used to compute the `dataCid`. Must specify `option.dataCid` if `undefined`.
+   * @param options.dataCid CID of the data that is already stored in the DWN. Must specify `option.data` if `undefined`.
+   * @param options.dataSize Size of data in number of bytes. Must be defined if `option.dataCid` is defined; must be `undefined` otherwise.
+   */
+  public static async createPart(options: RecordsUploadPartOptions): Promise<RecordsUpload> {
+    if ((options.data === undefined && options.dataCid === undefined) ||
+        (options.data !== undefined && options.dataCid !== undefined)) {
+      throw new Error('one and only one parameter between `data` and `dataCid` is allowed');
+    }
+
+    if ((options.dataCid === undefined && options.dataSize !== undefined) ||
+        (options.dataCid !== undefined && options.dataSize === undefined)) {
+      throw new Error('`dataCid` and `dataSize` must both be defined or undefined at the same time');
+    }
+
+    const dataCid = options.dataCid ?? await Cid.computeDagPbCidFromBytes(options.data!);
+    const dataSize = options.dataSize ?? options.data!.length;
+
+    const descriptor: RecordsUploadPartDescriptor = {
+      interface : DwnInterfaceName.Records,
+      method    : DwnMethodName.Upload,
+      state     : DwnStateName.Part,
+      protocol  : options.protocol,
+      schema    : options.schema,
+      recipient : options.recipient,
+      index     : options.index,
+      dataCid,
+      dataSize
+    };
+
+    // delete all descriptor properties that are `undefined` else the code will encounter the following IPLD issue when attempting to generate CID:
+    // Error: `undefined` is not supported by the IPLD Data Model and cannot be encoded
+    removeUndefinedProperties(descriptor);
+
+    // `attestation` generation
+    const descriptorCid = await computeCid(descriptor);
+    const attestation = await RecordsUpload.createAttestation(descriptorCid, options.attestationSignatureInputs);
+
+    // `authorization` generation
+    const authorization = await RecordsUpload.createAuthorization(
+      options.recordId,
+      descriptorCid,
+      attestation,
+      options.authorizationSignatureInput
+    );
+
+    const message: RecordsUploadPartMessage = {
+      recordId: options.recordId,
+      descriptor,
+      authorization
+    };
+
+    if (attestation !== undefined) { message.attestation = attestation; } // assign `attestation` only if it is defined
+
+    Message.validateJsonSchema(message);
+
+    return new RecordsUpload(message);
+  }
+
+  /**
+   * Creates a RecordsUpload message.
+   * @param options.recordId The ID of the upload. Must be provided.
+   * @param options.count Number of parts for the upload. Must be provided.
+   * @param options.dataCid CID of the data that has already been uploaded to the DWN. Must be provided.
+   * @param options.dataSize Size of data in number of bytes. Must be provided.
+   */
+  public static async createComplete(options: RecordsUploadCompleteOptions): Promise<RecordsUpload> {
+    const descriptor: RecordsUploadCompleteDescriptor = {
+      interface : DwnInterfaceName.Records,
+      method    : DwnMethodName.Upload,
+      state     : DwnStateName.Complete,
+      protocol  : options.protocol,
+      schema    : options.schema,
+      recipient : options.recipient,
+      count     : options.count,
+      dataCid   : options.dataCid,
+      dataSize  : options.dataSize
+    };
+
+    // delete all descriptor properties that are `undefined` else the code will encounter the following IPLD issue when attempting to generate CID:
+    // Error: `undefined` is not supported by the IPLD Data Model and cannot be encoded
+    removeUndefinedProperties(descriptor);
+
+    // `attestation` generation
+    const descriptorCid = await computeCid(descriptor);
+    const attestation = await RecordsUpload.createAttestation(descriptorCid, options.attestationSignatureInputs);
+
+    // `authorization` generation
+    const authorization = await RecordsUpload.createAuthorization(
+      options.recordId,
+      descriptorCid,
+      attestation,
+      options.authorizationSignatureInput
+    );
+
+    const message: RecordsUploadCompleteMessage = {
+      recordId: options.recordId,
+      descriptor,
+      authorization
+    };
+
+    if (attestation !== undefined) { message.attestation = attestation; } // assign `attestation` only if it is defined
+
+    Message.validateJsonSchema(message);
+
+    return new RecordsUpload(message);
+  }
+
+  public async authorize(tenant: string, messageStore: MessageStore): Promise<void> {
+    if (this.message.descriptor.protocol !== undefined) {
+      await ProtocolAuthorization.authorize(tenant, this, this.author, messageStore);
+    } else {
+      await authorize(tenant, this);
+    }
+  }
+
+  /**
+   * Validates the integrity of the RecordsUpload message assuming the message passed basic schema validation.
+   * There is opportunity to integrate better with `validateSchema(...)`
+   */
+  private async validateIntegrity(): Promise<void> {
+    // make sure the same `recordId` in message is the same as the `recordId` in `authorization`
+    if (this.message.recordId !== this.authorizationPayload.recordId) {
+      throw new Error(
+        `recordId in message ${this.message.recordId} does not match recordId in authorization: ${this.authorizationPayload.recordId}`
+      );
+    }
+
+    // if `attestation` is given in message, make sure the correct `attestationCid` is in the `authorization`
+    if (this.message.attestation !== undefined) {
+      const expectedAttestationCid = await computeCid(this.message.attestation);
+      const actualAttestationCid = this.authorizationPayload.attestationCid;
+      if (actualAttestationCid !== expectedAttestationCid) {
+        throw new Error(
+          `CID ${expectedAttestationCid} of attestation property in message does not match attestationCid in authorization: ${actualAttestationCid}`
+        );
+      }
+    }
+  }
+
+  /**
+   * Validates the structural integrity of the `attestation` property.
+   * NOTE: signature is not verified.
+   */
+  private static async validateAttestationIntegrity(message: RecordsUploadMessageVariant): Promise<void> {
+    if (message.attestation === undefined) {
+      return;
+    }
+
+    // TODO: multi-attesters to be unblocked by #205 - Revisit database interfaces (https://github.com/TBD54566975/dwn-sdk-js/issues/205)
+    if (message.attestation.signatures.length !== 1) {
+      throw new Error(`Currently implementation only supports 1 attester, but got ${message.attestation.signatures.length}`);
+    }
+
+    const payloadJson = Jws.decodePlainObjectPayload(message.attestation);
+    const { descriptorCid } = payloadJson;
+
+    // `descriptorCid` validation - ensure that the provided descriptorCid matches the CID of the actual message
+    const expectedDescriptorCid = await computeCid(message.descriptor);
+    if (descriptorCid !== expectedDescriptorCid) {
+      throw new Error(`descriptorCid ${descriptorCid} does not match expected descriptorCid ${expectedDescriptorCid}`);
+    }
+
+    // check to ensure that no other unexpected properties exist in payload.
+    const propertyCount = Object.keys(payloadJson).length;
+    if (propertyCount > 1) {
+      throw new Error(`Only 'descriptorCid' is allowed in attestation payload, but got ${propertyCount} properties.`);
+    }
+  };
+
+  /**
+   * Computes the deterministic Entry ID of this message.
+   */
+  public async getEntryId(): Promise<string> {
+    const entryId = await RecordsUpload.getEntryId(this.author, this.message.descriptor);
+    return entryId;
+  };
+
+  /**
+   * Computes the deterministic Entry ID of this message.
+   */
+  public static async getEntryId(author: string, descriptor: RecordsUploadDescriptorVariant): Promise<string> {
+    const entryIdInput = { ...descriptor };
+    (entryIdInput as any).author = author;
+
+    const cid = await computeCid(entryIdInput);
+    return cid;
+  };
+
+  /**
+   * Checks if the given message is the start entry of an upload.
+   */
+  public async isUploadStart(): Promise<boolean> {
+    if (this.message.descriptor.state !== DwnStateName.Start) {
+      return false;
+    }
+
+    const entryId = await this.getEntryId();
+    return entryId === this.message.recordId;
+  }
+
+  /**
+   * Checks if the given message is the start entry of an upload.
+   */
+  public static async isUploadStart(message: BaseMessage): Promise<boolean> {
+    // can't be the upload start if the message is not a Records Upload
+    if (message.descriptor.interface !== DwnInterfaceName.Records ||
+        message.descriptor.method !== DwnMethodName.Upload) {
+      return false;
+    }
+
+    if (message.descriptor.state !== DwnStateName.Start) {
+      return false;
+    }
+
+    const recordsUploadStartMessage = message as RecordsUploadStartMessage;
+    const author = Message.getAuthor(message);
+    const entryId = await RecordsUpload.getEntryId(author, recordsUploadStartMessage.descriptor);
+    return entryId === recordsUploadStartMessage.recordId;
+  }
+
+  /**
+   * Checks if the given message is a part entry of an upload.
+   */
+  public async isUploadPart(): Promise<boolean> {
+    if (this.message.descriptor.state !== DwnStateName.Part) {
+      return false;
+    }
+
+    const entryId = await this.getEntryId();
+    return entryId === this.message.recordId;
+  }
+
+  /**
+   * Checks if the given message is a part entry of an upload.
+   */
+  public static async isUploadPart(message: BaseMessage): Promise<boolean> {
+    // can't be an upload part if the message is not a Records Upload
+    if (message.descriptor.interface !== DwnInterfaceName.Records ||
+        message.descriptor.method !== DwnMethodName.Upload) {
+      return false;
+    }
+
+    if (message.descriptor.state !== DwnStateName.Part) {
+      return false;
+    }
+
+    const recordsUploadPartMessage = message as RecordsUploadPartMessage;
+    const author = Message.getAuthor(message);
+    const entryId = await RecordsUpload.getEntryId(author, recordsUploadPartMessage.descriptor);
+    return entryId === recordsUploadPartMessage.recordId;
+  }
+
+  /**
+   * Checks if the given message is the complete entry of an upload.
+   */
+  public async isUploadComplete(): Promise<boolean> {
+    if (this.message.descriptor.state !== DwnStateName.Complete) {
+      return false;
+    }
+
+    const entryId = await this.getEntryId();
+    return entryId === this.message.recordId;
+  }
+
+  /**
+   * Checks if the given message is the complete entry of an upload.
+   */
+  public static async isUploadComplete(message: BaseMessage): Promise<boolean> {
+    // can't be the upload complete if the message is not a Records Upload
+    if (message.descriptor.interface !== DwnInterfaceName.Records ||
+        message.descriptor.method !== DwnMethodName.Upload) {
+      return false;
+    }
+
+    if (message.descriptor.state !== DwnStateName.Complete) {
+      return false;
+    }
+
+    const recordsUploadCompleteMessage = message as RecordsUploadCompleteMessage;
+    const author = Message.getAuthor(message);
+    const entryId = await RecordsUpload.getEntryId(author, recordsUploadCompleteMessage.descriptor);
+    return entryId === recordsUploadCompleteMessage.recordId;
+  }
+
+  /**
+   * Creates the `attestation` property of a RecordsUpload message if given signature inputs; returns `undefined` otherwise.
+   */
+  private static async createAttestation(descriptorCid: string, signatureInputs?: SignatureInput[]): Promise<GeneralJws | undefined> {
+    if (signatureInputs === undefined || signatureInputs.length === 0) {
+      return undefined;
+    }
+
+    const attestationPayload: RecordsAttestationPayload = { descriptorCid };
+    const attestationPayloadBytes = Encoder.objectToBytes(attestationPayload);
+
+    const signer = await GeneralJwsSigner.create(attestationPayloadBytes, signatureInputs);
+    return signer.getJws();
+  }
+
+  /**
+   * Creates the `authorization` property of a RecordsUpload message.
+   */
+  private static async createAuthorization(
+    recordId: string,
+    descriptorCid: string,
+    attestation: GeneralJws | undefined,
+    signatureInput: SignatureInput
+  ): Promise<GeneralJws> {
+    const authorizationPayload: RecordsAuthorizationPayload = {
+      recordId,
+      descriptorCid
+    };
+
+    const attestationCid = attestation ? await computeCid(attestation) : undefined;
+
+    if (attestationCid !== undefined) { authorizationPayload.attestationCid = attestationCid; } // assign `attestationCid` only if it is defined
+
+    const authorizationPayloadBytes = Encoder.objectToBytes(authorizationPayload);
+
+    const signer = await GeneralJwsSigner.create(authorizationPayloadBytes, [signatureInput]);
+    return signer.getJws();
+  }
+
+  /**
+   * Gets the upload start from the given list or record upload.
+   */
+  public static async getUploadStart(messages: BaseMessage[]): Promise<RecordsUploadStartMessage> {
+    for (const message of messages) {
+      if (await RecordsUpload.isUploadStart(message)) {
+        return message as RecordsUploadStartMessage;
+      }
+    }
+
+    throw new Error(`upload start is not found`);
+  }
+
+  /**
+   * Gets the upload complete from the given list or record upload.
+   */
+  public static async getUploadComplete(messages: BaseMessage[]): Promise<RecordsUploadCompleteMessage> {
+    for (const message of messages) {
+      if (await RecordsUpload.isUploadComplete(message)) {
+        return message as RecordsUploadCompleteMessage;
+      }
+    }
+
+    throw new Error(`upload complete is not found`);
+  }
+
+  /**
+   * Verifies that immutable properties of the two given messages are identical.
+   * @throws {Error} if immutable properties between two RecordsWrite message
+   */
+  public static verifyEqualityOfImmutableProperties(existingMessage: RecordsUploadMessageVariant, newMessage: RecordsUploadMessageVariant): void {
+    for (const immutableDescriptorProperty of [ 'protocol', 'schema', 'recipient' ]) {
+      const existingValue = existingMessage.descriptor[immutableDescriptorProperty];
+      const newValue = newMessage.descriptor[immutableDescriptorProperty];
+      if ((existingValue !== undefined || newValue !== undefined) && newValue !== existingValue) {
+        throw new Error(`${immutableDescriptorProperty} is an immutable property: cannot change '${existingValue}' to '${newValue}'`);
+      }
+    }
+  }
+
+  /**
+   * Verifies that unique properties of the two given messages are not the same.
+   * @throws {Error} if unique properties between two RecordsWrite message
+   */
+  public static verifyExclusivityOfUniqueProperties(existingMessage: RecordsUploadMessageVariant, newMessage: RecordsUploadMessageVariant): void {
+    for (const uniqueDescriptorProperty of [ 'index' ]) {
+      const existingValue = existingMessage.descriptor[uniqueDescriptorProperty];
+      const newValue = newMessage.descriptor[uniqueDescriptorProperty];
+      if ((existingValue !== undefined || newValue !== undefined) && newValue === existingValue) {
+        throw new Error(`${uniqueDescriptorProperty} is a unique property: cannot reuse '${existingValue}'`);
+      }
+    }
+  }
+
+  /**
+   * Gets the DID of the author of the given message.
+   */
+  public static getAttesters(message: RecordsUploadMessageVariant): string[] {
+    const attestationSignatures = message.attestation?.signatures ?? [];
+    const attesters = attestationSignatures.map((signature) => Jws.getSignerDid(signature));
+    return attesters;
+  }
+}

--- a/src/interfaces/records/messages/records-write.ts
+++ b/src/interfaces/records/messages/records-write.ts
@@ -1,7 +1,7 @@
 import type { BaseMessage } from '../../../core/types.js';
 import type { MessageStore } from '../../../store/message-store.js';
 import type { GeneralJws, SignatureInput } from '../../../jose/jws/general/types.js';
-import type { RecordsWriteAttestationPayload, RecordsWriteAuthorizationPayload, RecordsWriteDescriptor, RecordsWriteMessage, UnsignedRecordsWriteMessage } from '../types.js';
+import type { RecordsAttestationPayload, RecordsAuthorizationPayload, RecordsWriteDescriptor, RecordsWriteMessage, UnsignedRecordsWriteMessage } from '../types.js';
 
 import { Encoder } from '../../../utils/encoder.js';
 import { GeneralJwsSigner } from '../../../jose/jws/general/signer.js';
@@ -371,7 +371,7 @@ export class RecordsWrite extends Message {
       return undefined;
     }
 
-    const attestationPayload: RecordsWriteAttestationPayload = { descriptorCid };
+    const attestationPayload: RecordsAttestationPayload = { descriptorCid };
     const attestationPayloadBytes = Encoder.objectToBytes(attestationPayload);
 
     const signer = await GeneralJwsSigner.create(attestationPayloadBytes, signatureInputs);
@@ -388,7 +388,7 @@ export class RecordsWrite extends Message {
     attestation: GeneralJws | undefined,
     signatureInput: SignatureInput
   ): Promise<GeneralJws> {
-    const authorizationPayload: RecordsWriteAuthorizationPayload = {
+    const authorizationPayload: RecordsAuthorizationPayload = {
       recordId,
       descriptorCid
     };

--- a/src/interfaces/records/types.ts
+++ b/src/interfaces/records/types.ts
@@ -1,7 +1,7 @@
 import type { BaseMessage } from '../../core/types.js';
 import type { DateSort } from './messages/records-query.js';
 import type { GeneralJws } from '../../jose/jws/general/types.js';
-import type { DwnInterfaceName, DwnMethodName } from '../../core/message.js';
+import type { DwnInterfaceName, DwnMethodName, DwnStateName } from '../../core/message.js';
 
 export type RecordsWriteDescriptor = {
   interface: DwnInterfaceName.Records;
@@ -36,6 +36,52 @@ export type UnsignedRecordsWriteMessage = {
   encodedData?: string;
 };
 
+export type RecordsUploadDescriptor = {
+  interface: DwnInterfaceName.Records;
+  method: DwnMethodName.Upload;
+  state: string;
+  protocol?: string;
+  schema?: string;
+  recipient?: string;
+};
+
+export type RecordsUploadStartDescriptor = RecordsUploadDescriptor & {
+  state: DwnStateName.Start;
+  dataFormat: string;
+};
+
+export type RecordsUploadPartDescriptor = RecordsUploadDescriptor & {
+  state: DwnStateName.Part;
+  index: number;
+  dataCid: string;
+  dataSize: number;
+};
+
+export type RecordsUploadCompleteDescriptor = RecordsUploadDescriptor & {
+  state: DwnStateName.Complete;
+  count: number;
+  dataCid: string;
+  dataSize: number;
+};
+
+export type RecordsUploadMessage = BaseMessage & {
+  recordId: string;
+  descriptor: RecordsUploadDescriptor;
+  attestation?: GeneralJws;
+};
+
+export type RecordsUploadStartMessage = RecordsUploadMessage & {
+  descriptor: RecordsUploadStartDescriptor;
+};
+
+export type RecordsUploadPartMessage = RecordsUploadMessage & {
+  descriptor: RecordsUploadPartDescriptor;
+};
+
+export type RecordsUploadCompleteMessage = RecordsUploadMessage & {
+  descriptor: RecordsUploadCompleteDescriptor;
+};
+
 export type RecordsQueryDescriptor = {
   interface: DwnInterfaceName.Records;
   method: DwnMethodName.Query;
@@ -45,6 +91,7 @@ export type RecordsQueryDescriptor = {
 };
 
 export type RecordsQueryFilter = {
+  state?: string;
   attester?: string;
   recipient?: string;
   protocol?: string;
@@ -68,11 +115,11 @@ export type RangeCriterion = {
   to?: string;
 };
 
-export type RecordsWriteAttestationPayload = {
+export type RecordsAttestationPayload = {
   descriptorCid: string;
 };
 
-export type RecordsWriteAuthorizationPayload = {
+export type RecordsAuthorizationPayload = {
   recordId: string;
   contextId?: string;
   descriptorCid: string;

--- a/src/store/blockstore-level.ts
+++ b/src/store/blockstore-level.ts
@@ -4,6 +4,8 @@ import type { Blockstore, Options } from 'interface-blockstore';
 
 import { createLevelDatabase, LevelWrapper } from './level-wrapper.js';
 
+type Key = CID | string | number;
+
 // `level` works in Node.js 12+ and Electron 5+ on Linux, Mac OS, Windows and
 // FreeBSD, including any future Node.js and Electron release thanks to Node-API, including ARM
 // platforms like Raspberry Pi and Android, as well as in Chrome, Firefox, Edge, Safari, iOS Safari
@@ -35,24 +37,30 @@ export class BlockstoreLevel implements Blockstore {
     return this.db.close();
   }
 
-  async partition(name: string): Promise<BlockstoreLevel> {
-    const db = await this.db.partition(name);
+  async partition(name: Key): Promise<BlockstoreLevel> {
+    const db = await this.db.partition(String(name));
     return new BlockstoreLevel({ ...this.config, location: '' }, db);
   }
 
-  async put(key: CID | string, val: Uint8Array, options?: Options): Promise<void> {
+  async put(key: Key, val: Uint8Array, options?: Options): Promise<void> {
     return this.db.put(String(key), val, options);
   }
 
-  async get(key: CID | string, options?: Options): Promise<Uint8Array> {
+  async get(key: Key, options?: Options): Promise<Uint8Array> {
     return this.db.get(String(key), options);
   }
 
-  async has(key: CID | string, options?: Options): Promise<boolean> {
+  async has(key: Key, options?: Options): Promise<boolean> {
     return this.db.has(String(key), options);
   }
 
-  async delete(key: CID | string, options?: Options): Promise<void> {
+  async * iterator(options?: Options): AsyncGenerator<[string, Uint8Array]> {
+    for await (const entry of this.db.iterator({ }, options)) {
+      yield entry;
+    }
+  }
+
+  async delete(key: Key, options?: Options): Promise<void> {
     return this.db.delete(String(key), options);
   }
 

--- a/src/store/level-wrapper.ts
+++ b/src/store/level-wrapper.ts
@@ -93,7 +93,7 @@ export class LevelWrapper<V> {
     await abortOr(options?.signal, this.createLevelDatabase());
 
     try {
-      const value = await abortOr(options?.signal, this.db.get(String(key)));
+      const value = await abortOr(options?.signal, this.db.get(key));
       return value;
     } catch (error) {
       // `Level`` throws an error if the key is not present.  Return `undefined` in this case.
@@ -138,7 +138,7 @@ export class LevelWrapper<V> {
 
     await abortOr(options?.signal, this.createLevelDatabase());
 
-    return abortOr(options?.signal, this.db.put(String(key), value));
+    return abortOr(options?.signal, this.db.put(key, value));
   }
 
   async delete(key: string, options?: LevelWrapperOptions): Promise<void> {
@@ -146,7 +146,7 @@ export class LevelWrapper<V> {
 
     await abortOr(options?.signal, this.createLevelDatabase());
 
-    return abortOr(options?.signal, this.db.del(String(key)));
+    return abortOr(options?.signal, this.db.del(key));
   }
 
   async isEmpty(options?: LevelWrapperOptions): Promise<boolean> {

--- a/src/store/upload-store-level.ts
+++ b/src/store/upload-store-level.ts
@@ -1,0 +1,196 @@
+import type { ImportResult } from 'ipfs-unixfs-importer';
+import type { Readable } from 'readable-stream';
+import type { UnixFSEntry } from 'ipfs-unixfs-exporter';
+import type { UploadCompleteResult, UploadPartResult, UploadStore, UploadStoreOptions } from './upload-store.js';
+
+import { abortOr } from '../utils/abort.js';
+import { BlockstoreLevel } from './blockstore-level.js';
+import { Cid } from '../utils/cid.js';
+import { createLevelDatabase } from './level-wrapper.js';
+import { DataStream } from '../utils/data-stream.js';
+import { Encoder } from '../utils/encoder.js';
+import { exporter } from 'ipfs-unixfs-exporter';
+import { importer } from 'ipfs-unixfs-importer';
+import { sum } from '../utils/array.js';
+
+const DATA_PARTITION = 'data';
+const ROOT_PARTITION = 'root';
+
+/**
+ * A simple implementation of {@link UploadStore} that works in both the browser and server-side.
+ * Leverages LevelDB under the hood.
+ *
+ * It has the following structure (`+` represents a sublevel and `->` represents a key->value pair):
+ *   '<tenant>' + <recordId> + 'data' + <index> -> <data>
+ *   '<tenant>' + <recordId> + 'root' + <index> -> <dataCid>
+ *
+ * This allows for the <data> to be stored without having to provide it's `<dataCid>` upfront, which
+ * is especially necessary when getting _all_ the data for a <recordId> for a <tenant>, as the root
+ * <dataCid> can be retrieved for each <index> internally (i.e. not needing the client to provide
+ * each <dataCid> for each part).
+ */
+export class UploadStoreLevel implements UploadStore {
+  config: UploadStoreLevelConfig;
+
+  blockstore: BlockstoreLevel;
+
+  constructor(config: UploadStoreLevelConfig = { }) {
+    this.config = {
+      blockstoreLocation: 'UPLOADSTORE',
+      createLevelDatabase,
+      ...config
+    };
+
+    this.blockstore = new BlockstoreLevel({
+      location            : this.config.blockstoreLocation,
+      createLevelDatabase : this.config.createLevelDatabase,
+    });
+  }
+
+  async open(): Promise<void> {
+    await this.blockstore.open();
+  }
+
+  async close(): Promise<void> {
+    await this.blockstore.close();
+  }
+
+  async start(_tenant: string, _recordId: string, _dataFormat: string, options?: UploadStoreOptions): Promise<boolean> {
+    options?.signal?.throwIfAborted();
+
+    return true;
+  }
+
+  async part(tenant: string, recordId: string, index: number, dataStream: Readable, options?: UploadStoreOptions): Promise<UploadPartResult> {
+    options?.signal?.throwIfAborted();
+
+    const partitionsForRecord = await abortOr(options?.signal, this.blockstore.partition(tenant));
+    const indexesForPartition = await abortOr(options?.signal, partitionsForRecord.partition(recordId));
+
+    const blocksForIndex = await abortOr(options?.signal, indexesForPartition.partition(DATA_PARTITION));
+    const blocks = await abortOr(options?.signal, blocksForIndex.partition(index));
+
+    const asyncDataBlocks = importer([{ content: dataStream }], blocks, { cidVersion: 1 });
+
+    // NOTE: the last block contains the root CID as well as info to derive the data size
+    let dataDagRoot: ImportResult;
+    for await (dataDagRoot of asyncDataBlocks) {
+      options?.signal?.throwIfAborted();
+    }
+
+    const dataCid = String(dataDagRoot.cid);
+    const dataSize = Number(dataDagRoot.unixfs?.fileSize() ?? dataDagRoot.size);
+
+    const rootForIndex = await abortOr(options?.signal, indexesForPartition.partition(ROOT_PARTITION));
+
+    await rootForIndex.put(index, Encoder.stringToBytes(dataCid), options);
+
+    return { dataCid, dataSize };
+  }
+
+  async complete(tenant: string, recordId: string, count: number, options?: UploadStoreOptions): Promise<UploadCompleteResult> {
+    options?.signal?.throwIfAborted();
+
+    const partitionsForRecord = await abortOr(options?.signal, this.blockstore.partition(tenant));
+    const indexesForPartition = await abortOr(options?.signal, partitionsForRecord.partition(recordId));
+
+    const blocksForIndex = await abortOr(options?.signal, indexesForPartition.partition(DATA_PARTITION));
+    const rootForIndex = await abortOr(options?.signal, indexesForPartition.partition(ROOT_PARTITION));
+
+    const dataCids: Uint8Array[] = Array(count).fill(new Uint8Array());
+    const dataSizes: number[] = Array(count).fill(0);
+
+    for await (const [ indexString, rootDataCidBytes ] of rootForIndex.iterator()) {
+      options?.signal?.throwIfAborted();
+
+      const index = Number(indexString);
+
+      const blocks = await abortOr(options?.signal, blocksForIndex.partition(indexString));
+
+      if (index < count) {
+        const rootDataCid = Encoder.bytesToString(rootDataCidBytes);
+        const dataDagRoot = await abortOr<UnixFSEntry>(options?.signal, exporter(rootDataCid, blocks));
+
+        dataCids[index] = Encoder.stringToBytes(dataDagRoot.cid);
+        dataSizes[index] = Number(dataDagRoot.unixfs?.fileSize() ?? dataDagRoot.size);
+      } else {
+        await abortOr(options?.signal, blocks.clear());
+        await rootForIndex.delete(indexString, options);
+      }
+    }
+
+    return {
+      dataCid  : await Cid.computeDagPbCidFromStream(DataStream.fromIterable(dataCids)),
+      dataSize : sum(dataSizes)
+    };
+  }
+
+  async has(tenant: string, recordId: string, options?: UploadStoreOptions): Promise<boolean> {
+    options?.signal?.throwIfAborted();
+
+    const partitionsForRecord = await abortOr(options?.signal, this.blockstore.partition(tenant));
+    const indexesForPartition = await abortOr(options?.signal, partitionsForRecord.partition(recordId));
+
+    const empty = await abortOr(options?.signal, indexesForPartition.isEmpty());
+    return !empty;
+  }
+
+  async get(tenant: string, recordId: string, options?: UploadStoreOptions): Promise<Readable | undefined> {
+    options?.signal?.throwIfAborted();
+
+    const partitionsForRecord = await abortOr(options?.signal, this.blockstore.partition(tenant));
+    const indexesForPartition = await abortOr(options?.signal, partitionsForRecord.partition(recordId));
+
+    const empty = await abortOr(options?.signal, indexesForPartition.isEmpty());
+    if (empty) {
+      return undefined;
+    }
+
+    const blocksForIndex = await abortOr(options?.signal, indexesForPartition.partition(DATA_PARTITION));
+    const rootForIndex = await abortOr(options?.signal, indexesForPartition.partition(ROOT_PARTITION));
+
+    return DataStream.fromAsyncIterator((async function*(): AsyncGenerator<Uint8Array> {
+      for (let index = 0; true; ++index) {
+        const rootDataCidBytes = await rootForIndex.get(index, options);
+        if (!rootDataCidBytes) {
+          break;
+        }
+
+        const blocks = await abortOr(options?.signal, blocksForIndex.partition(index));
+
+        const rootDataCid = Encoder.bytesToString(rootDataCidBytes);
+        const dataDagRoot = await abortOr<UnixFSEntry>(options?.signal, exporter(rootDataCid, blocks));
+
+        for await (const block of dataDagRoot.content()) {
+          options?.signal?.throwIfAborted();
+
+          yield block;
+        }
+      }
+    })());
+  }
+
+  async delete(tenant: string, recordId: string, options?: UploadStoreOptions): Promise<void> {
+    options?.signal?.throwIfAborted();
+
+    const recordForTenant = await abortOr(options?.signal, this.blockstore.partition(tenant));
+    const indexForRecord = await abortOr(options?.signal, recordForTenant.partition(recordId));
+
+    await abortOr(options?.signal, indexForRecord.clear());
+  }
+
+  async clear(): Promise<void> {
+    await this.blockstore.clear();
+  }
+
+  async dump(): Promise<void> {
+    console.group('blockstore');
+    await this.blockstore['dump']?.();
+    console.groupEnd();
+  }
+}
+
+type UploadStoreLevelConfig = {
+  blockstoreLocation?: string,
+  createLevelDatabase?: typeof createLevelDatabase,
+};

--- a/src/store/upload-store.ts
+++ b/src/store/upload-store.ts
@@ -1,0 +1,33 @@
+import type { Readable } from 'readable-stream';
+
+export interface UploadStoreOptions {
+  signal?: AbortSignal;
+}
+
+export interface UploadStore {
+  open(): Promise<void>;
+
+  close(): Promise<void>;
+
+  start(tenant: string, recordId: string, dataFormat: string, options?: UploadStoreOptions): Promise<boolean>;
+
+  part(tenant: string, recordId: string, index: number, dataStream: Readable, options?: UploadStoreOptions): Promise<UploadPartResult>;
+
+  complete(tenant: string, recordId: string, count: number, options?: UploadStoreOptions): Promise<UploadCompleteResult>;
+
+  has(tenant: string, recordId: string, options?: UploadStoreOptions): Promise<boolean>;
+
+  get(tenant: string, recordId: string, options?: UploadStoreOptions): Promise<Readable | undefined>;
+
+  delete(tenant: string, recordId: string, options?: UploadStoreOptions): Promise<void>;
+}
+
+export type UploadPartResult = {
+  dataCid: string;
+  dataSize: number;
+};
+
+export type UploadCompleteResult = {
+  dataCid: string;
+  dataSize: number;
+};

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -9,3 +9,11 @@ export async function asyncGeneratorToArray<T>(iterator: AsyncGenerator<T>): Pro
   }
   return array;
 }
+
+export function sum(iterable: Iterable<number>): number {
+  let result = 0;
+  for (const value of iterable) {
+    result += value;
+  }
+  return result;
+}

--- a/src/utils/cid.ts
+++ b/src/utils/cid.ts
@@ -2,9 +2,9 @@ import * as cbor from '@ipld/dag-cbor';
 
 import type { Readable } from 'readable-stream';
 
+import { BaseBlockstore } from 'blockstore-core';
 import { CID } from 'multiformats/cid';
 import { importer } from 'ipfs-unixfs-importer';
-import { MemoryBlockstore } from 'blockstore-core';
 import { sha256 } from 'multiformats/hashes/sha2';
 
 // a map of all supported CID hashing algorithms. This map is used to select the appropriate hasher
@@ -65,6 +65,9 @@ export function parseCid(str: string): CID {
   return cid;
 }
 
+class FakeBlockstore extends BaseBlockstore {
+  async put(): Promise<void> { }
+}
 
 /**
  * Utility class for creating CIDs. Exported for the convenience of developers.
@@ -74,7 +77,7 @@ export class Cid {
    * @returns V1 CID of the DAG comprised by chunking data into unixfs DAG-PB encoded blocks
    */
   public static async computeDagPbCidFromBytes(content: Uint8Array): Promise<string> {
-    const asyncDataBlocks = importer([{ content }], new MemoryBlockstore(), { cidVersion: 1 });
+    const asyncDataBlocks = importer([{ content }], new FakeBlockstore(), { cidVersion: 1 });
 
     // NOTE: the last block contains the root CID
     let block;
@@ -87,7 +90,7 @@ export class Cid {
    * @returns V1 CID of the DAG comprised by chunking data into unixfs DAG-PB encoded blocks
    */
   public static async computeDagPbCidFromStream(dataStream: Readable): Promise<string> {
-    const asyncDataBlocks = importer([{ content: dataStream }], new MemoryBlockstore(), { cidVersion: 1 });
+    const asyncDataBlocks = importer([{ content: dataStream }], new FakeBlockstore(), { cidVersion: 1 });
 
     // NOTE: the last block contains the root CID
     let block;

--- a/src/utils/data-stream.ts
+++ b/src/utils/data-stream.ts
@@ -73,4 +73,31 @@ export class DataStream {
     const bytes = Encoder.objectToBytes(object);
     return DataStream.fromBytes(bytes);
   }
+
+  /**
+   * Creates a readable stream from the async iterator given.
+   */
+  public static fromAsyncIterator(iterator: Iterator<Uint8Array> | Iterator<Promise<Uint8Array>> | AsyncIterator<Uint8Array>): Readable {
+    return new Readable({
+      async read(): Promise<void> {
+        const result = await iterator.next();
+        if (result.done) {
+          this.push(null); // end the stream
+        } else {
+          this.push(result.value);
+        }
+      }
+    });
+  }
+
+  /**
+   * Creates a readable stream from the iterable given.
+   */
+  public static fromIterable(iterable: Iterable<Uint8Array> | Iterable<Promise<Uint8Array>>): Readable {
+    return DataStream.fromAsyncIterator((async function*(): AsyncGenerator<Uint8Array> {
+      for (const promise of iterable) {
+        yield await promise;
+      }
+    })());
+  }
 }

--- a/tests/dwn.spec.ts
+++ b/tests/dwn.spec.ts
@@ -10,12 +10,14 @@ import { Dwn } from '../src/dwn.js';
 import { Message } from '../src/core/message.js';
 import { MessageStoreLevel } from '../src/store/message-store-level.js';
 import { TestDataGenerator } from './utils/test-data-generator.js';
+import { UploadStoreLevel } from '../src/store/upload-store-level.js';
 
 chai.use(chaiAsPromised);
 
 describe('DWN', () => {
   let messageStore: MessageStoreLevel;
   let dataStore: DataStoreLevel;
+  let uploadStore: UploadStoreLevel;
   let dwn: Dwn;
 
   before(async () => {
@@ -30,7 +32,11 @@ describe('DWN', () => {
       blockstoreLocation: 'TEST-DATASTORE'
     });
 
-    dwn = await Dwn.create({ messageStore, dataStore });
+    uploadStore = new UploadStoreLevel({
+      blockstoreLocation: 'TEST-UPLOADSTORE'
+    });
+
+    dwn = await Dwn.create({ messageStore, dataStore, uploadStore });
   });
 
   beforeEach(async () => {
@@ -125,8 +131,14 @@ describe('DWN', () => {
 
       const messageStoreStub = sinon.createStubInstance(MessageStoreLevel);
       const dataStoreStub = sinon.createStubInstance(DataStoreLevel);
+      const uploadStoreStub = sinon.createStubInstance(UploadStoreLevel);
 
-      const dwnWithConfig = await Dwn.create({ tenantGate: blockAllTenantGate, messageStore: messageStoreStub, dataStore: dataStoreStub });
+      const dwnWithConfig = await Dwn.create({
+        tenantGate   : blockAllTenantGate,
+        messageStore : messageStoreStub,
+        dataStore    : dataStoreStub,
+        uploadStore  : uploadStoreStub
+      });
       const alice = await DidKeyResolver.generate();
       const { requester, message } = await TestDataGenerator.generateRecordsQuery({ requester: alice });
 

--- a/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
@@ -12,7 +12,7 @@ import { Message } from '../../../../src/core/message.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
-
+import { UploadStoreLevel } from '../../../../src/store/upload-store-level.js';
 import { DidResolver, Dwn, Encoder, Jws } from '../../../../src/index.js';
 
 chai.use(chaiAsPromised);
@@ -21,6 +21,7 @@ describe('ProtocolsConfigureHandler.handle()', () => {
   let didResolver: DidResolver;
   let messageStore: MessageStoreLevel;
   let dataStore: DataStoreLevel;
+  let uploadStore: UploadStoreLevel;
   let dwn: Dwn;
 
   describe('functional tests', () => {
@@ -38,7 +39,11 @@ describe('ProtocolsConfigureHandler.handle()', () => {
         blockstoreLocation: 'TEST-DATASTORE'
       });
 
-      dwn = await Dwn.create({ didResolver, messageStore, dataStore });
+      uploadStore = new UploadStoreLevel({
+        blockstoreLocation: 'TEST-UPLOADSTORE'
+      });
+
+      dwn = await Dwn.create({ didResolver, messageStore, dataStore, uploadStore });
     });
 
     beforeEach(async () => {
@@ -47,6 +52,7 @@ describe('ProtocolsConfigureHandler.handle()', () => {
       // clean up before each test rather than after so that a test does not depend on other tests to do the clean up
       await messageStore.clear();
       await dataStore.clear();
+      await uploadStore.clear();
     });
 
     after(async () => {

--- a/tests/interfaces/protocols/handlers/protocols-query.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-query.spec.ts
@@ -8,7 +8,7 @@ import { GeneralJwsSigner } from '../../../../src/jose/jws/general/signer.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
-
+import { UploadStoreLevel } from '../../../../src/store/upload-store-level.js';
 import { DidResolver, Dwn, Encoder, Jws } from '../../../../src/index.js';
 
 chai.use(chaiAsPromised);
@@ -17,6 +17,7 @@ describe('ProtocolsQueryHandler.handle()', () => {
   let didResolver: DidResolver;
   let messageStore: MessageStoreLevel;
   let dataStore: DataStoreLevel;
+  let uploadStore: UploadStoreLevel;
   let dwn: Dwn;
 
   describe('functional tests', () => {
@@ -34,7 +35,11 @@ describe('ProtocolsQueryHandler.handle()', () => {
         blockstoreLocation: 'TEST-DATASTORE'
       });
 
-      dwn = await Dwn.create({ didResolver, messageStore, dataStore });
+      uploadStore = new UploadStoreLevel({
+        blockstoreLocation: 'TEST-UPLOADSTORE'
+      });
+
+      dwn = await Dwn.create({ didResolver, messageStore, dataStore, uploadStore });
     });
 
     beforeEach(async () => {
@@ -43,6 +48,7 @@ describe('ProtocolsQueryHandler.handle()', () => {
       // clean up before each test rather than after so that a test does not depend on other tests to do the clean up
       await messageStore.clear();
       await dataStore.clear();
+      await uploadStore.clear();
     });
 
     after(async () => {

--- a/tests/interfaces/records/handlers/records-delete.spec.ts
+++ b/tests/interfaces/records/handlers/records-delete.spec.ts
@@ -11,6 +11,7 @@ import { MessageStoreLevel } from '../../../../src/store/message-store-level.js'
 import { RecordsDeleteHandler } from '../../../../src/interfaces/records/handlers/records-delete.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
+import { UploadStoreLevel } from '../../../../src/store/upload-store-level.js';
 import { DidResolver, Dwn, Encoder, Jws, RecordsDelete } from '../../../../src/index.js';
 
 chai.use(chaiAsPromised);
@@ -19,6 +20,7 @@ describe('RecordsDeleteHandler.handle()', () => {
   let didResolver: DidResolver;
   let messageStore: MessageStoreLevel;
   let dataStore: DataStoreLevel;
+  let uploadStore: UploadStoreLevel;
   let dwn: Dwn;
 
   describe('functional tests', () => {
@@ -36,7 +38,11 @@ describe('RecordsDeleteHandler.handle()', () => {
         blockstoreLocation: 'TEST-DATASTORE'
       });
 
-      dwn = await Dwn.create({ didResolver, messageStore, dataStore });
+      uploadStore = new UploadStoreLevel({
+        blockstoreLocation: 'TEST-UPLOADSTORE'
+      });
+
+      dwn = await Dwn.create({ didResolver, messageStore, dataStore, uploadStore });
     });
 
     beforeEach(async () => {
@@ -45,6 +51,7 @@ describe('RecordsDeleteHandler.handle()', () => {
       // clean up before each test rather than after so that a test does not depend on other tests to do the clean up
       await messageStore.clear();
       await dataStore.clear();
+      await uploadStore.clear();
     });
 
     after(async () => {
@@ -511,8 +518,9 @@ describe('RecordsDeleteHandler.handle()', () => {
     const didResolver = TestStubGenerator.createDidResolverStub(mismatchingPersona);
     const messageStore = sinon.createStubInstance(MessageStoreLevel);
     const dataStore = sinon.createStubInstance(DataStoreLevel);
+    const uploadStore = sinon.createStubInstance(UploadStoreLevel);
 
-    const recordsDeleteHandler = new RecordsDeleteHandler(didResolver, messageStore, dataStore);
+    const recordsDeleteHandler = new RecordsDeleteHandler(didResolver, messageStore, dataStore, uploadStore);
     const reply = await recordsDeleteHandler.handle({ tenant, message });
     expect(reply.status.code).to.equal(401);
   });
@@ -524,8 +532,9 @@ describe('RecordsDeleteHandler.handle()', () => {
     // setting up a stub method resolver & message store
     const messageStore = sinon.createStubInstance(MessageStoreLevel);
     const dataStore = sinon.createStubInstance(DataStoreLevel);
+    const uploadStore = sinon.createStubInstance(UploadStoreLevel);
 
-    const recordsDeleteHandler = new RecordsDeleteHandler(didResolver, messageStore, dataStore);
+    const recordsDeleteHandler = new RecordsDeleteHandler(didResolver, messageStore, dataStore, uploadStore);
 
     // stub the `parse()` function to throw an error
     sinon.stub(RecordsDelete, 'parse').throws('anyError');

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -4,6 +4,7 @@ import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
 
+import { constructRecordsWriteIndexes } from '../../../../src/interfaces/records/handlers/records-write.js';
 import { DataStoreLevel } from '../../../../src/store/data-store-level.js';
 import { DidKeyResolver } from '../../../../src/did/did-key-resolver.js';
 import { DwnConstant } from '../../../../src/core/dwn-constant.js';
@@ -15,8 +16,7 @@ import { StorageController } from '../../../../src/store/storage-controller.js';
 import { Temporal } from '@js-temporal/polyfill';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
-
-import { constructRecordsWriteIndexes } from '../../../../src/interfaces/records/handlers/records-write.js';
+import { UploadStoreLevel } from '../../../../src/store/upload-store-level.js';
 import { DateSort, RecordsQuery } from '../../../../src/interfaces/records/messages/records-query.js';
 import { DidResolver, Dwn } from '../../../../src/index.js';
 
@@ -27,6 +27,7 @@ describe('RecordsQueryHandler.handle()', () => {
     let didResolver: DidResolver;
     let messageStore: MessageStoreLevel;
     let dataStore: DataStoreLevel;
+    let uploadStore: UploadStoreLevel;
     let dwn: Dwn;
 
     before(async () => {
@@ -43,7 +44,11 @@ describe('RecordsQueryHandler.handle()', () => {
         blockstoreLocation: 'TEST-DATASTORE'
       });
 
-      dwn = await Dwn.create({ didResolver, messageStore, dataStore });
+      uploadStore = new UploadStoreLevel({
+        blockstoreLocation: 'TEST-UPLOADSTORE'
+      });
+
+      dwn = await Dwn.create({ didResolver, messageStore, dataStore, uploadStore });
     });
 
     beforeEach(async () => {
@@ -52,6 +57,7 @@ describe('RecordsQueryHandler.handle()', () => {
       // clean up before each test rather than after so that a test does not depend on other tests to do the clean up
       await messageStore.clear();
       await dataStore.clear();
+      await uploadStore.clear();
     });
 
     after(async () => {

--- a/tests/interfaces/records/handlers/records-read.spec.ts
+++ b/tests/interfaces/records/handlers/records-read.spec.ts
@@ -9,7 +9,7 @@ import { MessageStoreLevel } from '../../../../src/store/message-store-level.js'
 import { RecordsReadHandler } from '../../../../src/interfaces/records/handlers/records-read.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
-
+import { UploadStoreLevel } from '../../../../src/store/upload-store-level.js';
 import { DataStream, DidResolver, Dwn, Jws, RecordsDelete, RecordsRead } from '../../../../src/index.js';
 
 chai.use(chaiAsPromised);
@@ -18,6 +18,7 @@ describe('RecordsReadHandler.handle()', () => {
   let didResolver: DidResolver;
   let messageStore: MessageStoreLevel;
   let dataStore: DataStoreLevel;
+  let uploadStore: UploadStoreLevel;
   let dwn: Dwn;
 
   describe('functional tests', () => {
@@ -35,7 +36,11 @@ describe('RecordsReadHandler.handle()', () => {
         blockstoreLocation: 'TEST-DATASTORE'
       });
 
-      dwn = await Dwn.create({ didResolver, messageStore, dataStore });
+      uploadStore = new UploadStoreLevel({
+        blockstoreLocation: 'TEST-UPLOADSTORE'
+      });
+
+      dwn = await Dwn.create({ didResolver, messageStore, dataStore, uploadStore });
     });
 
     beforeEach(async () => {
@@ -44,6 +49,7 @@ describe('RecordsReadHandler.handle()', () => {
       // clean up before each test rather than after so that a test does not depend on other tests to do the clean up
       await messageStore.clear();
       await dataStore.clear();
+      await uploadStore.clear();
     });
 
     after(async () => {
@@ -217,8 +223,9 @@ describe('RecordsReadHandler.handle()', () => {
     const didResolver = TestStubGenerator.createDidResolverStub(mismatchingPersona);
     const messageStore = sinon.createStubInstance(MessageStoreLevel);
     const dataStore = sinon.createStubInstance(DataStoreLevel);
+    const uploadStore = sinon.createStubInstance(UploadStoreLevel);
 
-    const recordsReadHandler = new RecordsReadHandler(didResolver, messageStore, dataStore);
+    const recordsReadHandler = new RecordsReadHandler(didResolver, messageStore, dataStore, uploadStore);
     const reply = await recordsReadHandler.handle({ tenant: alice, message: recordsRead.message });
     expect(reply.status.code).to.equal(401);
   });
@@ -233,8 +240,9 @@ describe('RecordsReadHandler.handle()', () => {
     // setting up a stub method resolver & message store
     const messageStore = sinon.createStubInstance(MessageStoreLevel);
     const dataStore = sinon.createStubInstance(DataStoreLevel);
+    const uploadStore = sinon.createStubInstance(UploadStoreLevel);
 
-    const recordsReadHandler = new RecordsReadHandler(didResolver, messageStore, dataStore);
+    const recordsReadHandler = new RecordsReadHandler(didResolver, messageStore, dataStore, uploadStore);
 
     // stub the `parse()` function to throw an error
     sinon.stub(RecordsRead, 'parse').throws('anyError');

--- a/tests/store/upload-store.spec.ts
+++ b/tests/store/upload-store.spec.ts
@@ -1,0 +1,128 @@
+import chaiAsPromised from 'chai-as-promised';
+import chai, { expect } from 'chai';
+
+import { asyncGeneratorToArray } from '../../src/utils/array.js';
+import { Cid } from '../../src/utils/cid.js';
+import { DataStream } from '../../src/index.js';
+import { TestDataGenerator } from '../utils/test-data-generator.js';
+import { UploadStoreLevel } from '../../src/store/upload-store-level.js';
+
+chai.use(chaiAsPromised);
+
+let store: UploadStoreLevel;
+
+describe('UploadStore Test Suite', () => {
+  before(async () => {
+    store = new UploadStoreLevel({ blockstoreLocation: 'TEST-UPLOADSTORE' });
+    await store.open();
+  });
+
+  beforeEach(async () => {
+    await store.clear(); // clean up before each test rather than after so that a test does not depend on other tests to do the clean up
+  });
+
+  after(async () => {
+    await store.close();
+  });
+
+  describe('part', function () {
+    it('should return the correct size of the data stored', async () => {
+      const tenant = await TestDataGenerator.randomCborSha256Cid();
+      const recordId = await TestDataGenerator.randomCborSha256Cid();
+
+      let index = 0;
+      let dataSize = 10;
+
+      // iterate through order of magnitude in size until hitting 10MB
+      while (dataSize <= 10_000_000) {
+        const dataBytes = TestDataGenerator.randomBytes(dataSize);
+        const dataStream = DataStream.fromBytes(dataBytes);
+        const dataCid = await Cid.computeDagPbCidFromBytes(dataBytes);
+
+        const result = await store.part(tenant, recordId, index, dataStream);
+
+        expect(result.dataCid).to.equal(dataCid);
+        expect(result.dataSize).to.equal(dataSize);
+
+        ++index;
+        dataSize *= 10;
+      }
+    });
+  });
+
+  describe('complete', function () {
+    it('should delete all extra data', async () => {
+      const tenant = await TestDataGenerator.randomCborSha256Cid();
+      const recordId = await TestDataGenerator.randomCborSha256Cid();
+
+      const count = 2;
+      const dataSize = 1_000_000;
+
+      const dataBytes = TestDataGenerator.randomBytes(dataSize);
+      const dataCid = await Cid.computeDagPbCidFromBytes(dataBytes);
+
+      for (let index = 0; index < count * 2; ++index) {
+        await store.part(tenant, recordId, index, DataStream.fromBytes(dataBytes));
+      }
+
+      const keysBeforeDelete = await asyncGeneratorToArray(store.blockstore.db.keys());
+      expect(keysBeforeDelete.length).to.equal(24);
+
+      const result = await store.complete(tenant, recordId, count);
+
+      expect(result.dataCid).to.equal(await Cid.computeDagPbCidFromStream(DataStream.fromIterable(Array(count).fill(dataCid))));
+      expect(result.dataSize).to.equal(dataSize * count);
+
+      const keysAfterDelete = await asyncGeneratorToArray(store.blockstore.db.keys());
+      expect(keysAfterDelete.length).to.equal(12);
+    });
+  });
+
+  describe('get', function () {
+    it('should return `undefined` if unable to find the data specified', async () => {
+      const tenant = await TestDataGenerator.randomCborSha256Cid();
+      const recordId = await TestDataGenerator.randomCborSha256Cid();
+
+      const result = await store.get(tenant, recordId);
+
+      expect(result).to.be.undefined;
+    });
+
+    it('should assemble all parts', async () => {
+      const tenant = await TestDataGenerator.randomCborSha256Cid();
+      const recordId = await TestDataGenerator.randomCborSha256Cid();
+
+      const dataBytes = TestDataGenerator.randomBytes(1_000_000);
+
+      await store.part(tenant, recordId, 0, DataStream.fromBytes(dataBytes));
+      await store.part(tenant, recordId, 1, DataStream.fromBytes(dataBytes));
+      await store.part(tenant, recordId, 2, DataStream.fromBytes(dataBytes));
+
+      const stream = await store.get(tenant, recordId);
+      const storedDataBytes = await DataStream.toBytes(stream);
+
+      expect([ ...storedDataBytes ]).to.eql([ ...dataBytes, ...dataBytes, ...dataBytes ]);
+    });
+  });
+
+  describe('delete', function () {
+    it('should not leave anything behind when deleting a the root CID', async () => {
+      const tenant = await TestDataGenerator.randomCborSha256Cid();
+      const recordId = await TestDataGenerator.randomCborSha256Cid();
+
+      const dataBytes = TestDataGenerator.randomBytes(1_000_000);
+
+      for (let index = 0; index < 5; ++index) {
+        await store.part(tenant, recordId, index, DataStream.fromBytes(dataBytes));
+      }
+
+      const keysBeforeDelete = await asyncGeneratorToArray(store.blockstore.db.keys());
+      expect(keysBeforeDelete.length).to.equal(30);
+
+      await store.delete(tenant, recordId);
+
+      const keysAfterDelete = await asyncGeneratorToArray(store.blockstore.db.keys());
+      expect(keysAfterDelete.length).to.equal(0);
+    });
+  });
+});


### PR DESCRIPTION
rather than try to shove everything into a single `RecordsWrite`, allow for clients to send data in multiple parts that are assembled on the receiving end

the following new messages are added:

- `RecordsUploadStart` indicates that an upload is now beginning
- `RecordsUploadPart` contains a chunk of data and an `index` indicating where in the overall whole it belonds
- `RecordsUploadComplete` gives a final `count` of the number of `RecordsUploadPart` and the `dataFormat` it should use

with these new messages, there are new expectations:

- all `RecordsUpload*` for the same upload must have the same `recordId`
- there can never be more than one `RecordsUploadStart` for a `recordId`
- each `RecordsUploadPart` must provide a `dataCid` and `dataSize` corresponding to the `dataStream`
- each `index` must be unique across all `RecordsUploadPart`
- there can not be any `RecordsUpload*` after a `RecordsUploadComplete` for a `recordId`
- the `RecordsUploadComplete` must provide a `dataCid` and `dataSize` computed by combining all of the `RecordsUploadPart`
- any extra `index` beyond the `count` are deleted when handling the `RecordsUploadComplete`
- `RecordsWrite` cannot use the same `recordId` as `RecordsUpload*`

the default storage mechanism for `RecordsUpload*` is `UploadStoreLevel`, which has the following structure (`+` represents a sublevel and `->` represents a key->value pair):

```
  '<tenant>' + <recordId> + 'data' + <index> -> <data>
  '<tenant>' + <recordId> + 'root' + <index> -> <dataCid>
```

this allows for the `<data>` to be stored without having to provide it's `<dataCid>` upfront, which is especially necessary when getting _all_ the data for a `<recordId>` for a `<tenant>`, as the root `<dataCid>` can be retrieved for each `<index>` internally (i.e. not needing the client to provide each `<dataCid>` for each part).