### PR TITLE
Reject messages with nonnormalized schema URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-<<<<<<< HEAD
-![Statements](https://img.shields.io/badge/statements-94.06%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.65%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.89%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.06%25-brightgreen.svg?style=flat)
-=======
-![Statements](https://img.shields.io/badge/statements-94.07%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.6%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.8%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.07%25-brightgreen.svg?style=flat)
->>>>>>> main
+![Statements](https://img.shields.io/badge/statements-94.1%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.71%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.94%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.1%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.03%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.54%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.75%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.03%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.06%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.65%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.89%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.06%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -32,7 +32,7 @@ export enum DwnErrorCode {
   RecordsWriteValidateIntegrityEncryptionCidMismatch = 'RecordsWriteValidateIntegrityEncryptionCidMismatch',
   Secp256k1KeyNotValid = 'Secp256k1KeyNotValid',
   UrlProtocolNotNormalized = 'UrlProtocolNotNormalized',
-  UrlPrococolNotNormalizable = 'UrlPrococolNotNormalizable',
+  UrlProtocolNotNormalizable = 'UrlProtocolNotNormalizable',
   UrlSchemaNotNormalized = 'UrlSchemaNotNormalized',
   UrlSchemaNotNormalizable = 'UrlSchemaNotNormalizable'
 };

--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -31,5 +31,7 @@ export enum DwnErrorCode {
   RecordsWriteValidateIntegrityEncryptionCidMismatch = 'RecordsWriteValidateIntegrityEncryptionCidMismatch',
   Secp256k1KeyNotValid = 'Secp256k1KeyNotValid',
   UrlProtocolNotNormalized = 'UrlProtocolNotNormalized',
-  UrlPrococolNotNormalizable = 'UriPrococolNotNormalizable'
+  UrlPrococolNotNormalizable = 'UriPrococolNotNormalizable',
+  UrlSchemaNotNormalized = 'UrlSchemaNotNormalized',
+  UrlSchemaNotNormalizable = 'UrlSchemaNotNormalizable'
 };

--- a/src/interfaces/protocols/messages/protocols-configure.ts
+++ b/src/interfaces/protocols/messages/protocols-configure.ts
@@ -5,7 +5,7 @@ import { getCurrentTimeInHighPrecision } from '../../../utils/time.js';
 import { validateAuthorizationIntegrity } from '../../../core/auth.js';
 
 import { DwnInterfaceName, DwnMethodName, Message } from '../../../core/message.js';
-import { normalizeProtocolUri, normalizeSchemaUri, validateProtocolUriNormalized, validateSchemaUriNormalized } from '../../../utils/url.js';
+import { normalizeProtocolUrl, normalizeSchemaUrl, validateProtocolUrlNormalized, validateSchemaUrlNormalized } from '../../../utils/url.js';
 
 export type ProtocolsConfigureOptions = {
   dateCreated? : string;
@@ -18,7 +18,7 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
 
   public static async parse(message: ProtocolsConfigureMessage): Promise<ProtocolsConfigure> {
     await validateAuthorizationIntegrity(message);
-    validateProtocolUriNormalized(message.descriptor.protocol);
+    validateProtocolUrlNormalized(message.descriptor.protocol);
     ProtocolsConfigure.validateDefinitionNormalized(message.descriptor.definition);
 
     return new ProtocolsConfigure(message);
@@ -29,7 +29,7 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
       interface   : DwnInterfaceName.Protocols,
       method      : DwnMethodName.Configure,
       dateCreated : options.dateCreated ?? getCurrentTimeInHighPrecision(),
-      protocol    : normalizeProtocolUri(options.protocol),
+      protocol    : normalizeProtocolUrl(options.protocol),
       // TODO: #139 - move definition out of the descriptor - https://github.com/TBD54566975/dwn-sdk-js/issues/139
       definition  : ProtocolsConfigure.normalizeDefinition(options.definition)
     };
@@ -44,19 +44,19 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
   }
 
   private static validateDefinitionNormalized(definition: ProtocolDefinition): void {
-    // validate schema uri normalized
+    // validate schema url normalized
     for (const labelKey in definition.labels) {
       const schema = definition.labels[labelKey].schema;
-      validateSchemaUriNormalized(schema);
+      validateSchemaUrlNormalized(schema);
     }
   }
 
   private static normalizeDefinition(definition: ProtocolDefinition): ProtocolDefinition {
     const definitionCopy = { ...definition };
 
-    // Normalize schema uri
+    // Normalize schema url
     for (const labelKey in definition.labels) {
-      definitionCopy.labels[labelKey].schema = normalizeSchemaUri(definitionCopy.labels[labelKey].schema);
+      definitionCopy.labels[labelKey].schema = normalizeSchemaUrl(definitionCopy.labels[labelKey].schema);
     }
 
     return definitionCopy;

--- a/src/interfaces/protocols/messages/protocols-configure.ts
+++ b/src/interfaces/protocols/messages/protocols-configure.ts
@@ -5,7 +5,7 @@ import { getCurrentTimeInHighPrecision } from '../../../utils/time.js';
 import { validateAuthorizationIntegrity } from '../../../core/auth.js';
 
 import { DwnInterfaceName, DwnMethodName, Message } from '../../../core/message.js';
-import { normalizeProtocolUri, validateProtocolUriNormalized } from '../../../utils/url.js';
+import { normalizeProtocolUri, normalizeSchemaUri, validateProtocolUriNormalized, validateSchemaUriNormalized } from '../../../utils/url.js';
 
 export type ProtocolsConfigureOptions = {
   dateCreated? : string;
@@ -19,6 +19,7 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
   public static async parse(message: ProtocolsConfigureMessage): Promise<ProtocolsConfigure> {
     await validateAuthorizationIntegrity(message);
     validateProtocolUriNormalized(message.descriptor.protocol);
+    ProtocolsConfigure.validateDefinitionNormalized(message.descriptor.definition);
 
     return new ProtocolsConfigure(message);
   }
@@ -29,7 +30,8 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
       method      : DwnMethodName.Configure,
       dateCreated : options.dateCreated ?? getCurrentTimeInHighPrecision(),
       protocol    : normalizeProtocolUri(options.protocol),
-      definition  : options.definition // TODO: #139 - move definition out of the descriptor - https://github.com/TBD54566975/dwn-sdk-js/issues/139
+      // TODO: #139 - move definition out of the descriptor - https://github.com/TBD54566975/dwn-sdk-js/issues/139
+      definition  : ProtocolsConfigure.normalizeDefinition(options.definition)
     };
 
     Message.validateJsonSchema({ descriptor, authorization: { } });
@@ -39,5 +41,24 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
 
     const protocolsConfigure = new ProtocolsConfigure(message);
     return protocolsConfigure;
+  }
+
+  private static validateDefinitionNormalized(definition: ProtocolDefinition): void {
+    // validate schema uri normalized
+    for (const labelKey in definition.labels) {
+      const schema = definition.labels[labelKey].schema;
+      validateSchemaUriNormalized(schema);
+    }
+  }
+
+  private static normalizeDefinition(definition: ProtocolDefinition): ProtocolDefinition {
+    const definitionCopy = { ...definition };
+
+    // Normalize schema uri
+    for (const labelKey in definition.labels) {
+      definitionCopy.labels[labelKey].schema = normalizeSchemaUri(definitionCopy.labels[labelKey].schema);
+    }
+
+    return definitionCopy;
   }
 }

--- a/src/interfaces/protocols/messages/protocols-query.ts
+++ b/src/interfaces/protocols/messages/protocols-query.ts
@@ -5,7 +5,7 @@ import { getCurrentTimeInHighPrecision } from '../../../utils/time.js';
 import { removeUndefinedProperties } from '../../../utils/object.js';
 import { validateAuthorizationIntegrity } from '../../../core/auth.js';
 import { DwnInterfaceName, DwnMethodName, Message } from '../../../core/message.js';
-import { normalizeProtocolUri, validateProtocolUriNormalized } from '../../../utils/url.js';
+import { normalizeProtocolUrl, validateProtocolUrlNormalized } from '../../../utils/url.js';
 
 export type ProtocolsQueryOptions = {
   dateCreated?: string;
@@ -19,7 +19,7 @@ export class ProtocolsQuery extends Message<ProtocolsQueryMessage> {
     await validateAuthorizationIntegrity(message);
 
     if (message.descriptor.filter !== undefined) {
-      validateProtocolUriNormalized(message.descriptor.filter.protocol);
+      validateProtocolUrlNormalized(message.descriptor.filter.protocol);
     }
 
     return new ProtocolsQuery(message);
@@ -53,7 +53,7 @@ export class ProtocolsQuery extends Message<ProtocolsQueryMessage> {
 
     return {
       ...filter,
-      protocol: normalizeProtocolUri(filter.protocol),
+      protocol: normalizeProtocolUrl(filter.protocol),
     };
   }
 }

--- a/src/interfaces/records/messages/records-query.ts
+++ b/src/interfaces/records/messages/records-query.ts
@@ -7,7 +7,7 @@ import { Message } from '../../../core/message.js';
 import { removeUndefinedProperties } from '../../../utils/object.js';
 import { validateAuthorizationIntegrity } from '../../../core/auth.js';
 import { DwnInterfaceName, DwnMethodName } from '../../../core/message.js';
-import { normalizeProtocolUri, normalizeSchemaUri, validateProtocolUriNormalized, validateSchemaUriNormalized } from '../../../utils/url.js';
+import { normalizeProtocolUrl, normalizeSchemaUrl, validateProtocolUrlNormalized, validateSchemaUrlNormalized } from '../../../utils/url.js';
 
 export enum DateSort {
   CreatedAscending = 'createdAscending',
@@ -29,10 +29,10 @@ export class RecordsQuery extends Message<RecordsQueryMessage> {
     await validateAuthorizationIntegrity(message);
 
     if (message.descriptor.filter.protocol !== undefined) {
-      validateProtocolUriNormalized(message.descriptor.filter.protocol);
+      validateProtocolUrlNormalized(message.descriptor.filter.protocol);
     }
     if (message.descriptor.filter.schema !== undefined) {
-      validateSchemaUriNormalized(message.descriptor.filter.schema);
+      validateSchemaUrlNormalized(message.descriptor.filter.schema);
     }
 
     return new RecordsQuery(message);
@@ -109,14 +109,14 @@ export class RecordsQuery extends Message<RecordsQueryMessage> {
     if (filter.protocol === undefined) {
       protocol = undefined;
     } else {
-      protocol = normalizeProtocolUri(filter.protocol);
+      protocol = normalizeProtocolUrl(filter.protocol);
     }
 
     let schema;
     if (filter.schema === undefined) {
       schema = undefined;
     } else {
-      schema = normalizeSchemaUri(filter.schema);
+      schema = normalizeSchemaUrl(filter.schema);
     }
 
     return {

--- a/src/interfaces/records/messages/records-write.ts
+++ b/src/interfaces/records/messages/records-write.ts
@@ -28,7 +28,7 @@ import { authorize, validateAuthorizationIntegrity } from '../../../core/auth.js
 import { Cid, computeCid } from '../../../utils/cid.js';
 import { DwnError, DwnErrorCode } from '../../../core/dwn-error.js';
 import { DwnInterfaceName, DwnMethodName } from '../../../core/message.js';
-import { normalizeProtocolUri, validateProtocolUriNormalized } from '../../../utils/url.js';
+import { normalizeProtocolUri, normalizeSchemaUri, validateProtocolUriNormalized, validateSchemaUriNormalized } from '../../../utils/url.js';
 
 export type RecordsWriteOptions = {
   recipient?: string;
@@ -164,7 +164,7 @@ export class RecordsWrite extends Message<RecordsWriteMessage> {
       protocol      : options.protocol !== undefined ? normalizeProtocolUri(options.protocol) : undefined,
       protocolPath  : options.protocolPath,
       recipient     : options.recipient!,
-      schema        : options.schema,
+      schema        : options.schema !== undefined ? normalizeSchemaUri(options.schema) : undefined,
       parentId      : options.parentId,
       dataCid,
       dataSize,
@@ -371,6 +371,9 @@ export class RecordsWrite extends Message<RecordsWriteMessage> {
 
     if (this.message.descriptor.protocol !== undefined) {
       validateProtocolUriNormalized(this.message.descriptor.protocol);
+    }
+    if (this.message.descriptor.schema !== undefined) {
+      validateSchemaUriNormalized(this.message.descriptor.schema);
     }
   }
 

--- a/src/interfaces/records/messages/records-write.ts
+++ b/src/interfaces/records/messages/records-write.ts
@@ -28,7 +28,7 @@ import { authorize, validateAuthorizationIntegrity } from '../../../core/auth.js
 import { Cid, computeCid } from '../../../utils/cid.js';
 import { DwnError, DwnErrorCode } from '../../../core/dwn-error.js';
 import { DwnInterfaceName, DwnMethodName } from '../../../core/message.js';
-import { normalizeProtocolUri, normalizeSchemaUri, validateProtocolUriNormalized, validateSchemaUriNormalized } from '../../../utils/url.js';
+import { normalizeProtocolUrl, normalizeSchemaUrl, validateProtocolUrlNormalized, validateSchemaUrlNormalized } from '../../../utils/url.js';
 
 export type RecordsWriteOptions = {
   recipient?: string;
@@ -166,10 +166,10 @@ export class RecordsWrite extends Message<RecordsWriteMessage> {
     const descriptor: RecordsWriteDescriptor = {
       interface     : DwnInterfaceName.Records,
       method        : DwnMethodName.Write,
-      protocol      : options.protocol !== undefined ? normalizeProtocolUri(options.protocol) : undefined,
+      protocol      : options.protocol !== undefined ? normalizeProtocolUrl(options.protocol) : undefined,
       protocolPath  : options.protocolPath,
       recipient     : options.recipient!,
-      schema        : options.schema !== undefined ? normalizeSchemaUri(options.schema) : undefined,
+      schema        : options.schema !== undefined ? normalizeSchemaUrl(options.schema) : undefined,
       parentId      : options.parentId,
       dataCid,
       dataSize,
@@ -375,10 +375,10 @@ export class RecordsWrite extends Message<RecordsWriteMessage> {
     }
 
     if (this.message.descriptor.protocol !== undefined) {
-      validateProtocolUriNormalized(this.message.descriptor.protocol);
+      validateProtocolUrlNormalized(this.message.descriptor.protocol);
     }
     if (this.message.descriptor.schema !== undefined) {
-      validateSchemaUriNormalized(this.message.descriptor.schema);
+      validateSchemaUrlNormalized(this.message.descriptor.schema);
     }
   }
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,44 +1,44 @@
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 
-export function validateProtocolUriNormalized(uri: string): void {
+export function validateProtocolUrlNormalized(url: string): void {
   let normalized: string | undefined;
   try {
-    normalized = normalizeProtocolUri(uri);
+    normalized = normalizeProtocolUrl(url);
   } catch {
     normalized = undefined;
   }
 
-  if (uri !== normalized) {
-    throw new DwnError(DwnErrorCode.UrlProtocolNotNormalized, `Protocol URI ${uri} must be normalized.`);
+  if (url !== normalized) {
+    throw new DwnError(DwnErrorCode.UrlProtocolNotNormalized, `Protocol URI ${url} must be normalized.`);
   }
 }
 
-export function normalizeProtocolUri(url: string): string {
+export function normalizeProtocolUrl(url: string): string {
   // Keeping protocol normalization as a separate function in case
   // protocol and schema normalization diverge in the future
-  return normalizeUri(url);
+  return normalizeUrl(url);
 }
 
-export function validateSchemaUriNormalized(uri: string): void {
+export function validateSchemaUrlNormalized(url: string): void {
   let normalized: string | undefined;
   try {
-    normalized = normalizeSchemaUri(uri);
+    normalized = normalizeSchemaUrl(url);
   } catch {
     normalized = undefined;
   }
 
-  if (uri !== normalized) {
-    throw new DwnError(DwnErrorCode.UrlSchemaNotNormalized, `Schema URI ${uri} must be normalized.`);
+  if (url !== normalized) {
+    throw new DwnError(DwnErrorCode.UrlSchemaNotNormalized, `Schema URI ${url} must be normalized.`);
   }
 }
 
-export function normalizeSchemaUri(url: string): string {
+export function normalizeSchemaUrl(url: string): string {
   // Keeping schema normalization as a separate function in case
   // protocol and schema normalization diverge in the future
-  return normalizeUri(url);
+  return normalizeUrl(url);
 }
 
-function normalizeUri(url: string): string {
+function normalizeUrl(url: string): string {
   let fullUrl: string;
   if (/^[^:]+:\/\/./.test(url)) {
     fullUrl = url;

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,20 +1,44 @@
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 
-
-export function validateProtocolUriNormalized(protocol: string): void {
+export function validateProtocolUriNormalized(uri: string): void {
   let normalized: string | undefined;
   try {
-    normalized = normalizeProtocolUri(protocol);
+    normalized = normalizeProtocolUri(uri);
   } catch {
     normalized = undefined;
   }
 
-  if (protocol !== normalized) {
-    throw new DwnError(DwnErrorCode.UrlProtocolNotNormalized, 'Protocol URI must be normalized.');
+  if (uri !== normalized) {
+    throw new DwnError(DwnErrorCode.UrlProtocolNotNormalized, `Protocol URI ${uri} must be normalized.`);
   }
 }
 
 export function normalizeProtocolUri(url: string): string {
+  // Keeping protocol normalization as a separate function in case
+  // protocol and schema normalization diverge in the future
+  return normalizeUri(url);
+}
+
+export function validateSchemaUriNormalized(uri: string): void {
+  let normalized: string | undefined;
+  try {
+    normalized = normalizeSchemaUri(uri);
+  } catch {
+    normalized = undefined;
+  }
+
+  if (uri !== normalized) {
+    throw new DwnError(DwnErrorCode.UrlSchemaNotNormalized, `Schema URI ${uri} must be normalized.`);
+  }
+}
+
+export function normalizeSchemaUri(url: string): string {
+  // Keeping schema normalization as a separate function in case
+  // protocol and schema normalization diverge in the future
+  return normalizeUri(url);
+}
+
+function normalizeUri(url: string): string {
   let fullUrl: string;
   if (/^[^:]+:\/\/./.test(url)) {
     fullUrl = url;

--- a/tests/interfaces/protocols/messages/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols/messages/protocols-configure.spec.ts
@@ -43,6 +43,27 @@ describe('ProtocolsConfigure', () => {
 
       expect(message.descriptor.protocol).to.eq('http://example.com');
     });
+
+    it('should auto-normalize schema URIs', async () => {
+      const alice = await TestDataGenerator.generatePersona();
+
+      const nonnormalizedDexProtocol = { ...dexProtocolDefinition };
+      nonnormalizedDexProtocol.labels.ask.schema = 'ask';
+
+      const options = {
+        recipient                   : alice.did,
+        data                        : TestDataGenerator.randomBytes(10),
+        dataFormat                  : 'application/json',
+        authorizationSignatureInput : Jws.createSignatureInput(alice),
+        protocol                    : 'example.com/',
+        definition                  : nonnormalizedDexProtocol
+      };
+      const protocolsConfig = await ProtocolsConfigure.create(options);
+
+      const message = protocolsConfig.message as ProtocolsConfigureMessage;
+
+      expect(message.descriptor.definition.labels.ask.schema).to.eq('http://ask');
+    });
   });
 });
 

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1125,10 +1125,10 @@ describe('RecordsWriteHandler.handle()', () => {
         const protocolDefinition = {
           labels: {
             email: {
-              schema: 'emailSchema'
+              schema: 'http://emailschema'
             },
             sms: {
-              schema: 'smsSchema'
+              schema: 'http://smsschema'
             }
           },
           records: {
@@ -1168,7 +1168,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const reply = await dwn.processMessage(alice.did, smsSchemaResponse.message, smsSchemaResponse.dataStream);
 
         expect(reply.status.code).to.equal(401);
-        expect(reply.status.detail).to.contain('record with schema: \'smsSchema\' not allowed in structure level 1');
+        expect(reply.status.detail).to.contain('record with schema: \'http://smsschema\' not allowed in structure level 1');
       });
 
       it('should only allow DWN owner to write if record does not have an allow rule defined', async () => {
@@ -1303,7 +1303,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const askMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
-          schema       : 'ask',
+          schema       : protocolDefinition.labels.ask.schema,
           protocol,
           protocolPath : 'ask',
           data
@@ -1316,7 +1316,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const offerMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : pfi,
           recipientDid : alice.did,
-          schema       : 'offer',
+          schema       : protocolDefinition.labels.offer.schema,
           contextId,
           parentId     : askMessageData.message.recordId,
           protocol,
@@ -1331,7 +1331,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const fulfillmentMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
-          schema       : 'fulfillment',
+          schema       : protocolDefinition.labels.fulfillment.schema,
           contextId,
           parentId     : offerMessageData.message.recordId,
           protocol,
@@ -1383,7 +1383,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const askMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
-          schema       : 'ask',
+          schema       : protocolDefinition.labels.ask.schema,
           protocol,
           protocolPath : 'ask',
           data
@@ -1397,7 +1397,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const fulfillmentMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
-          schema       : 'fulfillment',
+          schema       : protocolDefinition.labels.fulfillment.schema,
           contextId,
           parentId     : 'non-existent-id',
           protocolPath : 'ask/offer/fulfillment',

--- a/tests/interfaces/records/messages/records-query.spec.ts
+++ b/tests/interfaces/records/messages/records-query.spec.ts
@@ -37,11 +37,29 @@ describe('RecordsQuery', () => {
         filter                      : { protocol: 'example.com/' },
         definition                  : dexProtocolDefinition
       };
-      const protocolsConfig = await RecordsQuery.create(options);
+      const recordsQuery = await RecordsQuery.create(options);
 
-      const message = protocolsConfig.message as RecordsQueryMessage;
+      const message = recordsQuery.message as RecordsQueryMessage;
 
       expect(message.descriptor.filter!.protocol).to.eq('http://example.com');
+    });
+
+    it('should auto-normalize schema URI', async () => {
+      const alice = await TestDataGenerator.generatePersona();
+
+      const options = {
+        recipient                   : alice.did,
+        data                        : TestDataGenerator.randomBytes(10),
+        dataFormat                  : 'application/json',
+        authorizationSignatureInput : Jws.createSignatureInput(alice),
+        filter                      : { schema: 'example.com/' },
+        definition                  : dexProtocolDefinition
+      };
+      const recordsQuery = await RecordsQuery.create(options);
+
+      const message = recordsQuery.message as RecordsQueryMessage;
+
+      expect(message.descriptor.filter!.schema).to.eq('http://example.com');
     });
   });
 });

--- a/tests/interfaces/records/messages/records-query.spec.ts
+++ b/tests/interfaces/records/messages/records-query.spec.ts
@@ -26,7 +26,7 @@ describe('RecordsQuery', () => {
       expect(recordsQuery.message.descriptor.dateCreated).to.equal(currentTime);
     });
 
-    it('should auto-normalize protocol URI', async () => {
+    it('should auto-normalize protocol URL', async () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const options = {
@@ -44,7 +44,7 @@ describe('RecordsQuery', () => {
       expect(message.descriptor.filter!.protocol).to.eq('http://example.com');
     });
 
-    it('should auto-normalize schema URI', async () => {
+    it('should auto-normalize schema URL', async () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const options = {

--- a/tests/interfaces/records/messages/records-write.spec.ts
+++ b/tests/interfaces/records/messages/records-write.spec.ts
@@ -125,7 +125,7 @@ describe('RecordsWrite', () => {
       await expect(createPromise2).to.be.rejectedWith('`dataCid` and `dataSize` must both be defined or undefined at the same time');
     });
 
-    it('should auto-normalize protocol URI', async () => {
+    it('should auto-normalize protocol URL', async () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const options = {

--- a/tests/store/message-store.spec.ts
+++ b/tests/store/message-store.spec.ts
@@ -74,7 +74,7 @@ describe('MessageStoreLevel Tests', () => {
     it('should index properties with characters beyond just letters and digits', async () => {
       const alice = await DidKeyResolver.generate();
 
-      const schema = 'http://my-awesome-schema/awesomeness_schema#awesome-1?id=awesome_1';
+      const schema = 'http://my-awesome-schema/awesomeness_schema';
       const { message } = await TestDataGenerator.generateRecordsWrite({ schema });
 
       await messageStore.put(alice.did, message, { schema });

--- a/tests/utils/url.spec.ts
+++ b/tests/utils/url.spec.ts
@@ -1,42 +1,42 @@
 import chaiAsPromised from 'chai-as-promised';
 import chai, { expect } from 'chai';
 
-import { normalizeProtocolUri, validateProtocolUriNormalized } from '../../src/utils/url.js';
+import { normalizeProtocolUrl, validateProtocolUrlNormalized } from '../../src/utils/url.js';
 
 chai.use(chaiAsPromised);
 
 describe('url', () => {
-  describe('validateProtocolUriNormalized', () => {
+  describe('validateProtocolUrlNormalized', () => {
     it('errors when URI is not normalized', () => {
-      expect(() => validateProtocolUriNormalized('https://example.com')).to.not.throw();
-      expect(() => validateProtocolUriNormalized('example.com')).to.throw();
-      expect(() => validateProtocolUriNormalized(':foo:')).to.throw();
+      expect(() => validateProtocolUrlNormalized('https://example.com')).to.not.throw();
+      expect(() => validateProtocolUrlNormalized('example.com')).to.throw();
+      expect(() => validateProtocolUrlNormalized(':foo:')).to.throw();
     });
   });
 
-  describe('normalizeProtocolUri', () => {
+  describe('normalizeProtocolUrl', () => {
     it('returns hostname and path with trailing slash removed', () => {
-      expect(normalizeProtocolUri('example.com')).to.equal('http://example.com');
-      expect(normalizeProtocolUri('example.com/')).to.equal('http://example.com');
-      expect(normalizeProtocolUri('http://example.com')).to.equal('http://example.com');
-      expect(normalizeProtocolUri('http://example.com/')).to.equal('http://example.com');
-      expect(normalizeProtocolUri('example.com?foo=bar')).to.equal('http://example.com');
-      expect(normalizeProtocolUri('example.com/?foo=bar')).to.equal('http://example.com');
+      expect(normalizeProtocolUrl('example.com')).to.equal('http://example.com');
+      expect(normalizeProtocolUrl('example.com/')).to.equal('http://example.com');
+      expect(normalizeProtocolUrl('http://example.com')).to.equal('http://example.com');
+      expect(normalizeProtocolUrl('http://example.com/')).to.equal('http://example.com');
+      expect(normalizeProtocolUrl('example.com?foo=bar')).to.equal('http://example.com');
+      expect(normalizeProtocolUrl('example.com/?foo=bar')).to.equal('http://example.com');
 
-      expect(normalizeProtocolUri('example.com/path')).to.equal('http://example.com/path');
-      expect(normalizeProtocolUri('example.com/path/')).to.equal('http://example.com/path');
-      expect(normalizeProtocolUri('http://example.com/path')).to.equal('http://example.com/path');
-      expect(normalizeProtocolUri('http://example.com/path')).to.equal('http://example.com/path');
-      expect(normalizeProtocolUri('example.com/path?foo=bar')).to.equal('http://example.com/path');
-      expect(normalizeProtocolUri('example.com/path/?foo=bar')).to.equal('http://example.com/path');
-      expect(normalizeProtocolUri('example.com/path#baz')).to.equal('http://example.com/path');
-      expect(normalizeProtocolUri('example.com/path/#baz')).to.equal('http://example.com/path');
+      expect(normalizeProtocolUrl('example.com/path')).to.equal('http://example.com/path');
+      expect(normalizeProtocolUrl('example.com/path/')).to.equal('http://example.com/path');
+      expect(normalizeProtocolUrl('http://example.com/path')).to.equal('http://example.com/path');
+      expect(normalizeProtocolUrl('http://example.com/path')).to.equal('http://example.com/path');
+      expect(normalizeProtocolUrl('example.com/path?foo=bar')).to.equal('http://example.com/path');
+      expect(normalizeProtocolUrl('example.com/path/?foo=bar')).to.equal('http://example.com/path');
+      expect(normalizeProtocolUrl('example.com/path#baz')).to.equal('http://example.com/path');
+      expect(normalizeProtocolUrl('example.com/path/#baz')).to.equal('http://example.com/path');
 
-      expect(normalizeProtocolUri('example')).to.equal('http://example');
-      expect(normalizeProtocolUri('/example/')).to.equal('http://example');
+      expect(normalizeProtocolUrl('example')).to.equal('http://example');
+      expect(normalizeProtocolUrl('/example/')).to.equal('http://example');
 
-      expect(() => normalizeProtocolUri('://http')).to.throw(Error);
-      expect(() => normalizeProtocolUri(':foo:')).to.throw(Error);
+      expect(() => normalizeProtocolUrl('://http')).to.throw(Error);
+      expect(() => normalizeProtocolUrl(':foo:')).to.throw(Error);
     });
   });
 });

--- a/tests/vectors/protocol-definitions/dex.json
+++ b/tests/vectors/protocol-definitions/dex.json
@@ -1,13 +1,13 @@
 {
   "labels": {
     "ask": {
-      "schema": "ask"
+      "schema": "https://tbd/website/tbdex/ask"
     },
     "offer": {
-      "schema": "offer"
+      "schema": "https://tbd/website/tbdex/offer"
     },
     "fulfillment": {
-      "schema": "fulfillment"
+      "schema": "https://tbd/website/tbdex/fulfillment"
     }
   },
   "records": {


### PR DESCRIPTION
Finishes addressing https://github.com/TBD54566975/dwn-sdk-js/issues/265
Copying lots of code from https://github.com/TBD54566975/dwn-sdk-js/pull/317

## Changes
To ensure that schema URIs are bucketed intuitively,
1. `#create` methods auto-normalize schema for an ergonomic developer experience
2. non-normalized schemas are rejected from DWNs