### PR TITLE
Support protocol authorized reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-93.6%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.15%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.24%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.6%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-93.63%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.18%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.24%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.63%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-93.62%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.19%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.24%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.62%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-93.62%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.2%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.24%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.62%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-93.56%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.09%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.24%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.56%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-93.6%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.15%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.24%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.6%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-93.63%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.18%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.24%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.63%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-93.62%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.18%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.24%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.62%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-93.62%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.18%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.24%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.62%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-93.62%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.19%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.24%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.62%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/json-schemas/protocol-rule-set.json
+++ b/json-schemas/protocol-rule-set.json
@@ -6,91 +6,78 @@
   "properties": {
     "allow": {
       "type": "object",
-      "oneOf": [
-        {
+      "minProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "anyone": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "anyone": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "to": {
-                  "type": "array",
-                  "minItems": 1,
-                  "items": {
-                    "type": "string",
-                    "enum": [
-                      "write"
-                    ]
-                  }
-                }
-              },
-              "required": [
-                "to"
-              ]
+            "to": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "read",
+                  "write"
+                ]
+              }
             }
-          }
+          },
+          "required": [
+            "to"
+          ]
         },
-        {
+        "author": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "author": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "of": {
-                  "type": "string"
-                },
-                "to": {
-                  "type": "array",
-                  "minItems": 1,
-                  "items": {
-                    "type": "string",
-                    "enum": [
-                      "write"
-                    ]
-                  }
-                }
-              },
-              "required": [
-                "of",
-                "to"
-              ]
+            "of": {
+              "type": "string"
+            },
+            "to": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "read",
+                  "write"
+                ]
+              }
             }
-          }
+          },
+          "required": [
+            "of",
+            "to"
+          ]
         },
-        {
+        "recipient": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "recipient": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "of": {
-                  "type": "string"
-                },
-                "to": {
-                  "type": "array",
-                  "minItems": 1,
-                  "items": {
-                    "type": "string",
-                    "enum": [
-                      "write"
-                    ]
-                  }
-                }
-              },
-              "required": [
-                "of",
-                "to"
-              ]
+            "of": {
+              "type": "string"
+            },
+            "to": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "read",
+                  "write"
+                ]
+              }
             }
-          }
+          },
+          "required": [
+            "of",
+            "to"
+          ]
         }
