### PR TITLE
Reject messages with nonnormalize protocol URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-93.86%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.36%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.54%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.86%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-93.94%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.42%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.69%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.94%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-<<<<<<< HEAD
-![Statements](https://img.shields.io/badge/statements-93.95%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.47%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.69%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.95%25-brightgreen.svg?style=flat)
-=======
-![Statements](https://img.shields.io/badge/statements-93.86%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.39%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.54%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.86%25-brightgreen.svg?style=flat)
->>>>>>> main
+![Statements](https://img.shields.io/badge/statements-93.95%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.46%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.69%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.95%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -20,6 +20,7 @@ export enum DwnErrorCode {
   MessageStoreDataCidMismatch = 'MessageStoreDataCidMismatch',
   MessageStoreDataNotFound = 'MessageStoreDataNotFound',
   MessageStoreDataSizeMismatch = 'MessageStoreDataSizeMismatch',
+  ProtocolUriNotNormalized = 'ProtocolUriNotNormalized',
   RecordsDecryptNoMatchingKeyDerivationScheme = 'RecordsDecryptNoMatchingKeyDerivationScheme',
   RecordsDeriveLeafPrivateKeyUnSupportedCurve = 'RecordsDeriveLeafPrivateKeyUnSupportedCurve',
   RecordsDeriveLeafPublicKeyUnSupportedCurve = 'RecordsDeriveLeafPublicKeyUnSupportedCurve',

--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -20,12 +20,13 @@ export enum DwnErrorCode {
   MessageStoreDataCidMismatch = 'MessageStoreDataCidMismatch',
   MessageStoreDataNotFound = 'MessageStoreDataNotFound',
   MessageStoreDataSizeMismatch = 'MessageStoreDataSizeMismatch',
-  ProtocolUriNotNormalized = 'ProtocolUriNotNormalized',
   RecordsDecryptNoMatchingKeyDerivationScheme = 'RecordsDecryptNoMatchingKeyDerivationScheme',
   RecordsDeriveLeafPrivateKeyUnSupportedCurve = 'RecordsDeriveLeafPrivateKeyUnSupportedCurve',
   RecordsDeriveLeafPublicKeyUnSupportedCurve = 'RecordsDeriveLeafPublicKeyUnSupportedCurve',
   RecordsInvalidAncestorKeyDerivationSegment = 'RecordsInvalidAncestorKeyDerivationSegment',
   RecordsWriteGetEntryIdUndefinedAuthor = 'RecordsWriteGetEntryIdUndefinedAuthor',
   RecordsWriteValidateIntegrityEncryptionCidMismatch = 'RecordsWriteValidateIntegrityEncryptionCidMismatch',
-  Secp256k1KeyNotValid = 'Secp256k1KeyNotValid'
+  Secp256k1KeyNotValid = 'Secp256k1KeyNotValid',
+  UrlProtocolNotNormalized = 'UrlProtocolNotNormalized',
+  UrlPrococolNotNormalizable = 'UriPrococolNotNormalizable'
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export type { EventLog, Event } from './event-log/event-log.js';
 export type { EventsGetMessage, EventsGetReply } from './interfaces/events/types.js';
 export type { HooksWriteMessage } from './interfaces/hooks/types.js';
 export type { MessagesGetMessage, MessagesGetReply } from './interfaces/messages/types.js';
-export type { ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureMessage, ProtocolsQueryMessage } from './interfaces/protocols/types.js';
+export type { ProtocolDefinition, ProtocolRuleSet, ProtocolsQueryFilter, ProtocolsConfigureMessage, ProtocolsQueryMessage } from './interfaces/protocols/types.js';
 export type { RecordsDeleteMessage, RecordsQueryMessage, RecordsWriteMessage } from './interfaces/records/types.js';
 export { AllowAllTenantGate, TenantGate } from './core/tenant-gate.js';
 export { Cid } from './utils/cid.js';

--- a/src/interfaces/protocols/messages/protocols-configure.ts
+++ b/src/interfaces/protocols/messages/protocols-configure.ts
@@ -5,6 +5,7 @@ import { getCurrentTimeInHighPrecision } from '../../../utils/time.js';
 import { validateAuthorizationIntegrity } from '../../../core/auth.js';
 
 import { DwnInterfaceName, DwnMethodName, Message } from '../../../core/message.js';
+import { normalizeProtocolUri, validateProtocolUriNormalized } from '../../../utils/url.js';
 
 export type ProtocolsConfigureOptions = {
   dateCreated? : string;
@@ -17,6 +18,7 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
 
   public static async parse(message: ProtocolsConfigureMessage): Promise<ProtocolsConfigure> {
     await validateAuthorizationIntegrity(message);
+    validateProtocolUriNormalized(message.descriptor.protocol);
 
     return new ProtocolsConfigure(message);
   }
@@ -26,7 +28,7 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
       interface   : DwnInterfaceName.Protocols,
       method      : DwnMethodName.Configure,
       dateCreated : options.dateCreated ?? getCurrentTimeInHighPrecision(),
-      protocol    : options.protocol,
+      protocol    : normalizeProtocolUri(options.protocol),
       definition  : options.definition // TODO: #139 - move definition out of the descriptor - https://github.com/TBD54566975/dwn-sdk-js/issues/139
     };
 

--- a/src/interfaces/protocols/types.ts
+++ b/src/interfaces/protocols/types.ts
@@ -41,13 +41,15 @@ export type ProtocolsConfigureMessage = BaseMessage & {
   descriptor: ProtocolsConfigureDescriptor;
 };
 
+export type ProtocolsQueryFilter = {
+  protocol: string,
+};
+
 export type ProtocolsQueryDescriptor = {
   interface : DwnInterfaceName.Protocols,
   method: DwnMethodName.Query;
   dateCreated: string;
-  filter?: {
-    protocol: string;
-  }
+  filter?: ProtocolsQueryFilter
 };
 
 export type ProtocolsQueryMessage = BaseMessage & {

--- a/src/interfaces/records/messages/records-write.ts
+++ b/src/interfaces/records/messages/records-write.ts
@@ -119,10 +119,6 @@ export class RecordsWrite extends Message<RecordsWriteMessage> {
     await validateAuthorizationIntegrity(message, { allowedProperties: new Set(['recordId', 'contextId', 'attestationCid', 'encryptionCid']) });
     await RecordsWrite.validateAttestationIntegrity(message);
 
-    if (message.descriptor.protocol !== undefined) {
-      validateProtocolUriNormalized(message.descriptor.protocol);
-    }
-
     const recordsWrite = new RecordsWrite(message);
 
     await recordsWrite.validateIntegrity(); // RecordsWrite specific data integrity check
@@ -363,6 +359,10 @@ export class RecordsWrite extends Message<RecordsWriteMessage> {
           `CID ${expectedEncryptionCid} of encryption property in message does not match encryptionCid in authorization: ${actualEncryptionCid}`
         );
       }
+    }
+
+    if (this.message.descriptor.protocol !== undefined) {
+      validateProtocolUriNormalized(this.message.descriptor.protocol);
     }
   }
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,42 @@
+import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
+
+const URL_PROTOCOL_REGEX = /^[^:]+:\/\/./;
+
+export function validateProtocolUriNormalized(protocol: string): void {
+  let normalized: string | undefined;
+  try {
+    normalized = normalizeProtocolUri(protocol);
+  } catch {
+    normalized = undefined;
+  }
+
+  if (protocol !== normalized) {
+    throw new DwnError(DwnErrorCode.ProtocolUriNotNormalized, 'Protocol URI must be normalized.');
+  }
+}
+
+export function normalizeProtocolUri(url: string): string {
+  let fullUrl: string;
+  if (URL_PROTOCOL_REGEX.test(url)) {
+    fullUrl = url;
+  } else {
+    fullUrl = `http://${url}`;
+  }
+
+  try {
+    const result = new URL(fullUrl);
+    result.search = '';
+    result.hash = '';
+    return removeTrailingSlash(result.href);
+  } catch (e) {
+    throw new Error('Could not normalize protocol URI');
+  }
+}
+
+function removeTrailingSlash(str: string): string {
+  if (str.endsWith('/')) {
+    return str.slice(0, -1);
+  } else {
+    return str;
+  }
+}

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,6 +1,5 @@
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 
-const URL_PROTOCOL_REGEX = /^[^:]+:\/\/./;
 
 export function validateProtocolUriNormalized(protocol: string): void {
   let normalized: string | undefined;
@@ -11,13 +10,13 @@ export function validateProtocolUriNormalized(protocol: string): void {
   }
 
   if (protocol !== normalized) {
-    throw new DwnError(DwnErrorCode.ProtocolUriNotNormalized, 'Protocol URI must be normalized.');
+    throw new DwnError(DwnErrorCode.UrlProtocolNotNormalized, 'Protocol URI must be normalized.');
   }
 }
 
 export function normalizeProtocolUri(url: string): string {
   let fullUrl: string;
-  if (URL_PROTOCOL_REGEX.test(url)) {
+  if (/^[^:]+:\/\/./.test(url)) {
     fullUrl = url;
   } else {
     fullUrl = `http://${url}`;
@@ -29,7 +28,7 @@ export function normalizeProtocolUri(url: string): string {
     result.hash = '';
     return removeTrailingSlash(result.href);
   } catch (e) {
-    throw new Error('Could not normalize protocol URI');
+    throw new DwnError(DwnErrorCode.UrlPrococolNotNormalizable, 'Could not normalize protocol URI');
   }
 }
 

--- a/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
@@ -161,7 +161,7 @@ describe('ProtocolsConfigureHandler.handle()', () => {
       // Send records write message
       const reply = await dwn.processMessage(alice.did, protocolsConfig.message);
       expect(reply.status.code).to.equal(400);
-      expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolUriNotNormalized);
+      expect(reply.status.detail).to.contain(DwnErrorCode.UrlProtocolNotNormalized);
     });
 
     describe('event log', () => {

--- a/tests/interfaces/protocols/handlers/protocols-query.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-query.spec.ts
@@ -6,11 +6,12 @@ import { DataStoreLevel } from '../../../../src/store/data-store-level.js';
 import { DidKeyResolver } from '../../../../src/did/did-key-resolver.js';
 import { EventLogLevel } from '../../../../src/event-log/event-log-level.js';
 import { GeneralJwsSigner } from '../../../../src/jose/jws/general/signer.js';
+import { Message } from '../../../../src/core/message.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
 
-import { DidResolver, Dwn, Encoder, Jws } from '../../../../src/index.js';
+import { DidResolver, Dwn, DwnErrorCode, Encoder, Jws } from '../../../../src/index.js';
 
 chai.use(chaiAsPromised);
 
@@ -91,6 +92,30 @@ describe('ProtocolsQueryHandler.handle()', () => {
 
       expect(reply2.status.code).to.equal(200);
       expect(reply2.entries?.length).to.equal(3); // expecting all 3 entries written above match the query
+    });
+
+    it('should return 400 if protocol is not normalized', async () => {
+      const alice = await DidKeyResolver.generate();
+
+      // query for non-normalized protocol
+      const protocolsQuery = await TestDataGenerator.generateProtocolsQuery({
+        requester : alice,
+        filter    : { protocol: 'example.com/' },
+      });
+
+      // overwrite protocol because #create auto-normalizes protocol
+      protocolsQuery.message.descriptor.filter!.protocol = 'example.com/';
+
+      // Re-create auth because we altered the descriptor after signing
+      protocolsQuery.message.authorization = await Message.signAsAuthorization(
+        protocolsQuery.message.descriptor,
+        Jws.createSignatureInput(alice)
+      );
+
+      // Send records write message
+      const reply = await dwn.processMessage(alice.did, protocolsQuery.message);
+      expect(reply.status.code).to.equal(400);
+      expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolUriNotNormalized);
     });
 
     it('should fail with 400 if `authorization` is referencing a different message (`descriptorCid`)', async () => {

--- a/tests/interfaces/protocols/handlers/protocols-query.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-query.spec.ts
@@ -115,7 +115,7 @@ describe('ProtocolsQueryHandler.handle()', () => {
       // Send records write message
       const reply = await dwn.processMessage(alice.did, protocolsQuery.message);
       expect(reply.status.code).to.equal(400);
-      expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolUriNotNormalized);
+      expect(reply.status.detail).to.contain(DwnErrorCode.UrlProtocolNotNormalized);
     });
 
     it('should fail with 400 if `authorization` is referencing a different message (`descriptorCid`)', async () => {

--- a/tests/interfaces/protocols/messages/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols/messages/protocols-configure.spec.ts
@@ -1,6 +1,8 @@
 import chaiAsPromised from 'chai-as-promised';
 import chai, { expect } from 'chai';
 
+import type { ProtocolsConfigureMessage } from '../../../../src/index.js';
+
 import dexProtocolDefinition from '../../../vectors/protocol-definitions/dex.json' assert { type: 'json' };
 import { getCurrentTimeInHighPrecision } from '../../../../src/utils/time.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
@@ -22,6 +24,24 @@ describe('ProtocolsConfigure', () => {
       });
 
       expect(protocolsConfigure.message.descriptor.dateCreated).to.equal(currentTime);
+    });
+
+    it('should auto-normalize protocol URI', async () => {
+      const alice = await TestDataGenerator.generatePersona();
+
+      const options = {
+        recipient                   : alice.did,
+        data                        : TestDataGenerator.randomBytes(10),
+        dataFormat                  : 'application/json',
+        authorizationSignatureInput : Jws.createSignatureInput(alice),
+        protocol                    : 'example.com/',
+        definition                  : dexProtocolDefinition
+      };
+      const protocolsConfig = await ProtocolsConfigure.create(options);
+
+      const message = protocolsConfig.message as ProtocolsConfigureMessage;
+
+      expect(message.descriptor.protocol).to.eq('http://example.com');
     });
   });
 });

--- a/tests/interfaces/protocols/messages/protocols-query.spec.ts
+++ b/tests/interfaces/protocols/messages/protocols-query.spec.ts
@@ -1,6 +1,9 @@
 import chaiAsPromised from 'chai-as-promised';
 import chai, { expect } from 'chai';
 
+import type { ProtocolsQueryMessage } from '../../../../src/index.js';
+
+import dexProtocolDefinition from '../../../vectors/protocol-definitions/dex.json' assert { type: 'json' };
 import { getCurrentTimeInHighPrecision } from '../../../../src/utils/time.js';
 import { Jws } from '../../../../src/index.js';
 import { ProtocolsQuery } from '../../../../src/interfaces/protocols/messages/protocols-query.js';
@@ -21,6 +24,25 @@ describe('ProtocolsQuery', () => {
       });
 
       expect(protocolsQuery.message.descriptor.dateCreated).to.equal(currentTime);
+    });
+
+
+    it('should auto-normalize protocol URI', async () => {
+      const alice = await TestDataGenerator.generatePersona();
+
+      const options = {
+        recipient                   : alice.did,
+        data                        : TestDataGenerator.randomBytes(10),
+        dataFormat                  : 'application/json',
+        authorizationSignatureInput : Jws.createSignatureInput(alice),
+        filter                      : { protocol: 'example.com/' },
+        definition                  : dexProtocolDefinition
+      };
+      const protocolsConfig = await ProtocolsQuery.create(options);
+
+      const message = protocolsConfig.message as ProtocolsQueryMessage;
+
+      expect(message.descriptor.filter!.protocol).to.eq('http://example.com');
     });
   });
 });

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -614,7 +614,7 @@ describe('RecordsQueryHandler.handle()', () => {
       // Send records write message
       const reply = await dwn.processMessage(alice.did, recordsQuery.message);
       expect(reply.status.code).to.equal(400);
-      expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolUriNotNormalized);
+      expect(reply.status.detail).to.contain(DwnErrorCode.UrlProtocolNotNormalized);
     });
 
     describe('encryption scenarios', () => {

--- a/tests/interfaces/records/handlers/records-read.spec.ts
+++ b/tests/interfaces/records/handlers/records-read.spec.ts
@@ -373,7 +373,7 @@ describe('RecordsReadHandler.handle()', () => {
         TestStubGenerator.stubDidResolver(didResolver, [alice, bob]);
 
         // configure protocol
-        const protocol = 'email-protocol';
+        const protocol = 'https://email-protocol.com';
         const protocolDefinition: ProtocolDefinition = emailProtocolDefinition;
         const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
           requester: alice,

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1383,11 +1383,11 @@ describe('RecordsWriteHandler.handle()', () => {
 
         // write a message into DB
         const recordsWrite = await TestDataGenerator.generateRecordsWrite({
-          requester : alice,
-          data      : new TextEncoder().encode('data1'),
-          protocol  : 'example.com/',
-          protocolPath: 'email', // from email protocol
-          schema    : emailProtocolDefinition.labels.email.schema
+          requester    : alice,
+          data         : new TextEncoder().encode('data1'),
+          protocol     : 'example.com/',
+          protocolPath : 'email', // from email protocol
+          schema       : emailProtocolDefinition.labels.email.schema
         });
 
         // overwrite protocol because #create auto-normalizes protocol

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1433,7 +1433,7 @@ describe('RecordsWriteHandler.handle()', () => {
         // Send records write message
         const reply = await dwn.processMessage(alice.did, recordsWrite.message, recordsWrite.dataStream);
         expect(reply.status.code).to.equal(400);
-        expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolUriNotNormalized);
+        expect(reply.status.detail).to.contain(DwnErrorCode.UrlProtocolNotNormalized);
       });
     });
   });

--- a/tests/interfaces/records/messages/records-query.spec.ts
+++ b/tests/interfaces/records/messages/records-query.spec.ts
@@ -1,6 +1,9 @@
 import chaiAsPromised from 'chai-as-promised';
 import chai, { expect } from 'chai';
 
+import type { RecordsQueryMessage } from '../../../../src/index.js';
+
+import dexProtocolDefinition from '../../../vectors/protocol-definitions/dex.json' assert { type: 'json' };
 import { getCurrentTimeInHighPrecision } from '../../../../src/utils/time.js';
 import { Jws } from '../../../../src/index.js';
 import { RecordsQuery } from '../../../../src/interfaces/records/messages/records-query.js';
@@ -21,6 +24,24 @@ describe('RecordsQuery', () => {
       });
 
       expect(recordsQuery.message.descriptor.dateCreated).to.equal(currentTime);
+    });
+
+    it('should auto-normalize protocol URI', async () => {
+      const alice = await TestDataGenerator.generatePersona();
+
+      const options = {
+        recipient                   : alice.did,
+        data                        : TestDataGenerator.randomBytes(10),
+        dataFormat                  : 'application/json',
+        authorizationSignatureInput : Jws.createSignatureInput(alice),
+        filter                      : { protocol: 'example.com/' },
+        definition                  : dexProtocolDefinition
+      };
+      const protocolsConfig = await RecordsQuery.create(options);
+
+      const message = protocolsConfig.message as RecordsQueryMessage;
+
+      expect(message.descriptor.filter!.protocol).to.eq('http://example.com');
     });
   });
 });

