### PR TITLE
Normalize protocol URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-93.69%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.17%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.36%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.69%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-93.72%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.25%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.42%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.72%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-93.73%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.25%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.42%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.73%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-93.73%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.26%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.42%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.73%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-93.72%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.25%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.42%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.72%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-93.73%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.26%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.42%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.73%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-93.73%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.26%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.42%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.73%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-93.73%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.25%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.42%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.73%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -4,6 +4,7 @@ import type { Filter, TimestampedMessage } from './types.js';
 import type { ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureMessage } from '../interfaces/protocols/types.js';
 import type { RecordsReadMessage, RecordsWriteMessage } from '../interfaces/records/types.js';
 
+import { normalizeProtocolUrl } from '../utils/url.js';
 import { RecordsWrite } from '../interfaces/records/messages/records-write.js';
 import { DwnInterfaceName, DwnMethodName, Message } from './message.js';
 
@@ -86,7 +87,7 @@ export class ProtocolAuthorization {
     const query: Filter = {
       interface : DwnInterfaceName.Protocols,
       method    : DwnMethodName.Configure,
-      protocol  : protocolUri
+      protocol  : normalizeProtocolUrl(protocolUri)
     };
     const protocols = await messageStore.query(tenant, query) as ProtocolsConfigureMessage[];
 
@@ -137,7 +138,7 @@ export class ProtocolAuthorization {
       const query: Filter = {
         interface : DwnInterfaceName.Records,
         method    : DwnMethodName.Write,
-        protocol,
+        protocol  : normalizeProtocolUrl(protocol),
         contextId,
         recordId  : currentParentId
       };

--- a/src/interfaces/protocols/handlers/protocols-configure.ts
+++ b/src/interfaces/protocols/handlers/protocols-configure.ts
@@ -57,8 +57,8 @@ export class ProtocolsConfigureHandler implements MethodHandler {
     if (incomingMessageIsNewest) {
       const { author } = protocolsConfigure;
       const indexes = {
-        author,
         ... message.descriptor,
+        author,
         protocol: normalizeProtocolUrl(message.descriptor.protocol),
       };
 

--- a/src/interfaces/protocols/handlers/protocols-configure.ts
+++ b/src/interfaces/protocols/handlers/protocols-configure.ts
@@ -1,10 +1,12 @@
 import type { EventLog } from '../../../event-log/event-log.js';
+import type { Filter } from '../../../core/types.js';
 import type { MethodHandler } from '../../types.js';
 import type { ProtocolsConfigureMessage } from '../types.js';
 import type { DataStore, DidResolver, MessageStore } from '../../../index.js';
 
 import { canonicalAuth } from '../../../core/auth.js';
 import { MessageReply } from '../../../core/message-reply.js';
+import { normalizeProtocolUrl } from '../../../utils/url.js';
 import { ProtocolsConfigure } from '../messages/protocols-configure.js';
 import { StorageController } from '../../../store/storage-controller.js';
 
@@ -35,10 +37,10 @@ export class ProtocolsConfigureHandler implements MethodHandler {
     }
 
     // attempt to get existing protocol
-    const query = {
+    const query: Filter = {
       interface : DwnInterfaceName.Protocols,
       method    : DwnMethodName.Configure,
-      protocol  : message.descriptor.protocol
+      protocol  : normalizeProtocolUrl(message.descriptor.protocol)
     };
     const existingMessages = await this.messageStore.query(tenant, query) as ProtocolsConfigureMessage[];
 
@@ -56,7 +58,8 @@ export class ProtocolsConfigureHandler implements MethodHandler {
       const { author } = protocolsConfigure;
       const indexes = {
         author,
-        ... message.descriptor
+        ... message.descriptor,
+        protocol: normalizeProtocolUrl(message.descriptor.protocol),
       };
 
       // FIXME: indexes, Property 'dataSize' is incompatible with index signature.

--- a/src/interfaces/protocols/handlers/protocols-query.ts
+++ b/src/interfaces/protocols/handlers/protocols-query.ts
@@ -1,13 +1,13 @@
 import type { MethodHandler } from '../../types.js';
 import type { ProtocolsQueryMessage } from '../types.js';
-import type { QueryResultEntry } from '../../../core/types.js';
 import type { DataStore, DidResolver, MessageStore } from '../../../index.js';
+import type { Filter, QueryResultEntry } from '../../../core/types.js';
 
 import { canonicalAuth } from '../../../core/auth.js';
 import { MessageReply } from '../../../core/message-reply.js';
+import { normalizeProtocolUrl } from '../../../utils/url.js';
 import { ProtocolsQuery } from '../messages/protocols-query.js';
 import { removeUndefinedProperties } from '../../../utils/object.js';
-
 import { DwnInterfaceName, DwnMethodName } from '../../../core/message.js';
 
 export class ProtocolsQueryHandler implements MethodHandler {
@@ -32,11 +32,14 @@ export class ProtocolsQueryHandler implements MethodHandler {
       return MessageReply.fromError(e, 401);
     }
 
-    const query = {
+    const query: Filter = {
       interface : DwnInterfaceName.Protocols,
       method    : DwnMethodName.Configure,
-      ...message.descriptor.filter
     };
+    const protocol = message.descriptor.filter?.protocol;
+    if (protocol !== undefined) {
+      query.protocol = normalizeProtocolUrl(protocol);
+    }
     removeUndefinedProperties(query);
 
     const messages = await this.messageStore.query(tenant, query);

--- a/src/interfaces/protocols/handlers/protocols-query.ts
+++ b/src/interfaces/protocols/handlers/protocols-query.ts
@@ -35,10 +35,10 @@ export class ProtocolsQueryHandler implements MethodHandler {
     const query: Filter = {
       interface : DwnInterfaceName.Protocols,
       method    : DwnMethodName.Configure,
+      ...message.descriptor.filter
     };
-    const protocol = message.descriptor.filter?.protocol;
-    if (protocol !== undefined) {
-      query.protocol = normalizeProtocolUrl(protocol);
+    if (query.protocol !== undefined) {
+      query.protocol = normalizeProtocolUrl(query.protocol as string);
     }
     removeUndefinedProperties(query);
 

--- a/src/interfaces/records/handlers/records-query.ts
+++ b/src/interfaces/records/handlers/records-query.ts
@@ -1,11 +1,11 @@
 import type { MethodHandler } from '../../types.js';
+import type { RecordsWriteMessageWithOptionalEncodedData } from '../../../store/storage-controller.js';
 import type { DataStore, DidResolver, MessageStore } from '../../../index.js';
 import type { RecordsQueryMessage, RecordsQueryReplyEntry, RecordsWriteMessage } from '../types.js';
 
 import { authenticate } from '../../../core/auth.js';
 import { lexicographicalCompare } from '../../../utils/string.js';
 import { MessageReply } from '../../../core/message-reply.js';
-import type { RecordsWriteMessageWithOptionalEncodedData } from '../../../store/storage-controller.js';
 import { StorageController } from '../../../store/storage-controller.js';
 
 import { DateSort, RecordsQuery } from '../messages/records-query.js';

--- a/src/interfaces/records/handlers/records-write.ts
+++ b/src/interfaces/records/handlers/records-write.ts
@@ -121,8 +121,8 @@ export async function constructRecordsWriteIndexes(
     recordId  : message.recordId,
     entryId   : await RecordsWrite.getEntryId(recordsWrite.author, recordsWrite.message.descriptor)
   };
-  if (descriptor.protocol !== undefined) {
-    indexes.protocol = normalizeProtocolUrl(descriptor.protocol);
+  if (indexes.protocol !== undefined) {
+    indexes.protocol = normalizeProtocolUrl(indexes.protocol);
   }
 
   // add additional indexes to optional values if given

--- a/src/interfaces/records/handlers/records-write.ts
+++ b/src/interfaces/records/handlers/records-write.ts
@@ -9,6 +9,7 @@ import { deleteAllOlderMessagesButKeepInitialWrite } from '../records-interface.
 import { DwnErrorCode } from '../../../core/dwn-error.js';
 import { DwnInterfaceName } from '../../../core/message.js';
 import { MessageReply } from '../../../core/message-reply.js';
+import { normalizeProtocolUrl } from '../../../utils/url.js';
 import { RecordsWrite } from '../messages/records-write.js';
 import { StorageController } from '../../../store/storage-controller.js';
 
@@ -120,6 +121,9 @@ export async function constructRecordsWriteIndexes(
     recordId  : message.recordId,
     entryId   : await RecordsWrite.getEntryId(recordsWrite.author, recordsWrite.message.descriptor)
   };
+  if (descriptor.protocol !== undefined) {
+    indexes.protocol = normalizeProtocolUrl(descriptor.protocol);
+  }
 
   // add additional indexes to optional values if given
   // TODO: index multi-attesters to be unblocked by #205 - Revisit database interfaces (https://github.com/TBD54566975/dwn-sdk-js/issues/205)

--- a/src/interfaces/records/messages/records-query.ts
+++ b/src/interfaces/records/messages/records-query.ts
@@ -93,8 +93,8 @@ export class RecordsQuery extends Message<RecordsQueryMessage> {
       (filterCopy as Filter).dateCreated = rangeFilter;
     }
 
-    if (filter.protocol !== undefined) {
-      filterCopy.protocol = normalizeProtocolUrl(filter.protocol);
+    if (filterCopy.protocol !== undefined) {
+      filterCopy.protocol = normalizeProtocolUrl(filterCopy.protocol);
     }
 
     return filterCopy as Filter;

--- a/src/interfaces/records/messages/records-query.ts
+++ b/src/interfaces/records/messages/records-query.ts
@@ -4,6 +4,7 @@ import type { RecordsQueryDescriptor, RecordsQueryFilter, RecordsQueryMessage } 
 
 import { getCurrentTimeInHighPrecision } from '../../../utils/time.js';
 import { Message } from '../../../core/message.js';
+import { normalizeProtocolUrl } from '../../../utils/url.js';
 import { removeUndefinedProperties } from '../../../utils/object.js';
 import { validateAuthorizationIntegrity } from '../../../core/auth.js';
 import { DwnInterfaceName, DwnMethodName } from '../../../core/message.js';
@@ -90,6 +91,10 @@ export class RecordsQuery extends Message<RecordsQueryMessage> {
 
     if (rangeFilter) {
       (filterCopy as Filter).dateCreated = rangeFilter;
+    }
+
+    if (filter.protocol !== undefined) {
+      filterCopy.protocol = normalizeProtocolUrl(filter.protocol);
     }
 
     return filterCopy as Filter;

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,7 +1,19 @@
+const URL_PROTOCOL_REGEX = /^[^:]+:\/\/./;
+
 export function normalizeProtocolUrl(url: string): string {
-  const fullUrl = url.includes('://') ? url : `http://${url}`;
-  const { hostname, pathname } = new URL(fullUrl);
-  return removeTrailingSlash(hostname + pathname);
+  let fullUrl: string;
+  if (URL_PROTOCOL_REGEX.test(url)) {
+    fullUrl = url
+  } else {
+    fullUrl = `http://${url}`;
+  }
+
+  try {
+    const { hostname, pathname } = new URL(fullUrl);
+    return removeTrailingSlash(hostname + pathname);
+  } catch(e) {
+    return url;
+  }
 }
 
 function removeTrailingSlash(str: string): string {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -3,7 +3,7 @@ const URL_PROTOCOL_REGEX = /^[^:]+:\/\/./;
 export function normalizeProtocolUrl(url: string): string {
   let fullUrl: string;
   if (URL_PROTOCOL_REGEX.test(url)) {
-    fullUrl = url
+    fullUrl = url;
   } else {
     fullUrl = `http://${url}`;
   }
@@ -11,7 +11,7 @@ export function normalizeProtocolUrl(url: string): string {
   try {
     const { hostname, pathname } = new URL(fullUrl);
     return removeTrailingSlash(hostname + pathname);
-  } catch(e) {
+  } catch (e) {
     return url;
   }
 }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,13 @@
+export function normalizeProtocolUrl(url: string): string {
+  const fullUrl = url.includes('://') ? url : `http://${url}`;
+  const { hostname, pathname } = new URL(fullUrl);
+  return removeTrailingSlash(hostname + pathname);
+}
+
+function removeTrailingSlash(str: string): string {
+  if (str.endsWith('/')) {
+    return str.slice(0, -1);
+  } else {
+    return str;
+  }
+}

--- a/tests/interfaces/protocols/handlers/protocols-query.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-query.spec.ts
@@ -150,7 +150,7 @@ describe('ProtocolsQueryHandler.handle()', () => {
 
       // configure several more protocols, none of which match `example.com`
       const protocolSlashFoo = await TestDataGenerator.generateProtocolsConfigure({ requester: alice, protocol: 'example.com/foo' });
-      const protocolSubdomainFoo = await TestDataGenerator.generateProtocolsConfigure({ requester: alice, protocol: 'foo.example.Com' });
+      const protocolSubdomainFoo = await TestDataGenerator.generateProtocolsConfigure({ requester: alice, protocol: 'foo.example.com' });
 
       for (const protocol of [protocolSlashFoo, protocolSubdomainFoo]) {
         const configureReply = await dwn.processMessage(alice.did, protocol.message, protocol.dataStream);

--- a/tests/interfaces/protocols/handlers/protocols-query.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-query.spec.ts
@@ -138,7 +138,7 @@ describe('ProtocolsQueryHandler.handle()', () => {
         messageDataWithCid.push({ cid, ...messageData });
       }
 
-      messageDataWithCid = messageDataWithCid.sort((messageDataA, messageDataB) => {
+      messageDataWithCid.sort((messageDataA, messageDataB) => {
         return lexicographicalCompare(messageDataA.cid, messageDataB.cid);
       });
 

--- a/tests/interfaces/protocols/handlers/protocols-query.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-query.spec.ts
@@ -132,7 +132,7 @@ describe('ProtocolsQueryHandler.handle()', () => {
       // Sort messages into lexicographic order. We only allow protocol overwrites if the new message CID
       // has higher lexicographic value.
       const equivalentProtocols = [protocol1, protocolTrailingSlash, protocolParams, protocolCapitalized];
-      let messageDataWithCid: (GenerateProtocolsConfigureOutput & { cid: string })[] = [];
+      const messageDataWithCid: (GenerateProtocolsConfigureOutput & { cid: string })[] = [];
       for (const messageData of equivalentProtocols) {
         const cid = await Message.getCid(messageData.message);
         messageDataWithCid.push({ cid, ...messageData });
@@ -174,7 +174,7 @@ describe('ProtocolsQueryHandler.handle()', () => {
 
       // Expect equivalent protocol with highest lexicographic value to remain
       expect(resultProtocols).to.contain(
-        messageDataWithCid[messageDataWithCid.length-1].message.descriptor.protocol
+        messageDataWithCid[messageDataWithCid.length - 1].message.descriptor.protocol
       );
 
       // Expect URIs with subdomains, different capitalization, and different path to be excluded

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -185,7 +185,7 @@ describe('RecordsQueryHandler.handle()', () => {
           protocol: protocol2
         }
       });
-      const replyEquivalent = await dwn.processMessage(alice.did, messageData.message);
+      const replyEquivalent = await dwn.processMessage(alice.did, messageDataEquivalent.message);
 
       expect(replyEquivalent.status.code).to.equal(200);
       expect(replyEquivalent.entries?.length).to.equal(2); // only 2 entries should match the query on protocol

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -1,3 +1,4 @@
+import type { GenerateProtocolsConfigureOutput } from '../../../utils/test-data-generator.js';
 import type { RecordsQueryReplyEntry } from '../../../../src/interfaces/records/types.js';
 import type { DerivedPrivateJwk, EncryptionInput, ProtocolDefinition, RecordsWriteMessage } from '../../../../src/index.js';
 
@@ -7,6 +8,7 @@ import sinon from 'sinon';
 import chai, { expect } from 'chai';
 
 import { Comparer } from '../../../utils/comparer.js';
+import { constructRecordsWriteIndexes } from '../../../../src/interfaces/records/handlers/records-write.js';
 import { DataStoreLevel } from '../../../../src/store/data-store-level.js';
 import { DidKeyResolver } from '../../../../src/did/did-key-resolver.js';
 import { DwnConstant } from '../../../../src/core/dwn-constant.js';
@@ -14,18 +16,16 @@ import { Encoder } from '../../../../src/utils/encoder.js';
 import { Encryption } from '../../../../src/index.js';
 import { EventLogLevel } from '../../../../src/event-log/event-log-level.js';
 import { Jws } from '../../../../src/utils/jws.js';
+import { lexicographicalCompare } from '../../../../src/utils/string.js';
+import { Message } from '../../../../src/core/message.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
 import { RecordsQueryHandler } from '../../../../src/interfaces/records/handlers/records-query.js';
 import { StorageController } from '../../../../src/store/storage-controller.js';
 import { Temporal } from '@js-temporal/polyfill';
-import { GenerateProtocolsConfigureOutput, TestDataGenerator } from '../../../utils/test-data-generator.js';
+import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
-
-import { constructRecordsWriteIndexes } from '../../../../src/interfaces/records/handlers/records-write.js';
 import { DataStream, DidResolver, Dwn, HdKey, KeyDerivationScheme, Records } from '../../../../src/index.js';
 import { DateSort, RecordsQuery } from '../../../../src/interfaces/records/messages/records-query.js';
-import { Message } from '../../../../src/core/message.js';
-import { lexicographicalCompare } from '../../../../src/utils/string.js';
 
 chai.use(chaiAsPromised);
 
@@ -132,7 +132,7 @@ describe('RecordsQueryHandler.handle()', () => {
       const protocolsConfigures: GenerateProtocolsConfigureOutput[] = [];
       for (const protocol of protocols) {
         const protocolConfigure = await TestDataGenerator.generateProtocolsConfigure({
-          requester : alice,
+          requester: alice,
           protocol,
           protocolDefinition
         });
@@ -141,7 +141,7 @@ describe('RecordsQueryHandler.handle()', () => {
 
       // Sort messages into lexicographic order. We only allow protocol overwrites if the new message CID
       // has higher lexicographic value.
-      let messageDataWithCid: (GenerateProtocolsConfigureOutput & { cid: string })[] = [];
+      const messageDataWithCid: (GenerateProtocolsConfigureOutput & { cid: string })[] = [];
       for (const messageData of protocolsConfigures) {
         const cid = await Message.getCid(messageData.message);
         messageDataWithCid.push({ cid, ...messageData });

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -178,6 +178,19 @@ describe('RecordsQueryHandler.handle()', () => {
       expect(reply.status.code).to.equal(200);
       expect(reply.entries?.length).to.equal(2); // only 2 entries should match the query on protocol
 
+      // Query equivalent protocol to get same result
+      const messageDataEquivalent = await TestDataGenerator.generateRecordsQuery({
+        requester : alice,
+        filter    : {
+          protocol: protocol2
+        }
+      });
+      const replyEquivalent = await dwn.processMessage(alice.did, messageData.message);
+
+      expect(replyEquivalent.status.code).to.equal(200);
+      expect(replyEquivalent.entries?.length).to.equal(2); // only 2 entries should match the query on protocol
+
+      // Query a nonmatching protocol
       const messageData2 = await TestDataGenerator.generateRecordsQuery({
         requester : alice,
         filter    : {

--- a/tests/utils/url.spec.ts
+++ b/tests/utils/url.spec.ts
@@ -24,6 +24,13 @@ describe('url', () => {
 
       expect(normalizeProtocolUrl('example')).to.equal('example');
       expect(normalizeProtocolUrl('/example/')).to.equal('example');
+
+      // weird edge cases. if we see these in the wild, someone is misusing DWNs
+      expect(normalizeProtocolUrl('://')).to.equal('://');
+      expect(normalizeProtocolUrl('http://')).to.equal('http/');
+      expect(normalizeProtocolUrl('foo://')).to.equal(''); // oof
+      expect(normalizeProtocolUrl('foo://bar')).to.equal('bar');
+      expect(normalizeProtocolUrl('://foo')).to.equal('://foo');
     });
   });
 });

--- a/tests/utils/url.spec.ts
+++ b/tests/utils/url.spec.ts
@@ -1,0 +1,29 @@
+import chaiAsPromised from 'chai-as-promised';
+import chai, { expect } from 'chai';
+
+import { normalizeProtocolUrl } from '../../src/utils/url.js';
+
+chai.use(chaiAsPromised);
+
+describe('url', () => {
+  describe('normalizeProtocolUrl', () => {
+    it('returns hostname and path with trailing slash removed', () => {
+      expect(normalizeProtocolUrl('example.com')).to.equal('example.com');
+      expect(normalizeProtocolUrl('example.com/')).to.equal('example.com');
+      expect(normalizeProtocolUrl('https://example.com')).to.equal('example.com');
+      expect(normalizeProtocolUrl('https://example.com/')).to.equal('example.com');
+      expect(normalizeProtocolUrl('example.com?foo=bar')).to.equal('example.com');
+      expect(normalizeProtocolUrl('example.com/?foo=bar')).to.equal('example.com');
+
+      expect(normalizeProtocolUrl('example.com/path')).to.equal('example.com/path');
+      expect(normalizeProtocolUrl('example.com/path/')).to.equal('example.com/path');
+      expect(normalizeProtocolUrl('https://example.com/path')).to.equal('example.com/path');
+      expect(normalizeProtocolUrl('https://example.com/path')).to.equal('example.com/path');
+      expect(normalizeProtocolUrl('example.com/path?foo=bar')).to.equal('example.com/path');
+      expect(normalizeProtocolUrl('example.com/path/?foo=bar')).to.equal('example.com/path');
+
+      expect(normalizeProtocolUrl('example')).to.equal('example');
+      expect(normalizeProtocolUrl('/example/')).to.equal('example');
+    });
+  });
+});

--- a/tests/utils/url.spec.ts
+++ b/tests/utils/url.spec.ts
@@ -28,7 +28,7 @@ describe('url', () => {
       // weird edge cases. if we see these in the wild, someone is misusing DWNs
       expect(normalizeProtocolUrl('://')).to.equal('://');
       expect(normalizeProtocolUrl('http://')).to.equal('http/');
-      expect(normalizeProtocolUrl('foo://')).to.equal(''); // oof
+      expect(normalizeProtocolUrl('foo://')).to.equal('foo/');
       expect(normalizeProtocolUrl('foo://bar')).to.equal('bar');
       expect(normalizeProtocolUrl('://foo')).to.equal('://foo');
     });


### PR DESCRIPTION
Resolves part of #265. PR to normalize schemas will come next. Thanks @dcrousso for pointing me in the right direction!

The general approach is: Anywhere we call `MessageStore#put` or `MessageStore#query` normalize the protocol string in the indexes/filters respective.