### PR TITLE
#306 Validate data format on protocol authd writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-93.99%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.5%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.72%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-93.99%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.03%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.54%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.75%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.03%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/json-schemas/protocol-definition.json
+++ b/json-schemas/protocol-definition.json
@@ -17,6 +17,12 @@
           "properties": {
             "schema": {
               "type": "string"
+            },
+            "dataFormats": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         }

--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -20,6 +20,7 @@ export enum DwnErrorCode {
   MessageStoreDataCidMismatch = 'MessageStoreDataCidMismatch',
   MessageStoreDataNotFound = 'MessageStoreDataNotFound',
   MessageStoreDataSizeMismatch = 'MessageStoreDataSizeMismatch',
+  ProtocolAuthorizationIncorrectDataFormat = 'ProtocolAuthorizationIncorrectDataFormat',
   ProtocolAuthorizationIncorrectProtocolPath = 'ProtocolAuthorizationIncorrectProtocolPath',
   ProtocolAuthorizationInvalidSchema = 'ProtocolAuthorizationInvalidSchema',
   RecordsDecryptNoMatchingKeyDerivationScheme = 'RecordsDecryptNoMatchingKeyDerivationScheme',

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -59,7 +59,7 @@ export class ProtocolAuthorization {
       incomingMessage.message,
       protocolDefinition,
       recordSchemaToLabelMap,
-    )
+    );
 
     // verify method invoked against the allowed actions
     ProtocolAuthorization.verifyAllowedActions(
@@ -251,7 +251,7 @@ export class ProtocolAuthorization {
     inboundMessage: RecordsReadMessage | RecordsWriteMessage,
     protocolDefinition: ProtocolDefinition,
     recordSchemaToLabelMap: Map<string, string>
-  ) {
+  ): void {
     // skip verification if this is not a RecordsWrite
     if (inboundMessage.descriptor.method !== DwnMethodName.Write) {
       return;

--- a/src/interfaces/protocols/types.ts
+++ b/src/interfaces/protocols/types.ts
@@ -11,7 +11,10 @@ export type ProtocolsConfigureDescriptor = {
 
 export type ProtocolDefinition = {
   labels: {
-    [key: string]: { schema: string };
+    [key: string]: {
+      schema: string,
+      dataFormats?: string[],
+    };
   };
   records: {
     [key: string]: ProtocolRuleSet;

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1029,6 +1029,66 @@ describe('RecordsWriteHandler.handle()', () => {
         expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationIncorrectProtocolPath);
       });
 
+      it('should fail authorization if given `dataFormat` is mismatching with the dataFormats in protocol definition', async () => {
+        // TODO(diehuxx)
+        const alice = await DidKeyResolver.generate();
+
+        const protocolDefinition = {
+          labels: {
+            image: {
+              schema: 'https://example.com/schema',
+              dataFormats: ["image/jpeg", "image/png"]
+            }
+          },
+          records: {
+            image: {
+              allow: {
+                anyone: { to: ["write"] }
+              }
+            }
+          }
+        }
+
+        const protocol = 'https://tbd.website/decentralized-web-node/protocols/social-media';
+        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+          requester          : alice,
+          protocol,
+          protocolDefinition : protocolDefinition,
+        });
+
+        const protocolConfigureReply = await dwn.processMessage(alice.did, protocolConfig.message, protocolConfig.dataStream);
+        expect(protocolConfigureReply.status.code).to.equal(202);
+
+        // write record with matching dataFormat
+        const data = Encoder.stringToBytes('any data');
+        const recordsWriteMatch = await TestDataGenerator.generateRecordsWrite({
+          requester    : alice,
+          recipientDid : alice.did,
+          protocol,
+          protocolPath : 'image',
+          schema       : protocolDefinition.labels.image.schema,
+          dataFormat   : 'image/jpeg',
+          data
+        });
+        const replyMatch = await dwn.processMessage(alice.did, recordsWriteMatch.message, recordsWriteMatch.dataStream);
+        expect(replyMatch.status.code).to.equal(202);
+
+        // write record with mismatch dataFormat
+        const recordsWriteMismatch = await TestDataGenerator.generateRecordsWrite({
+          requester    : alice,
+          recipientDid : alice.did,
+          protocol,
+          protocolPath : 'image',
+          schema       : protocolDefinition.labels.image.schema,
+          dataFormat   : 'not/allowed/dataFormat',
+          data
+        });
+
+        const replyMismatch = await dwn.processMessage(alice.did, recordsWriteMismatch.message, recordsWriteMismatch.dataStream);
+        expect(replyMismatch.status.code).to.equal(401);
+        expect(replyMismatch.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationIncorrectDataFormat);
+      });
+
       it('should fail authorization if record schema is not allowed at the hierarchical level attempted for the RecordsWrite', async () => {
         const alice = await DidKeyResolver.generate();
 

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1030,24 +1030,23 @@ describe('RecordsWriteHandler.handle()', () => {
       });
 
       it('should fail authorization if given `dataFormat` is mismatching with the dataFormats in protocol definition', async () => {
-        // TODO(diehuxx)
         const alice = await DidKeyResolver.generate();
 
         const protocolDefinition = {
           labels: {
             image: {
-              schema: 'https://example.com/schema',
-              dataFormats: ["image/jpeg", "image/png"]
+              schema      : 'https://example.com/schema',
+              dataFormats : ['image/jpeg', 'image/png']
             }
           },
           records: {
             image: {
               allow: {
-                anyone: { to: ["write"] }
+                anyone: { to: ['write'] }
               }
             }
           }
-        }
+        };
 
         const protocol = 'https://tbd.website/decentralized-web-node/protocols/social-media';
         const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({


### PR DESCRIPTION
Fully addresses #306

* Add `dataFormats` to protocol definition JSON schema
* Validate that incoming RecordsWrites are within the allowed `dataFormats`