### PR TITLE
#276 - added encryption support to RecordsWrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-93.56%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.1%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.24%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.56%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-93.56%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.09%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.24%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.56%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-93.93%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-92.64%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.47%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.93%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-93.55%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.1%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.24%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.55%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-93.55%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.1%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.24%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.55%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-93.56%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.1%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.24%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.56%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/json-schemas/records/records-write.json
+++ b/json-schemas/records/records-write.json
@@ -42,7 +42,7 @@
               "derivationScheme": {
                 "type": "string",
                 "enum": [
-                  "protocol"
+                  "protocol-context"
                 ]
               },
               "algorithm": {

--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -17,8 +17,14 @@ export enum DwnErrorCode {
   AuthorizationMissing = 'AuthorizationMissing',
   AuthorizationUnknownAuthor = 'AuthorizationUnknownAuthor',
   HdKeyDerivationPathInvalid = 'HdKeyDerivationPathInvalid',
-  RecordsWriteGetEntryIdUndefinedAuthor = 'RecordsWriteGetEntryIdUndefinedAuthor',
   MessageStoreDataCidMismatch = 'MessageStoreDataCidMismatch',
   MessageStoreDataNotFound = 'MessageStoreDataNotFound',
-  MessageStoreDataSizeMismatch = 'MessageStoreDataSizeMismatch'
+  MessageStoreDataSizeMismatch = 'MessageStoreDataSizeMismatch',
+  RecordsDecryptNoMatchingKeyDerivationScheme = 'RecordsDecryptNoMatchingKeyDerivationScheme',
+  RecordsDeriveLeafPrivateKeyUnSupportedCurve = 'RecordsDeriveLeafPrivateKeyUnSupportedCurve',
+  RecordsDeriveLeafPublicKeyUnSupportedCurve = 'RecordsDeriveLeafPublicKeyUnSupportedCurve',
+  RecordsInvalidAncestorKeyDerivationSegment = 'RecordsInvalidAncestorKeyDerivationSegment',
+  RecordsWriteGetEntryIdUndefinedAuthor = 'RecordsWriteGetEntryIdUndefinedAuthor',
+  RecordsWriteValidateIntegrityEncryptionCidMismatch = 'RecordsWriteValidateIntegrityEncryptionCidMismatch',
+  Secp256k1KeyNotValid = 'Secp256k1KeyNotValid'
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export { Dwn } from './dwn.js';
 export { DwnConstant } from './core/dwn-constant.js';
 export { DwnInterfaceName, DwnMethodName } from './core/message.js';
 export { Encoder } from './utils/encoder.js';
-export { Encryption } from './utils/encryption.js';
+export { Encryption, EncryptionAlgorithm } from './utils/encryption.js';
 export { EncryptionInput, KeyEncryptionInput, RecordsWrite, RecordsWriteOptions, CreateFromOptions } from './interfaces/records/messages/records-write.js';
 export { HooksWrite, HooksWriteOptions } from './interfaces/hooks/messages/hooks-write.js';
 export { Jws } from './utils/jws.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,7 @@
 /* eslint-disable max-len */
 
-/**
- * exports everything that we want to be consumable
- */
 
-// yep, it's weird that we're exporting '.js' files when they're really
-// '.ts' files. Long story. If you're interested as to why, check out:
-//   - https://stackoverflow.com/questions/44979976/typescript-compiler-is-forgetting-to-add-file-extensions-to-es6-module-imports
-//   - https://github.com/microsoft/TypeScript/issues/40878
-//
+// export everything that we want to be consumable
 export type { DwnConfig } from './dwn.js';
 export type { DwnServiceEndpoint, ServiceEndpoint, DidDocument, DidResolutionResult, DidResolutionMetadata, DidDocumentMetadata, VerificationMethod } from './did/did-resolver.js';
 export type { HooksWriteMessage } from './interfaces/hooks/types.js';
@@ -20,6 +13,7 @@ export { DataStore } from './store/data-store.js';
 export { DataStoreLevel } from './store/data-store-level.js';
 export { DateSort } from './interfaces/records/messages/records-query.js';
 export { DataStream } from './utils/data-stream.js';
+export { DerivedPrivateJwk, DerivedPublicJwk, HdKey, KeyDerivationScheme } from './utils/hd-key.js';
 export { DidKeyResolver } from './did/did-key-resolver.js';
 export { DidIonResolver } from './did/did-ion-resolver.js';
 export { DidResolver, DidMethodResolver } from './did/did-resolver.js';
@@ -28,6 +22,7 @@ export { DwnConstant } from './core/dwn-constant.js';
 export { DwnInterfaceName, DwnMethodName } from './core/message.js';
 export { Encoder } from './utils/encoder.js';
 export { Encryption } from './utils/encryption.js';
+export { EncryptionInput, KeyEncryptionInput, RecordsWrite, RecordsWriteOptions, CreateFromOptions } from './interfaces/records/messages/records-write.js';
 export { HooksWrite, HooksWriteOptions } from './interfaces/hooks/messages/hooks-write.js';
 export { Jws } from './utils/jws.js';
 export { KeyMaterial, PrivateJwk, PublicJwk } from './jose/types.js';
@@ -36,9 +31,9 @@ export { MessageStore } from './store/message-store.js';
 export { MessageStoreLevel } from './store/message-store-level.js';
 export { ProtocolsConfigure, ProtocolsConfigureOptions } from './interfaces/protocols/messages/protocols-configure.js';
 export { ProtocolsQuery, ProtocolsQueryOptions } from './interfaces/protocols/messages/protocols-query.js';
+export { Records } from './utils/records.js';
 export { RecordsDelete, RecordsDeleteOptions } from './interfaces/records/messages/records-delete.js';
 export { RecordsQuery, RecordsQueryOptions } from './interfaces/records/messages/records-query.js';
 export { RecordsRead, RecordsReadOptions } from './interfaces/records/messages/records-read.js';
-export { RecordsWrite, RecordsWriteOptions, CreateFromOptions } from './interfaces/records/messages/records-write.js';
 export { Secp256k1 } from './utils/secp256k1.js';
 export { SignatureInput } from './jose/jws/general/types.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export { DidIonResolver } from './did/did-ion-resolver.js';
 export { DidResolver, DidMethodResolver } from './did/did-resolver.js';
 export { Dwn } from './dwn.js';
 export { DwnConstant } from './core/dwn-constant.js';
+export { DwnError, DwnErrorCode } from './core/dwn-error.js';
 export { DwnInterfaceName, DwnMethodName } from './core/message.js';
 export { Encoder } from './utils/encoder.js';
 export { Encryption, EncryptionAlgorithm } from './utils/encryption.js';

--- a/src/interfaces/protocols/handlers/protocols-query.ts
+++ b/src/interfaces/protocols/handlers/protocols-query.ts
@@ -39,12 +39,12 @@ export class ProtocolsQueryHandler implements MethodHandler {
     };
     removeUndefinedProperties(query);
 
-    const records = await this.messageStore.query(tenant, query);
+    const messages = await this.messageStore.query(tenant, query);
 
     // strip away `authorization` property for each record before responding
     const entries: QueryResultEntry[] = [];
-    for (const record of records) {
-      const { authorization: _, ...objectWithRemainingProperties } = record; // a trick to stripping away `authorization`
+    for (const message of messages) {
+      const { authorization: _, ...objectWithRemainingProperties } = message; // a trick to stripping away `authorization`
       entries.push(objectWithRemainingProperties);
     }
 

--- a/src/interfaces/records/handlers/records-query.ts
+++ b/src/interfaces/records/handlers/records-query.ts
@@ -152,17 +152,14 @@ export class RecordsQueryHandler implements MethodHandler {
  * 4. publishedDescending - If the message is published, sort in desc based on publish date
  *
  * If sorting is based on date published, records that are not published are filtered out.
- * @param entries - Entries to be sorted if dateSort is present
+ * @param messages - Messages to be sorted if dateSort is present
  * @param dateSort - Sorting scheme
  * @returns Sorted Messages
  */
-async function sortRecords<T extends RecordsWriteMessage>(
-  entries: T[],
+async function sortRecords(
+  messages: RecordsWriteMessage[],
   dateSort: DateSort
-): Promise<T[]> {
-
-  const messages = entries;
-
+): Promise<RecordsWriteMessage[]> {
   switch (dateSort) {
   case DateSort.CreatedAscending:
     return messages.sort((a, b) => lexicographicalCompare(a.descriptor.dateCreated, b.descriptor.dateCreated));

--- a/src/interfaces/records/types.ts
+++ b/src/interfaces/records/types.ts
@@ -1,7 +1,9 @@
 import type { BaseMessage } from '../../core/types.js';
 import type { BaseMessageReply } from '../../core/message-reply.js';
 import type { DateSort } from './messages/records-query.js';
+import type { EncryptionAlgorithm } from '../../utils/encryption.js';
 import type { GeneralJws } from '../../jose/jws/general/types.js';
+import type { KeyDerivationScheme } from '../../utils/hd-key.js';
 import type { PublicJwk } from '../../jose/types.js';
 import type { Readable } from 'readable-stream';
 import type { DwnInterfaceName, DwnMethodName } from '../../core/message.js';
@@ -27,18 +29,18 @@ export type RecordsWriteMessage = BaseMessage & {
   contextId?: string;
   descriptor: RecordsWriteDescriptor;
   attestation?: GeneralJws;
-  encryption?: EncryptionMetadata;
+  encryption?: EncryptionProperty;
 };
 
-export type EncryptionMetadata = {
-  algorithm: 'A256CTR';
+export type EncryptionProperty = {
+  algorithm: EncryptionAlgorithm;
   initializationVector: string;
   keyEncryption: EncryptedKey[]
 };
 
 export type EncryptedKey = {
-  derivationScheme: 'protocol';
-  algorithm: 'ECIES-ES256K';
+  derivationScheme: KeyDerivationScheme;
+  algorithm: EncryptionAlgorithm;
   encryptedKey: string;
   initializationVector: string;
   ephemeralPublicKey: PublicJwk;
@@ -96,6 +98,7 @@ export type RecordsWriteAuthorizationPayload = {
   contextId?: string;
   descriptorCid: string;
   attestationCid?: string;
+  encryptionCid?: string;
 };
 
 export type RecordsQueryMessage = BaseMessage & {
@@ -114,7 +117,7 @@ export type RecordsReadReply = BaseMessageReply & {
     descriptor: RecordsWriteDescriptor;
     // authorization: GeneralJws; // intentionally omitted
     attestation?: GeneralJws;
-    encryption?: EncryptionMetadata;
+    encryption?: EncryptionProperty;
     data: Readable;
   }
 };

--- a/src/interfaces/records/types.ts
+++ b/src/interfaces/records/types.ts
@@ -47,13 +47,20 @@ export type EncryptedKey = {
   messageAuthenticationCode: string;
 };
 
-/**
- * Used by the entries returned by queries.
- */
 export type UnsignedRecordsWriteMessage = {
   recordId: string,
   contextId?: string;
   descriptor: RecordsWriteDescriptor;
+  encryption?: EncryptionProperty;
+};
+
+/**
+ * Data structure returned in a `RecordsQuery` reply entry.
+ * NOTE: the message structure is a modified version of the message received, the most notable differences are:
+ * 1. does not contain `authorization`
+ * 2. may include encoded data
+ */
+export type RecordsQueryReplyEntry = UnsignedRecordsWriteMessage & {
   encodedData?: string;
 };
 

--- a/src/store/storage-controller.ts
+++ b/src/store/storage-controller.ts
@@ -6,6 +6,7 @@ import type { BaseMessage, Filter } from '../core/types.js';
 
 import { DwnConstant } from '../core/dwn-constant.js';
 import { Message } from '../core/message.js';
+import type { RecordsWriteMessage } from '../index.js';
 import { DataStream, Encoder } from '../index.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 
@@ -90,7 +91,7 @@ export class StorageController {
     filter: Filter
   ): Promise<RecordsWriteMessageWithOptionalEncodedData[]> {
 
-    const messages: RecordsWriteMessageWithOptionalEncodedData[] = await messageStore.query(tenant, filter);
+    const messages: RecordsWriteMessageWithOptionalEncodedData[] = (await messageStore.query(tenant, filter)) as RecordsWriteMessage[];
 
     // for every message, only include the data as `encodedData` if the data size is equal or smaller than the size threshold
     for (const message of messages) {
@@ -126,4 +127,4 @@ export class StorageController {
   }
 }
 
-type RecordsWriteMessageWithOptionalEncodedData = BaseMessage & { encodedData?: string };
+export type RecordsWriteMessageWithOptionalEncodedData = RecordsWriteMessage & { encodedData?: string };

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -83,13 +83,15 @@ export class Encryption {
    * Decrypt the given plaintext using ECIES (Elliptic Curve Integrated Encryption Scheme) with SECP256K1.
    */
   public static async eciesSecp256k1Decrypt(input: EciesEncryptionInput): Promise<Uint8Array> {
+    // underlying library requires Buffer as input
     // TODO: #291 - Swap out `eccrypto` in favor of a more up-to-date ECIES library - https://github.com/TBD54566975/dwn-sdk-js/issues/291
     const privateKeyBuffer = Buffer.from(input.privateKey);
+    const ephemPublicKey = Buffer.from(input.ephemeralPublicKey);
     const eciesEncryptionOutput = {
-      ciphertext     : input.ciphertext as Buffer,
-      ephemPublicKey : input.ephemeralPublicKey as Buffer,
-      iv             : input.initializationVector as Buffer,
-      mac            : input.messageAuthenticationCode as Buffer
+      ciphertext : input.ciphertext as Buffer,
+      ephemPublicKey,
+      iv         : input.initializationVector as Buffer,
+      mac        : input.messageAuthenticationCode as Buffer
     };
 
     const plaintext = await eccrypto.decrypt(privateKeyBuffer, eciesEncryptionOutput);
@@ -108,3 +110,8 @@ export type EciesEncryptionOutput = {
 export type EciesEncryptionInput = EciesEncryptionOutput & {
   privateKey: Uint8Array;
 };
+
+export enum EncryptionAlgorithm {
+  Aes256Ctr = 'A256CTR',
+  EciesSecp256k1 = 'ECIES-ES256K'
+}

--- a/src/utils/hd-key.ts
+++ b/src/utils/hd-key.ts
@@ -1,0 +1,41 @@
+import type { PrivateJwk, PublicJwk } from '../jose/types.js';
+
+import { Secp256k1 } from './secp256k1.js';
+
+export enum KeyDerivationScheme {
+  ProtocolContext = 'protocol-context'
+}
+
+export type DerivedPublicJwk = {
+  derivationScheme: KeyDerivationScheme;
+  derivationPath: string[];
+  derivedPublicKey: PublicJwk,
+};
+
+export type DerivedPrivateJwk = {
+  derivationScheme: KeyDerivationScheme;
+  derivationPath: string[];
+  derivedPrivateKey: PrivateJwk,
+};
+
+/**
+ * Class containing hierarchical deterministic key related utility methods used by the DWN.
+ */
+export class HdKey {
+  /**
+   * Derives a descendant private key.
+   * NOTE: currently only supports SECP256K1 keys.
+   */
+  public static async derivePrivateKey(ancestorKey: DerivedPrivateJwk, subDerivationPath: string[]): Promise<DerivedPrivateJwk> {
+    const ancestorPrivateKey = Secp256k1.privateJwkToBytes(ancestorKey.derivedPrivateKey);
+    const derivedPrivateKeyBytes = await Secp256k1.derivePrivateKey(ancestorPrivateKey, subDerivationPath);
+    const derivedPrivateJwk = await Secp256k1.privateKeyToJwk(derivedPrivateKeyBytes);
+    const derivedDescendantPrivateKey: DerivedPrivateJwk = {
+      derivationPath    : [...ancestorKey.derivationPath, ...subDerivationPath],
+      derivationScheme  : ancestorKey.derivationScheme,
+      derivedPrivateKey : derivedPrivateJwk
+    };
+
+    return derivedDescendantPrivateKey;
+  }
+}

--- a/src/utils/records.ts
+++ b/src/utils/records.ts
@@ -1,0 +1,119 @@
+import type { Readable } from 'readable-stream';
+import type { RecordsReadReply } from '../interfaces/records/types.js';
+import type { DerivedPrivateJwk, DerivedPublicJwk } from './hd-key.js';
+
+import { Encoder } from './encoder.js';
+import { Encryption } from './encryption.js';
+import { KeyDerivationScheme } from './hd-key.js';
+import { Secp256k1 } from './secp256k1.js';
+import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
+
+/**
+ * Class containing useful utilities related to the Records interface.
+ */
+export class Records {
+  /**
+   * Decrypts the encrypted data in a message reply using the given ancestor private key.
+   */
+  public static async decrypt(messageReply: RecordsReadReply, ancestorPrivateKey: DerivedPrivateJwk): Promise<Readable> {
+    const { encryption, contextId, descriptor, data } = messageReply.record!;
+
+    // look for an encrypted symmetric key that is encrypted using the same scheme as the given derived private key
+    const matchingEncryptedKey = encryption!.keyEncryption.find(key => key.derivationScheme === ancestorPrivateKey.derivationScheme);
+    if (matchingEncryptedKey === undefined) {
+      throw new DwnError(
+        DwnErrorCode.RecordsDecryptNoMatchingKeyDerivationScheme,
+        `Unable to find symmetric key encrypted using '${ancestorPrivateKey.derivationScheme}' derivation scheme.`
+      );
+    }
+
+    // NOTE: right now only `protocol-context` scheme is supported so we will assume that's the scheme without additional switch/if statements
+    // derive the leaf private key
+    const leafDerivationPath = [KeyDerivationScheme.ProtocolContext, descriptor.protocol!, contextId!];
+
+    // NOTE: right now only `ECIES-ES256K` algorithm is supported for asymmetric encryption,
+    // so we will assume that's the algorithm without additional switch/if statements
+    const leafPrivateKey = await Records.deriveLeafPrivateKey(ancestorPrivateKey, leafDerivationPath);
+    const encryptedKeyBytes = Encoder.base64UrlToBytes(matchingEncryptedKey.encryptedKey);
+    const ephemeralPublicKey = Secp256k1.publicJwkToBytes(matchingEncryptedKey.ephemeralPublicKey);
+    const keyEncryptionInitializationVector = Encoder.base64UrlToBytes(matchingEncryptedKey.initializationVector);
+    const messageAuthenticationCode = Encoder.base64UrlToBytes(matchingEncryptedKey.messageAuthenticationCode);
+    const dataEncryptionKey = await Encryption.eciesSecp256k1Decrypt({
+      ciphertext           : encryptedKeyBytes,
+      ephemeralPublicKey,
+      initializationVector : keyEncryptionInitializationVector,
+      messageAuthenticationCode,
+      privateKey           : leafPrivateKey
+    });
+
+    // NOTE: right now only `A256CTR` algorithm is supported for symmetric encryption,
+    // so we will assume that's the algorithm without additional switch/if statements
+    const dataEncryptionInitializationVector = Encoder.base64UrlToBytes(encryption!.initializationVector);
+    const plaintextStream = await Encryption.aes256CtrDecrypt(dataEncryptionKey, dataEncryptionInitializationVector, data!);
+
+    return plaintextStream;
+  }
+
+  /**
+   * Derives a descendant public key given an ancestor public key.
+   * NOTE: right now only `ECIES-ES256K` algorithm is supported for asymmetric encryption,
+   *       so we will assume that's the algorithm without additional switch/if statements
+   */
+  public static async deriveLeafPublicKey(ancestorPublicKey: DerivedPublicJwk, fullDescendantDerivationPath: string[]): Promise<Uint8Array> {
+    if (ancestorPublicKey.derivedPublicKey.crv !== 'secp256k1') {
+      throw new DwnError(
+        DwnErrorCode.RecordsDeriveLeafPublicKeyUnSupportedCurve,
+        `Curve ${ancestorPublicKey.derivedPublicKey.crv} is not supported.`
+      );
+    }
+
+    Records.validateAncestorKeyAndDescentKeyDerivationPathsMatch(ancestorPublicKey.derivationPath, fullDescendantDerivationPath);
+
+    const subDerivationPath = fullDescendantDerivationPath.slice(ancestorPublicKey.derivationPath.length);
+    const ancestorPublicKeyBytes = Secp256k1.publicJwkToBytes(ancestorPublicKey.derivedPublicKey);
+    const leafPublicKey = await Secp256k1.derivePublicKey(ancestorPublicKeyBytes, subDerivationPath);
+
+    return leafPublicKey;
+  }
+
+  /**
+   * Derives a descendant private key given an ancestor private key.
+   * NOTE: right now only `ECIES-ES256K` algorithm is supported for asymmetric encryption,
+   *       so we will assume that's the algorithm without additional switch/if statements
+   */
+  public static async deriveLeafPrivateKey(ancestorPrivateKey: DerivedPrivateJwk, fullDescendantDerivationPath: string[]): Promise<Uint8Array> {
+    if (ancestorPrivateKey.derivedPrivateKey.crv !== 'secp256k1') {
+      throw new DwnError(
+        DwnErrorCode.RecordsDeriveLeafPrivateKeyUnSupportedCurve,
+        `Curve ${ancestorPrivateKey.derivedPrivateKey.crv} is not supported.`
+      );
+    }
+
+    Records.validateAncestorKeyAndDescentKeyDerivationPathsMatch(ancestorPrivateKey.derivationPath, fullDescendantDerivationPath);
+
+    const subDerivationPath = fullDescendantDerivationPath.slice(ancestorPrivateKey.derivationPath.length);
+    const ancestorPrivateKeyBytes = Secp256k1.privateJwkToBytes(ancestorPrivateKey.derivedPrivateKey);
+    const leafPrivateKey = await Secp256k1.derivePrivateKey(ancestorPrivateKeyBytes, subDerivationPath);
+
+    return leafPrivateKey;
+  }
+
+  /**
+   * Validates that ancestor derivation path matches the descendant derivation path completely.
+   * @throws {DwnError} with `DwnErrorCode.RecordsInvalidAncestorKeyDerivationSegment` if fails validation.
+   */
+  public static validateAncestorKeyAndDescentKeyDerivationPathsMatch(
+    ancestorKeyDerivationPath: string[],
+    descendantKeyDerivationPath: string[]
+  ): void {
+    for (let i = 0; i < ancestorKeyDerivationPath.length; i++) {
+      const ancestorSegment = ancestorKeyDerivationPath[i];
+      const descendantSegment = descendantKeyDerivationPath[i];
+      if (ancestorSegment !== descendantSegment) {
+        throw new DwnError(
+          DwnErrorCode.RecordsInvalidAncestorKeyDerivationSegment,
+          `Ancestor key derivation segment '${ancestorSegment}' mismatches against the descendant key derivation segment '${descendantSegment}'.`);
+      }
+    }
+  }
+}

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -1,7 +1,5 @@
+import type { RecordsQueryReplyEntry } from '../../../../src/interfaces/records/types.js';
 import type { DerivedPrivateJwk, EncryptionInput, ProtocolDefinition, RecordsWriteMessage } from '../../../../src/index.js';
-import { Encryption } from '../../../../src/index.js';
-import { RecordsRead } from '../../../../src/index.js';
-import { DwnErrorCode } from '../../../../src/index.js';
 
 import chaiAsPromised from 'chai-as-promised';
 import emailProtocolDefinition from '../../../vectors/protocol-definitions/email.json' assert { type: 'json' };
@@ -13,6 +11,7 @@ import { DataStoreLevel } from '../../../../src/store/data-store-level.js';
 import { DidKeyResolver } from '../../../../src/did/did-key-resolver.js';
 import { DwnConstant } from '../../../../src/core/dwn-constant.js';
 import { Encoder } from '../../../../src/utils/encoder.js';
+import { Encryption } from '../../../../src/index.js';
 import { EventLogLevel } from '../../../../src/event-log/event-log-level.js';
 import { Jws } from '../../../../src/utils/jws.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
@@ -25,7 +24,6 @@ import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
 import { constructRecordsWriteIndexes } from '../../../../src/interfaces/records/handlers/records-write.js';
 import { DataStream, DidResolver, Dwn, HdKey, KeyDerivationScheme, Records } from '../../../../src/index.js';
 import { DateSort, RecordsQuery } from '../../../../src/interfaces/records/messages/records-query.js';
-import type { RecordsQueryReplyEntry } from '../../../../src/interfaces/records/types.js';
 
 chai.use(chaiAsPromised);
 

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -1,9 +1,14 @@
-import type { RecordsWriteMessage } from '../../../../src/index.js';
+import type { DerivedPrivateJwk, EncryptionInput, ProtocolDefinition, RecordsWriteMessage } from '../../../../src/index.js';
+import { Encryption } from '../../../../src/index.js';
+import { RecordsRead } from '../../../../src/index.js';
+import { DwnErrorCode } from '../../../../src/index.js';
 
 import chaiAsPromised from 'chai-as-promised';
+import emailProtocolDefinition from '../../../vectors/protocol-definitions/email.json' assert { type: 'json' };
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
 
+import { Comparer } from '../../../utils/comparer.js';
 import { DataStoreLevel } from '../../../../src/store/data-store-level.js';
 import { DidKeyResolver } from '../../../../src/did/did-key-resolver.js';
 import { DwnConstant } from '../../../../src/core/dwn-constant.js';
@@ -18,8 +23,9 @@ import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
 
 import { constructRecordsWriteIndexes } from '../../../../src/interfaces/records/handlers/records-write.js';
+import { DataStream, DidResolver, Dwn, HdKey, KeyDerivationScheme, Records } from '../../../../src/index.js';
 import { DateSort, RecordsQuery } from '../../../../src/interfaces/records/messages/records-query.js';
-import { DidResolver, Dwn } from '../../../../src/index.js';
+import type { RecordsQueryReplyEntry } from '../../../../src/interfaces/records/types.js';
 
 chai.use(chaiAsPromised);
 
@@ -584,6 +590,88 @@ describe('RecordsQueryHandler.handle()', () => {
 
       expect(reply.status.code).to.equal(200);
       expect(reply.entries?.length).to.equal(1);
+    });
+
+    describe('encryption scenarios', () => {
+      it('should only be able to decrypt record with a correct derived private key', async () => {
+        // scenario, Bob writes into Alice's DWN an encrypted "email", alice is able to decrypt it
+
+        // creating Alice and Bob persona and setting up a stub DID resolver
+        const alice = await TestDataGenerator.generatePersona();
+        const bob = await TestDataGenerator.generatePersona();
+        TestStubGenerator.stubDidResolver(didResolver, [alice, bob]);
+
+        // configure protocol
+        const protocol = 'email-protocol';
+        const protocolDefinition: ProtocolDefinition = emailProtocolDefinition;
+        const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
+          requester: alice,
+          protocol,
+          protocolDefinition
+        });
+
+        const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message, protocolsConfig.dataStream);
+        expect(protocolsConfigureReply.status.code).to.equal(202);
+
+        // encrypt bob's message
+        const bobMessageBytes = Encoder.stringToBytes('message from bob');
+        const bobMessageStream = DataStream.fromBytes(bobMessageBytes);
+        const dataEncryptionInitializationVector = TestDataGenerator.randomBytes(16);
+        const dataEncryptionKey = TestDataGenerator.randomBytes(32);
+        const bobMessageEncryptedStream = await Encryption.aes256CtrEncrypt(dataEncryptionKey, dataEncryptionInitializationVector, bobMessageStream);
+        const bobMessageEncryptedBytes = await DataStream.toBytes(bobMessageEncryptedStream);
+
+        // generate a `RecordsWrite` message from bob allowed by anyone
+        const encryptionInput: EncryptionInput = {
+          initializationVector : dataEncryptionInitializationVector,
+          key                  : dataEncryptionKey,
+          keyEncryptionInputs  : [{
+            publicKey: {
+              derivationScheme : KeyDerivationScheme.ProtocolContext,
+              derivationPath   : [],
+              derivedPublicKey : alice.keyPair.publicJwk // reusing signing key for encryption purely as a convenience
+            }
+          }]
+        };
+
+        const schema = 'email';
+        const { message, dataStream } = await TestDataGenerator.generateRecordsWrite(
+          {
+            requester : bob,
+            protocol,
+            schema,
+            data      : bobMessageEncryptedBytes,
+            encryptionInput
+          }
+        );
+
+        const bobWriteReply = await dwn.processMessage(alice.did, message, dataStream);
+        expect(bobWriteReply.status.code).to.equal(202);
+
+        const recordsQuery = await RecordsQuery.create({
+          filter                      : { schema },
+          authorizationSignatureInput : Jws.createSignatureInput(alice)
+        });
+        const queryReply = await dwn.processMessage(alice.did, recordsQuery.message);
+        expect(queryReply.status.code).to.equal(200);
+
+        const unsignedRecordsWrite = queryReply.entries![0] as RecordsQueryReplyEntry;
+
+        // test able to decrypt the message using a derived key
+        const rootPrivateKey: DerivedPrivateJwk = {
+          derivationScheme  : KeyDerivationScheme.ProtocolContext,
+          derivationPath    : [],
+          derivedPrivateKey : alice.keyPair.privateJwk
+        };
+        const relativeDescendantDerivationPath = [KeyDerivationScheme.ProtocolContext, protocol, message.contextId!];
+        const descendantPrivateKey: DerivedPrivateJwk = await HdKey.derivePrivateKey(rootPrivateKey, relativeDescendantDerivationPath);
+
+        const cipherStream = DataStream.fromBytes(Encoder.base64UrlToBytes(unsignedRecordsWrite.encodedData!));
+
+        const plaintextDataStream = await Records.decrypt(unsignedRecordsWrite, descendantPrivateKey, cipherStream);
+        const plaintextBytes = await DataStream.toBytes(plaintextDataStream);
+        expect(Comparer.byteArraysEqual(plaintextBytes, bobMessageBytes)).to.be.true;
+      });
     });
   });
 

--- a/tests/interfaces/records/handlers/records-read.spec.ts
+++ b/tests/interfaces/records/handlers/records-read.spec.ts
@@ -1,17 +1,26 @@
+import type { DerivedPrivateJwk } from '../../../../src/utils/hd-key.js';
+import type { EncryptionInput } from '../../../../src/interfaces/records/messages/records-write.js';
+import type { ProtocolDefinition } from '../../../../src/index.js';
+
 import chaiAsPromised from 'chai-as-promised';
+import emailProtocolDefinition from '../../../vectors/protocol-definitions/email.json' assert { type: 'json' };
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
 
 import { Comparer } from '../../../utils/comparer.js';
 import { DataStoreLevel } from '../../../../src/store/data-store-level.js';
 import { DidKeyResolver } from '../../../../src/did/did-key-resolver.js';
+import { DwnErrorCode } from '../../../../src/core/dwn-error.js';
+import { Encryption } from '../../../../src/utils/encryption.js';
 import { EventLogLevel } from '../../../../src/event-log/event-log-level.js';
+import { HdKey } from '../../../../src/utils/hd-key.js';
+import { KeyDerivationScheme } from '../../../../src/utils/hd-key.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
 import { RecordsReadHandler } from '../../../../src/interfaces/records/handlers/records-read.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
 
-import { DataStream, DidResolver, Dwn, Jws, RecordsDelete, RecordsRead } from '../../../../src/index.js';
+import { DataStream, DidResolver, Dwn, Encoder, Jws, Records, RecordsDelete, RecordsRead } from '../../../../src/index.js';
 
 chai.use(chaiAsPromised);
 
@@ -211,6 +220,100 @@ describe('RecordsReadHandler.handle()', () => {
 
       const readReply = await dwn.processMessage(alice.did, recordsRead.message);
       expect(readReply.status.code).to.equal(404);
+    });
+
+    describe('encryption scenarios', () => {
+      it('should only be able to decrypt record with a correct derived private key', async () => {
+        // scenario, Bob writes into Alice's DWN an encrypted "email", alice is able to decrypt it
+
+        // creating Alice and Bob persona and setting up a stub DID resolver
+        const alice = await TestDataGenerator.generatePersona();
+        const bob = await TestDataGenerator.generatePersona();
+        TestStubGenerator.stubDidResolver(didResolver, [alice, bob]);
+
+        // configure protocol
+        const protocol = 'email-protocol';
+        const protocolDefinition: ProtocolDefinition = emailProtocolDefinition;
+        const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
+          requester: alice,
+          protocol,
+          protocolDefinition
+        });
+
+        const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message, protocolsConfig.dataStream);
+        expect(protocolsConfigureReply.status.code).to.equal(202);
+
+        // encrypt bob's message
+        const bobMessageBytes = Encoder.stringToBytes('message from bob');
+        const bobMessageStream = DataStream.fromBytes(bobMessageBytes);
+        const dataEncryptionInitializationVector = TestDataGenerator.randomBytes(16);
+        const dataEncryptionKey = TestDataGenerator.randomBytes(32);
+        const bobMessageEncryptedStream = await Encryption.aes256CtrEncrypt(dataEncryptionKey, dataEncryptionInitializationVector, bobMessageStream);
+        const bobMessageEncryptedBytes = await DataStream.toBytes(bobMessageEncryptedStream);
+
+        // generate a `RecordsWrite` message from bob allowed by anyone
+        const encryptionInput: EncryptionInput = {
+          initializationVector : dataEncryptionInitializationVector,
+          key                  : dataEncryptionKey,
+          keyEncryptionInputs  : [{
+            publicKey: {
+              derivationScheme : KeyDerivationScheme.ProtocolContext,
+              derivationPath   : [],
+              derivedPublicKey : alice.keyPair.publicJwk // reusing signing key for encryption purely as a convenience
+            }
+          }]
+        };
+
+        const { message, dataStream } = await TestDataGenerator.generateRecordsWrite(
+          {
+            requester : bob,
+            protocol,
+            schema    : 'email',
+            data      : bobMessageEncryptedBytes,
+            encryptionInput
+          }
+        );
+
+        const bobWriteReply = await dwn.processMessage(alice.did, message, dataStream);
+        expect(bobWriteReply.status.code).to.equal(202);
+
+        const recordsRead = await RecordsRead.create({
+          recordId                    : message.recordId, // assume alice can do a query to get the new email and its `recordId`
+          authorizationSignatureInput : Jws.createSignatureInput(alice)
+        });
+        const readReply = await dwn.processMessage(alice.did, recordsRead.message);
+        expect(readReply.status.code).to.equal(200);
+
+        // test able to decrypt the message using a derived key
+        const rootPrivateKey: DerivedPrivateJwk = {
+          derivationScheme  : KeyDerivationScheme.ProtocolContext,
+          derivationPath    : [],
+          derivedPrivateKey : alice.keyPair.privateJwk
+        };
+        const relativeDescendantDerivationPath = [KeyDerivationScheme.ProtocolContext, protocol, message.contextId!];
+        const descendantPrivateKey: DerivedPrivateJwk = await HdKey.derivePrivateKey(rootPrivateKey, relativeDescendantDerivationPath);
+
+        const plaintextDataStream = await Records.decrypt(readReply, descendantPrivateKey);
+        const plaintextBytes = await DataStream.toBytes(plaintextDataStream);
+        expect(Comparer.byteArraysEqual(plaintextBytes, bobMessageBytes)).to.be.true;
+
+        // test unable to decrypt the message if derived key has an unexpected path
+        const invalidDerivationPath = [KeyDerivationScheme.ProtocolContext, protocol, 'invalidContextId'];
+        const inValidDescendantPrivateKey: DerivedPrivateJwk = await HdKey.derivePrivateKey(rootPrivateKey, invalidDerivationPath);
+        await expect(Records.decrypt(readReply, inValidDescendantPrivateKey)).to.be.rejectedWith(
+          DwnErrorCode.RecordsInvalidAncestorKeyDerivationSegment
+        );
+
+        // test unable to decrypt the message if there no derivation scheme(s) used by the message matches the scheme used by the given private key
+        const privateKeyWithMismatchingDerivationScheme: DerivedPrivateJwk = {
+          derivationScheme  : 'scheme-that-is-not-protocol-context' as any,
+          derivationPath    : [],
+          derivedPrivateKey : alice.keyPair.privateJwk
+        };
+        await expect(Records.decrypt(readReply, privateKeyWithMismatchingDerivationScheme)).to.be.rejectedWith(
+          DwnErrorCode.RecordsDecryptNoMatchingKeyDerivationScheme
+        );
+      });
     });
   });
 

--- a/tests/utils/records.spec.ts
+++ b/tests/utils/records.spec.ts
@@ -1,0 +1,30 @@
+import type { DerivedPrivateJwk, DerivedPublicJwk } from '../../src/index.js';
+
+import { DwnErrorCode } from '../../src/core/dwn-error.js';
+import { ed25519 } from '../../src/jose/algorithms/signing/ed25519.js';
+import { expect } from 'chai';
+import { KeyDerivationScheme, Records } from '../../src/index.js';
+
+describe('Records', () => {
+  describe('deriveLeafPublicKey()', () => {
+    it('should throw if given public key is not supported', async () => {
+      const derivedKey: DerivedPublicJwk = {
+        derivationPath   : [],
+        derivationScheme : KeyDerivationScheme.ProtocolContext,
+        derivedPublicKey : (await ed25519.generateKeyPair()).publicJwk
+      };
+      await expect(Records.deriveLeafPublicKey(derivedKey, ['a'])).to.be.rejectedWith(DwnErrorCode.RecordsDeriveLeafPublicKeyUnSupportedCurve);
+    });
+  });
+
+  describe('deriveLeafPrivateKey()', () => {
+    it('should throw if given private key is not supported', async () => {
+      const derivedKey: DerivedPrivateJwk = {
+        derivationPath    : [],
+        derivationScheme  : KeyDerivationScheme.ProtocolContext,
+        derivedPrivateKey : (await ed25519.generateKeyPair()).privateJwk
+      };
+      await expect(Records.deriveLeafPrivateKey(derivedKey, ['a'])).to.be.rejectedWith(DwnErrorCode.RecordsDeriveLeafPrivateKeyUnSupportedCurve);
+    });
+  });
+});

--- a/tests/utils/secp256k1.spec.ts
+++ b/tests/utils/secp256k1.spec.ts
@@ -6,6 +6,15 @@ import { Secp256k1 } from '../../src/utils/secp256k1.js';
 import { TestDataGenerator } from './test-data-generator.js';
 
 describe('Secp256k1', () => {
+  describe('validateKey()', () => {
+    it('should throw if key is not a valid SECP256K1 key', async () => {
+      const validKey = (await Secp256k1.generateKeyPair()).publicJwk;
+
+      expect(() => Secp256k1.validateKey({ ...validKey, kty: 'invalidKty' as any })).to.throw(DwnErrorCode.Secp256k1KeyNotValid);
+      expect(() => Secp256k1.validateKey({ ...validKey, crv: 'invalidCrv' as any })).to.throw(DwnErrorCode.Secp256k1KeyNotValid);
+    });
+  });
+
   describe('publicKeyToJwk()', () => {
     it('should generate the same JWK regardless of compressed or compressed public key bytes given', async () => {
       const compressedPublicKeyBase64UrlString = 'A5roVr1J6MufaaBwweb5Q75PrZCbZpzC55kTCO68ylMs';

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -1,8 +1,8 @@
 import type { BaseMessage } from '../../src/core/types.js';
-import type { CreateFromOptions } from '../../src/interfaces/records/messages/records-write.js';
 import type { DidResolutionResult } from '../../src/did/did-resolver.js';
 import type { Readable } from 'readable-stream';
 import type { RecordsQueryFilter } from '../../src/interfaces/records/types.js';
+import type { CreateFromOptions, EncryptionInput } from '../../src/interfaces/records/messages/records-write.js';
 import type {
   DateSort,
   HooksWriteMessage,
@@ -95,6 +95,7 @@ export type GenerateRecordsWriteInput = {
   dateCreated?: string;
   dateModified?: string;
   datePublished?: string;
+  encryptionInput?: EncryptionInput;
 };
 
 export type GenerateFromRecordsWriteInput = {
@@ -288,22 +289,23 @@ export class TestDataGenerator {
     }
 
     const options: RecordsWriteOptions = {
-      recipient     : input?.recipientDid,
-      protocol      : input?.protocol,
-      contextId     : input?.contextId,
-      schema        : input?.schema ?? TestDataGenerator.randomString(20),
-      recordId      : input?.recordId,
-      parentId      : input?.parentId,
-      published     : input?.published,
-      dataFormat    : input?.dataFormat ?? 'application/json',
-      dateCreated   : input?.dateCreated,
-      dateModified  : input?.dateModified,
-      datePublished : input?.datePublished,
-      data          : dataBytes,
+      recipient       : input?.recipientDid,
+      protocol        : input?.protocol,
+      contextId       : input?.contextId,
+      schema          : input?.schema ?? TestDataGenerator.randomString(20),
+      recordId        : input?.recordId,
+      parentId        : input?.parentId,
+      published       : input?.published,
+      dataFormat      : input?.dataFormat ?? 'application/json',
+      dateCreated     : input?.dateCreated,
+      dateModified    : input?.dateModified,
+      datePublished   : input?.datePublished,
+      data            : dataBytes,
       dataCid,
       dataSize,
       authorizationSignatureInput,
-      attestationSignatureInputs
+      attestationSignatureInputs,
+      encryptionInput : input?.encryptionInput
     };
 
     const recordsWrite = await RecordsWrite.create(options);

--- a/tests/vectors/protocol-definitions/email.json
+++ b/tests/vectors/protocol-definitions/email.json
@@ -1,0 +1,29 @@
+{
+  "labels": {
+    "email": {
+      "schema": "email"
+    }
+  },
+  "records": {
+    "email": {
+      "allow": {
+        "anyone": {
+          "to": [
+            "write"
+          ]
+        }
+      },
+      "records": {
+        "email": {
+          "allow": {
+            "anyone": {
+              "to": [
+                "write"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
There is A LOT of quality-of-life stuff that can be done to make the SDK much easier to use as follow ups, but this is nevertheless the first complete milestone that lights up the encryption feature.

Some features to be added in follow up PR(s) include:

1. Add `protocolPath` to every protocol-based `RecordsWrite`
1. Extend `protocol-context` derivation scheme further
1. Add more key derivation schemes