--- a/tests/interfaces/records/messages/records-write.spec.ts
+++ b/tests/interfaces/records/messages/records-write.spec.ts
@@ -123,6 +123,23 @@ describe('RecordsWrite', () => {
 
       await expect(createPromise2).to.be.rejectedWith('`dataCid` and `dataSize` must both be defined or undefined at the same time');
     });
+
+    it('should auto-normalize protocol URI', async () => {
+      const alice = await TestDataGenerator.generatePersona();
+
+      const options = {
+        recipient                   : alice.did,
+        data                        : TestDataGenerator.randomBytes(10),
+        dataFormat                  : 'application/json',
+        authorizationSignatureInput : Jws.createSignatureInput(alice),
+        protocol                    : 'example.com/'
+      };
+      const recordsWrite = await RecordsWrite.create(options);
+
+      const message = recordsWrite.message as RecordsWriteMessage;
+
+      expect(message.descriptor.protocol).to.eq('http://example.com');
+    });
   });
 
   describe('createFrom()', () => {

--- a/tests/utils/url.spec.ts
+++ b/tests/utils/url.spec.ts
@@ -1,0 +1,44 @@
+import chaiAsPromised from 'chai-as-promised';
+import chai, { expect } from 'chai';
+
+import { normalizeProtocolUri, validateProtocolUriNormalized } from '../../src/utils/url.js';
+
+chai.use(chaiAsPromised);
+
+describe('url', () => {
+  describe('validateProtocolUriNormalized', () => {
+    it('errors when URI is not normalized', () => {
+      expect(() => validateProtocolUriNormalized('https://example.com')).to.not.throw();
+      expect(() => validateProtocolUriNormalized('example.com')).to.throw();
+      expect(() => validateProtocolUriNormalized(':foo:')).to.throw();
+    });
+  });
+
+  describe('normalizeProtocolUri', () => {
+    it('returns hostname and path with trailing slash removed', () => {
+      expect(normalizeProtocolUri('example.com')).to.equal('http://example.com');
+      expect(normalizeProtocolUri('example.com/')).to.equal('http://example.com');
+      expect(normalizeProtocolUri('http://example.com')).to.equal('http://example.com');
+      expect(normalizeProtocolUri('http://example.com/')).to.equal('http://example.com');
+      expect(normalizeProtocolUri('example.com?foo=bar')).to.equal('http://example.com');
+      expect(normalizeProtocolUri('example.com/?foo=bar')).to.equal('http://example.com');
+
+      expect(normalizeProtocolUri('example.com/path')).to.equal('http://example.com/path');
+      expect(normalizeProtocolUri('example.com/path/')).to.equal('http://example.com/path');
+      expect(normalizeProtocolUri('http://example.com/path')).to.equal('http://example.com/path');
+      expect(normalizeProtocolUri('http://example.com/path')).to.equal('http://example.com/path');
+      expect(normalizeProtocolUri('example.com/path?foo=bar')).to.equal('http://example.com/path');
+      expect(normalizeProtocolUri('example.com/path/?foo=bar')).to.equal('http://example.com/path');
+      expect(normalizeProtocolUri('example.com/path#baz')).to.equal('http://example.com/path');
+      expect(normalizeProtocolUri('example.com/path/#baz')).to.equal('http://example.com/path');
+
+      expect(normalizeProtocolUri('example')).to.equal('http://example');
+      expect(normalizeProtocolUri('/example/')).to.equal('http://example');
+
+      // expect(() => normalizeProtocolUri('...')).to.throw(Error);
+      expect(() => normalizeProtocolUri('://http')).to.throw(Error);
+      expect(() => normalizeProtocolUri(':foo:')).to.throw(Error);
+
+    });
+  });
+});

--- a/tests/utils/url.spec.ts
+++ b/tests/utils/url.spec.ts
@@ -35,10 +35,8 @@ describe('url', () => {
       expect(normalizeProtocolUri('example')).to.equal('http://example');
       expect(normalizeProtocolUri('/example/')).to.equal('http://example');
 
-      // expect(() => normalizeProtocolUri('...')).to.throw(Error);
       expect(() => normalizeProtocolUri('://http')).to.throw(Error);
       expect(() => normalizeProtocolUri(':foo:')).to.throw(Error);
-
     });
   });
 });


### PR DESCRIPTION
Addresses part of https://github.com/TBD54566975/dwn-sdk-js/issues/265
Revises a previous attempt #314 

## Changes
To ensure that protocols URIs are bucketed intuitively,
1. `#create` methods auto-normalize protocols for an ergonomic developer experience
2. non-normalized protocols are rejected from DWNs

## TODO
Going to add a little more test coverage in the morning to bring relevant files back up to 100%