-      ]
+      }
     },
     "records": {
       "type": "object",

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -1,13 +1,15 @@
 import type { MessageStore } from '../store/message-store.js';
-import type { RecordsWrite } from '../interfaces/records/messages/records-write.js';
+import type { RecordsRead } from '../interfaces/records/messages/records-read.js';
 import type { RecordsWriteMessage } from '../interfaces/records/types.js';
-import type { BaseMessage, Filter } from './types.js';
+import type { Filter, TimestampedMessage } from './types.js';
 import type { ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureMessage } from '../interfaces/protocols/types.js';
 
+import { RecordsWrite } from '../interfaces/records/messages/records-write.js';
 import { DwnInterfaceName, DwnMethodName, Message } from './message.js';
 
 const methodToAllowedActionMap: Record<string, string> = {
-  [DwnMethodName.Write]: 'write',
+  [DwnMethodName.Write] : 'write',
+  [DwnMethodName.Read]  : 'read',
 };
 
 export class ProtocolAuthorization {
@@ -18,15 +20,33 @@ export class ProtocolAuthorization {
    */
   public static async authorize(
     tenant: string,
-    recordsWrite: RecordsWrite,
-    requesterDid: string,
+    incomingMessage: RecordsRead | RecordsWrite,
+    requesterDid: string | undefined,
     messageStore: MessageStore
   ): Promise<void> {
+    const isWrite = incomingMessage.message.descriptor.method === DwnMethodName.Write;
+
+    let recordsWrite: RecordsWrite;
+    if (isWrite) {
+      recordsWrite = incomingMessage as RecordsWrite;
+    } else {
+      const recordsRead = incomingMessage as RecordsRead;
+      const query = {
+        interface : DwnInterfaceName.Records,
+        method    : DwnMethodName.Write,
+        recordId  : recordsRead.message.descriptor.recordId,
+      };
+      const existingMessages = await messageStore.query(tenant, query) as TimestampedMessage[];
+      const recordsWriteMessage = await RecordsWrite.getNewestMessage(existingMessages) as RecordsWriteMessage;
+      recordsWrite = await RecordsWrite.parse(recordsWriteMessage);
+    }
+
     // fetch the protocol definition
     const protocolDefinition = await ProtocolAuthorization.fetchProtocolDefinition(tenant, recordsWrite, messageStore);
 
     // fetch ancestor message chain
-    const ancestorMessageChain: RecordsWriteMessage[] = await ProtocolAuthorization.constructAncestorMessageChain(tenant, recordsWrite, messageStore);
+    let ancestorMessageChain: RecordsWriteMessage[] =
+      await ProtocolAuthorization.constructAncestorMessageChain(tenant, incomingMessage, recordsWrite, messageStore);
 
     // record schema -> schema label map
     const recordSchemaToLabelMap: Map<string, string> = new Map();
@@ -37,24 +57,28 @@ export class ProtocolAuthorization {
 
     // get the rule set for the inbound message
     const inboundMessageRuleSet = ProtocolAuthorization.getRuleSet(
-      recordsWrite.message,
       protocolDefinition,
-      ancestorMessageChain,
+      [...ancestorMessageChain, recordsWrite.message],
       recordSchemaToLabelMap
     );
+
+    // For non-writes `recordsWrite` is actually part of the existing ancestor chain
+    if (!isWrite) {
+      ancestorMessageChain = [...ancestorMessageChain, recordsWrite.message];
+    }
 
     // verify method invoked against the allowed actions
     ProtocolAuthorization.verifyAllowedActions(
       tenant,
       requesterDid,
-      recordsWrite,
+      incomingMessage.message.descriptor.method,
       inboundMessageRuleSet,
       ancestorMessageChain,
       recordSchemaToLabelMap
     );
 
-    // verify allowed condition of the write
-    await ProtocolAuthorization.verifyActionCondition(tenant, recordsWrite, messageStore);
+    // verify allowed condition of incoming message
+    await ProtocolAuthorization.verifyActionCondition(tenant, incomingMessage, messageStore);
   }
 
   /**
@@ -84,7 +108,12 @@ export class ProtocolAuthorization {
    * Constructs a chain of ancestor messages
    * @returns the ancestor chain of messages where the first element is the root of the chain; returns empty array if no parent is specified.
    */
-  private static async constructAncestorMessageChain(tenant: string, recordsWrite: RecordsWrite, messageStore: MessageStore)
+  private static async constructAncestorMessageChain(
+    tenant: string,
+    incomingMessage: RecordsRead | RecordsWrite,
+    recordsWrite: RecordsWrite,
+    messageStore: MessageStore
+  )
     : Promise<RecordsWriteMessage[]> {
     const ancestorMessageChain: RecordsWriteMessage[] = [];
 
@@ -121,14 +150,10 @@ export class ProtocolAuthorization {
    * Gets the rule set corresponding to the inbound message.
    */
   private static getRuleSet(
-    inboundMessage: RecordsWriteMessage,
     protocolDefinition: ProtocolDefinition,
-    ancestorMessageChain: RecordsWriteMessage[],
+    messageChain: RecordsWriteMessage[],
     recordSchemaToLabelMap: Map<string, string>
   ): ProtocolRuleSet {
-    // make a copy of the ancestor messages and include the inbound message in the chain
-    const messageChain = [...ancestorMessageChain, inboundMessage];
-
     // walk down the ancestor message chain from the root ancestor record and match against the corresponding rule set at each level
     // to make sure the chain structure is allowed
     let allowedRecordsAtCurrentLevel: { [key: string]: ProtocolRuleSet} | undefined = protocolDefinition.records;
@@ -163,14 +188,13 @@ export class ProtocolAuthorization {
    */
   private static verifyAllowedActions(
     tenant: string,
-    requesterDid: string,
-    incomingMessage: Message<BaseMessage>,
+    requesterDid: string | undefined,
+    incomingMessageMethod: string,
     inboundMessageRuleSet: ProtocolRuleSet,
     ancestorMessageChain: RecordsWriteMessage[],
     recordSchemaToLabelMap: Map<string, string>
   ): void {
     const allowRule = inboundMessageRuleSet.allow;
-    const incomingMessageMethod = incomingMessage.message.descriptor.method;
 
     if (allowRule === undefined) {
       // if no allow rule is defined, owner of DWN can do everything
@@ -223,20 +247,25 @@ export class ProtocolAuthorization {
    * Currently the only check is: if the write is not the initial write, the author must be the same as the initial write
    * @throws {Error} if fails verification
    */
-  private static async verifyActionCondition(tenant: string, recordsWrite: RecordsWrite, messageStore: MessageStore): Promise<void> {
-    const isInitialWrite = await recordsWrite.isInitialWrite();
-    if (!isInitialWrite) {
-      // fetch the initialWrite
-      const query = {
-        entryId: recordsWrite.message.recordId
-      };
-      const result = await messageStore.query(tenant, query) as RecordsWriteMessage[];
+  private static async verifyActionCondition(tenant: string, incomingMessage: RecordsRead | RecordsWrite, messageStore: MessageStore): Promise<void> {
+    if (incomingMessage.message.descriptor.method === DwnMethodName.Read) {
+      // Currently no conditions for reads
+    } else if (incomingMessage.message.descriptor.method === DwnMethodName.Write) {
+      const recordsWrite = incomingMessage as RecordsWrite;
+      const isInitialWrite = await recordsWrite.isInitialWrite();
+      if (!isInitialWrite) {
+        // fetch the initialWrite
+        const query = {
+          entryId: recordsWrite.message.recordId
+        };
+        const result = await messageStore.query(tenant, query) as RecordsWriteMessage[];
 
-      // check the author of the initial write matches the author of the incoming message
-      const initialWrite = result[0];
-      const authorOfInitialWrite = Message.getAuthor(initialWrite);
-      if (recordsWrite.author !== authorOfInitialWrite) {
-        throw new Error(`author of incoming message '${recordsWrite.author}' must match to author of initial write '${authorOfInitialWrite}'`);
+        // check the author of the initial write matches the author of the incoming message
+        const initialWrite = result[0];
+        const authorOfInitialWrite = Message.getAuthor(initialWrite);
+        if (recordsWrite.author !== authorOfInitialWrite) {
+          throw new Error(`author of incoming message '${recordsWrite.author}' must match to author of initial write '${authorOfInitialWrite}'`);
+        }
       }
     }
   }

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -1,8 +1,8 @@
 import type { MessageStore } from '../store/message-store.js';
 import type { RecordsRead } from '../interfaces/records/messages/records-read.js';
-import type { RecordsReadMessage, RecordsWriteMessage } from '../interfaces/records/types.js';
 import type { Filter, TimestampedMessage } from './types.js';
 import type { ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureMessage } from '../interfaces/protocols/types.js';
+import type { RecordsReadMessage, RecordsWriteMessage } from '../interfaces/records/types.js';
 
 import { RecordsWrite } from '../interfaces/records/messages/records-write.js';
 import { DwnInterfaceName, DwnMethodName, Message } from './message.js';
@@ -25,7 +25,7 @@ export class ProtocolAuthorization {
     messageStore: MessageStore
   ): Promise<void> {
     // fetch ancestor message chain
-    let ancestorMessageChain: RecordsWriteMessage[] =
+    const ancestorMessageChain: RecordsWriteMessage[] =
       await ProtocolAuthorization.constructAncestorMessageChain(tenant, incomingMessage, messageStore);
 
     // fetch the protocol definition

--- a/src/interfaces/records/handlers/records-read.ts
+++ b/src/interfaces/records/handlers/records-read.ts
@@ -58,7 +58,7 @@ export class RecordsReadHandler implements MethodHandler {
       // NOTE we check for `true` as a defensive equality comparison, so we don't mistakenly assume a record that is not published as published.
     } else {
       try {
-        await recordsRead.authorize(tenant);
+        await recordsRead.authorize(tenant, await RecordsWrite.parse(newestRecordsWrite), this.messageStore);
       } catch (error) {
         return MessageReply.fromError(error, 401);
       }

--- a/tests/interfaces/records/handlers/records-read.spec.ts
+++ b/tests/interfaces/records/handlers/records-read.spec.ts
@@ -1,7 +1,7 @@
 import type { DerivedPrivateJwk } from '../../../../src/utils/hd-key.js';
+import emailProtocolDefinition from '../../../vectors/protocol-definitions/email.json' assert { type: 'json' };
 import type { EncryptionInput } from '../../../../src/interfaces/records/messages/records-write.js';
 import type { ProtocolDefinition } from '../../../../src/index.js';
-import emailProtocolDefinition from '../../../vectors/protocol-definitions/email.json' assert { type: 'json' };
 import socialMediaProtocolDefinition from '../../../vectors/protocol-definitions/social-media.json' assert { type: 'json' };
 
 import chaiAsPromised from 'chai-as-promised';

--- a/tests/interfaces/records/handlers/records-read.spec.ts
+++ b/tests/interfaces/records/handlers/records-read.spec.ts
@@ -173,7 +173,7 @@ describe('RecordsReadHandler.handle()', () => {
         const protocolWriteReply = await dwn.processMessage(alice.did, protocolsConfig.message, protocolsConfig.dataStream);
         expect(protocolWriteReply.status.code).to.equal(202);
 
-        // Alice writes image to Caroline's DWN with Alice herself as recipient
+        // Alice writes image to her DWN
         const encodedImage = new TextEncoder().encode('cafe-aesthetic.jpg');
         const imageRecordsWrite = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,

--- a/tests/interfaces/records/handlers/records-read.spec.ts
+++ b/tests/interfaces/records/handlers/records-read.spec.ts
@@ -161,9 +161,6 @@ describe('RecordsReadHandler.handle()', () => {
         const alice = await DidKeyResolver.generate();
         const bob = await DidKeyResolver.generate();
 
-        // setting up a stub DID resolver
-        TestStubGenerator.stubDidResolver(didResolver, [alice, bob]);
-
         const protocol = 'https://tbd.website/decentralized-web-node/protocols/social-media';
         const protocolDefinition: ProtocolDefinition = socialMediaProtocolDefinition;
 
@@ -253,9 +250,6 @@ describe('RecordsReadHandler.handle()', () => {
         const alice = await DidKeyResolver.generate();
         const bob = await DidKeyResolver.generate();
         const imposterBob = await DidKeyResolver.generate();
-
-        // setting up a stub DID resolver
-        TestStubGenerator.stubDidResolver(didResolver, [alice, bob, imposterBob]);
 
         const protocol = 'https://tbd.website/decentralized-web-node/protocols/email';
         const protocolDefinition: ProtocolDefinition = emailProtocolDefinition;

--- a/tests/vectors/protocol-definitions/email.json
+++ b/tests/vectors/protocol-definitions/email.json
@@ -11,6 +11,14 @@
           "to": [
             "write"
           ]
+        },
+        "author": {
+          "of": "email",
+          "to": ["read"]
+        },
+        "recipient": {
+          "of": "email",
+          "to": ["read"]
         }
       },
       "records": {
@@ -20,6 +28,14 @@
               "to": [
                 "write"
               ]
+            },
+            "author": {
+              "of": "email/email",
+              "to": ["read"]
+            },
+            "recipient": {
+              "of": "email/email",
+              "to": ["read"]
             }
           }
         }

--- a/tests/vectors/protocol-definitions/social-media.json
+++ b/tests/vectors/protocol-definitions/social-media.json
@@ -30,13 +30,12 @@
       "records": {
         "caption": {
           "allow": {
+            "anyone": {
+              "to": ["read"]
+            },
             "author": {
               "of": "image",
               "to": ["write"]
-            },
-            "recipient": {
-              "of": "image",
-              "to": ["read"]
             }
           }
         },

--- a/tests/vectors/protocol-definitions/social-media.json
+++ b/tests/vectors/protocol-definitions/social-media.json
@@ -24,20 +24,28 @@
     "image": {
       "allow": {
         "anyone": {
-          "to": ["write"]
+          "to": ["read", "write"]
         }
       },
       "records": {
         "caption": {
           "allow": {
             "author": {
-                "of": "image",
-                "to": ["write"]
+              "of": "image",
+              "to": ["write"]
+            },
+            "recipient": {
+              "of": "image",
+              "to": ["read"]
             }
           }
         },
         "reply": {
           "allow": {
+            "author": {
+              "of": "image",
+              "to": ["read"]
+            },
             "recipient": {
               "of": "image",
               "to": ["write"]


### PR DESCRIPTION
Addresses part of #285

## Notable Changes
* `json-schemas/protocol-rule-set.json`: Previously `ProtocolRule`s allowed exactly one of (`anyone`, `author`, `recipient`). This PR allows for AT LEAST one of those; i.e. we may have multiple of (`anyone`, `author`, `recipient`).