### PR TITLE
return the parsed message if `processMessage` is successful

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-93.68%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-92.29%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-90.8%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.68%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-93.66%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-92.29%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-90.76%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.66%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/src/core/message-reply.ts
+++ b/src/core/message-reply.ts
@@ -1,5 +1,6 @@
-import type { QueryResultEntry } from './types.js';
+import type { Message } from './message.js';
 import type { Readable } from 'readable-stream';
+import type { BaseMessage, QueryResultEntry } from './types.js';
 
 type Status = {
   code: number
@@ -8,12 +9,15 @@ type Status = {
 
 type MessageReplyOptions = {
   status: Status,
+  message?: Message<BaseMessage>,
   entries?: QueryResultEntry[];
   data? : Readable;
 };
 
 export class MessageReply {
   status: Status;
+
+  message?: Message<BaseMessage>;
 
   /**
    * Resulting message entries returned from the invocation of the corresponding message.
@@ -29,9 +33,10 @@ export class MessageReply {
   data?: Readable;
 
   constructor(opts: MessageReplyOptions) {
-    const { status, entries, data } = opts;
+    const { status, message, entries, data } = opts;
 
     this.status = status;
+    this.message = message;
     this.entries = entries;
     this.data = data;
   }

--- a/src/interfaces/permissions/handlers/permissions-request.ts
+++ b/src/interfaces/permissions/handlers/permissions-request.ts
@@ -36,7 +36,8 @@ export class PermissionsRequestHandler implements MethodHandler {
     await this.messageStore.put(tenant, message, index as any); // FIXME
 
     return new MessageReply({
-      status: { code: 202, detail: 'Accepted' }
+      status  : { code: 202, detail: 'Accepted' },
+      message : permissionRequest
     });
   };
 }

--- a/src/interfaces/protocols/handlers/protocols-configure.ts
+++ b/src/interfaces/protocols/handlers/protocols-configure.ts
@@ -62,7 +62,8 @@ export class ProtocolsConfigureHandler implements MethodHandler {
       await StorageController.put(this.messageStore, this.dataStore, tenant, message, indexes as any, dataStream);
 
       messageReply = new MessageReply({
-        status: { code: 202, detail: 'Accepted' }
+        status  : { code: 202, detail: 'Accepted' },
+        message : protocolsConfigure
       });
     } else {
       messageReply = new MessageReply({

--- a/src/interfaces/protocols/handlers/protocols-query.ts
+++ b/src/interfaces/protocols/handlers/protocols-query.ts
@@ -49,7 +49,8 @@ export class ProtocolsQueryHandler implements MethodHandler {
     }
 
     return new MessageReply({
-      status: { code: 200, detail: 'OK' },
+      status  : { code: 200, detail: 'OK' },
+      message : protocolsQuery,
       entries
     });
   };

--- a/src/interfaces/records/handlers/records-delete.ts
+++ b/src/interfaces/records/handlers/records-delete.ts
@@ -61,7 +61,8 @@ export class RecordsDeleteHandler implements MethodHandler {
       await this.messageStore.put(tenant, message, indexes);
 
       messageReply = new MessageReply({
-        status: { code: 202, detail: 'Accepted' }
+        status  : { code: 202, detail: 'Accepted' },
+        message : recordsDelete
       });
     } else {
       messageReply = new MessageReply({

--- a/src/interfaces/records/handlers/records-query.ts
+++ b/src/interfaces/records/handlers/records-query.ts
@@ -53,7 +53,8 @@ export class RecordsQueryHandler implements MethodHandler {
     }
 
     return new MessageReply({
-      status: { code: 200, detail: 'OK' },
+      status  : { code: 200, detail: 'OK' },
+      message : recordsQuery,
       entries
     });
   }

--- a/src/interfaces/records/handlers/records-read.ts
+++ b/src/interfaces/records/handlers/records-read.ts
@@ -74,8 +74,9 @@ export class RecordsReadHandler implements MethodHandler {
     }
 
     const messageReply = new MessageReply({
-      status : { code: 200, detail: 'OK' },
-      data   : result.dataStream
+      status  : { code: 200, detail: 'OK' },
+      message : recordsRead,
+      data    : result.dataStream
     });
     return messageReply;
   };

--- a/src/interfaces/records/handlers/records-write.ts
+++ b/src/interfaces/records/handlers/records-write.ts
@@ -88,7 +88,8 @@ export class RecordsWriteHandler implements MethodHandler {
       }
 
       messageReply = new MessageReply({
-        status: { code: 202, detail: 'Accepted' }
+        status  : { code: 202, detail: 'Accepted' },
+        message : recordsWrite
       });
     } else {
       messageReply = new MessageReply({

--- a/src/interfaces/records/messages/records-read.ts
+++ b/src/interfaces/records/messages/records-read.ts
@@ -13,22 +13,7 @@ export type RecordsReadOptions = {
   authorizationSignatureInput: SignatureInput;
 };
 
-export class RecordsRead {
-  /**
-   * RecordsRead message adhering to the DWN specification.
-   */
-  readonly message: RecordsReadMessage;
-
-  readonly author: string | undefined;
-
-  private constructor(message: RecordsReadMessage) {
-    this.message = message;
-
-    // introduce AuthorizationEnforcedOperation and
-    if (message.authorization !== undefined) {
-      this.author = Message.getAuthor(message as BaseMessage);
-    }
-  }
+export class RecordsRead extends Message<RecordsReadMessage> {
 
   public static async parse(message: RecordsReadMessage): Promise<RecordsRead> {
     if (message.authorization !== undefined) {

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -132,6 +132,7 @@ export type GenerateRecordsQueryInput = {
 
 export type GenerateRecordsQueryOutput = {
   requester: Persona;
+  recordsQuery: RecordsQuery;
   message: RecordsQueryMessage;
 };
 
@@ -370,11 +371,11 @@ export class TestDataGenerator {
     removeUndefinedProperties(options);
 
     const recordsQuery = await RecordsQuery.create(options);
-    const message = recordsQuery.message as RecordsQueryMessage;
 
     return {
       requester,
-      message
+      recordsQuery,
+      message: recordsQuery.message
     };
   };
 


### PR DESCRIPTION
this will make it easier for clients (e.g. `web5-js`) to use the actual `class` object instead of having to manipulate JSON