### PR TITLE
Refactor protocol allow rules

### DIFF
--- a/json-schemas/protocol-rule-set.json
+++ b/json-schemas/protocol-rule-set.json
@@ -5,77 +5,37 @@
   "additionalProperties": false,
   "properties": {
     "allow": {
-      "type": "object",
-      "minProperties": 1,
-      "additionalProperties": false,
-      "properties": {
-        "anyone": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "to": {
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "type": "string",
-                "enum": [
-                  "read",
-                  "write"
-                ]
-              }
-            }
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "actor",
+          "actions"
+        ],
+        "properties": {
+          "actor": {
+            "type": "string",
+            "enum": [
+              "anyone",
+              "author",
+              "recipient"
+            ]
           },
-          "required": [
-            "to"
-          ]
-        },
-        "author": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "of": {
-              "type": "string"
-            },
-            "to": {
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "type": "string",
-                "enum": [
-                  "read",
-                  "write"
-                ]
-              }
-            }
+          "protocolPath": {
+            "type": "string"
           },
-          "required": [
-            "of",
-            "to"
-          ]
-        },
-        "recipient": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "of": {
-              "type": "string"
-            },
-            "to": {
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "type": "string",
-                "enum": [
-                  "read",
-                  "write"
-                ]
-              }
+          "actions": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "enum": [
+                "read",
+                "write"
+              ]
             }
-          },
-          "required": [
-            "of",
-            "to"
-          ]
+          }
         }
       }
     },

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -5,9 +5,9 @@ import type { ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureMessage } f
 import type { RecordsReadMessage, RecordsWriteMessage } from '../interfaces/records/types.js';
 
 import { RecordsWrite } from '../interfaces/records/messages/records-write.js';
-import { ProtocolAction, ProtocolActor } from '../interfaces/protocols/types.js';
 import { DwnError, DwnErrorCode } from './dwn-error.js';
 import { DwnInterfaceName, DwnMethodName, Message } from './message.js';
+import { ProtocolAction, ProtocolActor } from '../interfaces/protocols/types.js';
 
 const methodToAllowedActionMap: Record<string, string> = {
   [DwnMethodName.Write] : ProtocolAction.Write,

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -1,10 +1,11 @@
 import type { MessageStore } from '../store/message-store.js';
 import type { RecordsRead } from '../interfaces/records/messages/records-read.js';
 import type { Filter, TimestampedMessage } from './types.js';
-import { ProtocolDefinition, ProtocolAction, ProtocolRuleSet, ProtocolsConfigureMessage, ProtocolActor } from '../interfaces/protocols/types.js';
+import type { ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureMessage } from '../interfaces/protocols/types.js';
 import type { RecordsReadMessage, RecordsWriteMessage } from '../interfaces/records/types.js';
 
 import { RecordsWrite } from '../interfaces/records/messages/records-write.js';
+import { ProtocolAction, ProtocolActor } from '../interfaces/protocols/types.js';
 import { DwnError, DwnErrorCode } from './dwn-error.js';
 import { DwnInterfaceName, DwnMethodName, Message } from './message.js';
 
@@ -302,38 +303,38 @@ export class ProtocolAuthorization {
     const allowedActions = new Set<string>();
     for (const allowRule of allowRules) {
       switch (allowRule.actor) {
-        case ProtocolActor.ANYONE:
-          allowRule.actions.forEach((operation) => allowedActions.add(operation));
-          break;
-        case ProtocolActor.AUTHOR:
-          const messageForAuthorCheck = ProtocolAuthorization.getMessage(
-            ancestorMessageChain,
+      case ProtocolActor.ANYONE:
+        allowRule.actions.forEach((operation) => allowedActions.add(operation));
+        break;
+      case ProtocolActor.AUTHOR:
+        const messageForAuthorCheck = ProtocolAuthorization.getMessage(
+          ancestorMessageChain,
             allowRule.protocolPath!,
             recordSchemaToLabelMap
-          );
+        );
 
-          if (messageForAuthorCheck !== undefined) {
-            const expectedRequesterDid = Message.getAuthor(messageForAuthorCheck);
-    
-            if (requesterDid === expectedRequesterDid) {
-              allowRule.actions.forEach(action => allowedActions.add(action));
-            }
+        if (messageForAuthorCheck !== undefined) {
+          const expectedRequesterDid = Message.getAuthor(messageForAuthorCheck);
+
+          if (requesterDid === expectedRequesterDid) {
+            allowRule.actions.forEach(action => allowedActions.add(action));
           }
-          break;
-        case ProtocolActor.RECIPIENT:
-          const messageForRecipientCheck = ProtocolAuthorization.getMessage(
-            ancestorMessageChain,
+        }
+        break;
+      case ProtocolActor.RECIPIENT:
+        const messageForRecipientCheck = ProtocolAuthorization.getMessage(
+          ancestorMessageChain,
             allowRule.protocolPath!,
             recordSchemaToLabelMap
-          );
-          if (messageForRecipientCheck !== undefined) {
-            const expectedRequesterDid = messageForRecipientCheck.descriptor.recipient;
-    
-            if (requesterDid === expectedRequesterDid) {
-              allowRule.actions.forEach(action => allowedActions.add(action));
-            }
+        );
+        if (messageForRecipientCheck !== undefined) {
+          const expectedRequesterDid = messageForRecipientCheck.descriptor.recipient;
+
+          if (requesterDid === expectedRequesterDid) {
+            allowRule.actions.forEach(action => allowedActions.add(action));
           }
-          break;
+        }
+        break;
         // default:
         //    This is handled by protocol-rule-set.json validator
       }

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -303,10 +303,10 @@ export class ProtocolAuthorization {
     const allowedActions = new Set<string>();
     for (const allowRule of allowRules) {
       switch (allowRule.actor) {
-      case ProtocolActor.ANYONE:
+      case ProtocolActor.Anyone:
         allowRule.actions.forEach((operation) => allowedActions.add(operation));
         break;
-      case ProtocolActor.AUTHOR:
+      case ProtocolActor.Author:
         const messageForAuthorCheck = ProtocolAuthorization.getMessage(
           ancestorMessageChain,
             allowRule.protocolPath!,
@@ -321,7 +321,7 @@ export class ProtocolAuthorization {
           }
         }
         break;
-      case ProtocolActor.RECIPIENT:
+      case ProtocolActor.Recipient:
         const messageForRecipientCheck = ProtocolAuthorization.getMessage(
           ancestorMessageChain,
             allowRule.protocolPath!,

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -9,8 +9,8 @@ import { DwnError, DwnErrorCode } from './dwn-error.js';
 import { DwnInterfaceName, DwnMethodName, Message } from './message.js';
 
 const methodToAllowedActionMap: Record<string, string> = {
-  [DwnMethodName.Write] : ProtocolAction.WRITE,
-  [DwnMethodName.Read]  : ProtocolAction.READ,
+  [DwnMethodName.Write] : ProtocolAction.Write,
+  [DwnMethodName.Read]  : ProtocolAction.Read,
 };
 
 export class ProtocolAuthorization {

--- a/src/interfaces/protocols/types.ts
+++ b/src/interfaces/protocols/types.ts
@@ -28,8 +28,8 @@ export enum ProtocolActor {
 }
 
 export enum ProtocolAction {
-  READ = 'read',
-  WRITE = 'write'
+  Read = 'read',
+  Write = 'write'
 }
 
 export type ProtocolRuleSet = {

--- a/src/interfaces/protocols/types.ts
+++ b/src/interfaces/protocols/types.ts
@@ -21,20 +21,23 @@ export type ProtocolDefinition = {
   };
 };
 
+export enum ProtocolActor {
+  ANYONE = 'anyone',
+  AUTHOR = 'author',
+  RECIPIENT = 'recipient'
+}
+
+export enum ProtocolAction {
+  READ = 'read',
+  WRITE = 'write'
+}
+
 export type ProtocolRuleSet = {
   allow?: {
-    anyone?: {
-      to: string[];
-    };
-    author?: {
-      of: string,
-      to: string[],
-    };
-    recipient?: {
-      of: string,
-      to: string[];
-    }
-  };
+    actor: string,
+    protocolPath?: string,
+    actions: string[]
+  }[];
   records?: {
     [key: string]: ProtocolRuleSet;
   }

--- a/src/interfaces/protocols/types.ts
+++ b/src/interfaces/protocols/types.ts
@@ -22,9 +22,9 @@ export type ProtocolDefinition = {
 };
 
 export enum ProtocolActor {
-  ANYONE = 'anyone',
-  AUTHOR = 'author',
-  RECIPIENT = 'recipient'
+  Anyone = 'anyone',
+  Author = 'author',
+  Recipient = 'recipient'
 }
 
 export enum ProtocolAction {

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1237,10 +1237,11 @@ describe('RecordsWriteHandler.handle()', () => {
         const allowRuleIndex =
           invalidProtocolDefinition.records.credentialApplication.records.credentialResponse.allow
             .findIndex((allowRule) => allowRule.actor === ProtocolActor.RECIPIENT);
-        // this is invalid as the root ancestor can only be `credentialApplication` based on record structure
         invalidProtocolDefinition.records.credentialApplication.records.credentialResponse
           .allow[allowRuleIndex].protocolPath
             = 'credentialResponse';
+            // this is invalid as the root ancestor can only be `credentialApplication` based on record structure
+
 
         // write the VC issuance protocol
         const protocol = 'https://identity.foundation/decentralized-web-node/protocols/credential-issuance';

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1236,7 +1236,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const invalidProtocolDefinition = { ...credentialIssuanceProtocolDefinition };
         const allowRuleIndex =
           invalidProtocolDefinition.records.credentialApplication.records.credentialResponse.allow
-            .findIndex((allowRule) => allowRule.actor === ProtocolActor.RECIPIENT);
+            .findIndex((allowRule) => allowRule.actor === ProtocolActor.Recipient);
         invalidProtocolDefinition.records.credentialApplication.records.credentialResponse
           .allow[allowRuleIndex].protocolPath
             = 'credentialResponse';

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -26,6 +26,7 @@ import { getCurrentTimeInHighPrecision } from '../../../../src/utils/time.js';
 import { KeyDerivationScheme } from '../../../../src/index.js';
 import { Message } from '../../../../src/core/message.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
+import { ProtocolActor } from '../../../../src/interfaces/protocols/types.js';
 import { RecordsWriteHandler } from '../../../../src/interfaces/records/handlers/records-write.js';
 import { StorageController } from '../../../../src/store/storage-controller.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
@@ -34,7 +35,6 @@ import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
 import { Cid, computeCid } from '../../../../src/utils/cid.js';
 import { Dwn, Jws, RecordsWrite } from '../../../../src/index.js';
 import { Encryption, EncryptionAlgorithm } from '../../../../src/utils/encryption.js';
-import { ProtocolActor } from '../../../../src/interfaces/protocols/types.js';
 
 chai.use(chaiAsPromised);
 
@@ -1043,8 +1043,8 @@ describe('RecordsWriteHandler.handle()', () => {
             image: {
               allow: [
                 {
-                  actor: 'anyone',
-                  actions: ['write']
+                  actor   : 'anyone',
+                  actions : ['write']
                 }
               ]
             }
@@ -1240,7 +1240,7 @@ describe('RecordsWriteHandler.handle()', () => {
         invalidProtocolDefinition.records.credentialApplication.records.credentialResponse
           .allow[allowRuleIndex].protocolPath
             = 'credentialResponse';
-            // this is invalid as the root ancestor can only be `credentialApplication` based on record structure
+        // this is invalid as the root ancestor can only be `credentialApplication` based on record structure
 
 
         // write the VC issuance protocol

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -1,9 +1,10 @@
 import { expect } from 'chai';
-import { Message } from '../../../../src/core/message.js';
+import { DwnInterfaceName, DwnMethodName, Message } from '../../../../src/core/message.js';
+import { ProtocolDefinition, ProtocolsConfigureMessage } from '../../../../src/index.js';
 import { validateJsonSchema } from '../../../../src/schema-validator.js';
 
 describe('ProtocolsConfigure schema definition', () => {
-  it('should throw if unknown allow rule is encountered', async () => {
+  it('should throw if unknown actor is encountered in allow rule', async () => {
     const protocolDefinition = {
       labels: {
         email: {
@@ -12,19 +13,20 @@ describe('ProtocolsConfigure schema definition', () => {
       },
       records: {
         email: {
-          allow: {
-            unknown: { // this will be considered an "additional property" beyond what's allowed in the `oneOf` definition
-              to: ['write']
+          allow: [
+            {
+              actor: "unknown",
+              actions: ['write']
             }
-          }
+          ]
         }
       }
     };
 
-    const message = {
+    const message: ProtocolsConfigureMessage = {
       descriptor: {
-        interface   : 'Protocols',
-        method      : 'Configure',
+        interface   : DwnInterfaceName.Protocols,
+        method      : DwnMethodName.Configure,
         dateCreated : '2022-10-14T10:20:30.405060Z',
         protocol    : 'anyProtocolUri',
         definition  : protocolDefinition
@@ -40,7 +42,7 @@ describe('ProtocolsConfigure schema definition', () => {
 
     expect(() => {
       Message.validateJsonSchema(message);
-    }).throws('must NOT have additional properties');
+    }).throws('actor: must be equal to one of the allowed values');
   });
 
   describe('rule-set tests', () => {

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -1,11 +1,12 @@
 import { expect } from 'chai';
-import { DwnInterfaceName, DwnMethodName, Message } from '../../../../src/core/message.js';
-import { ProtocolDefinition, ProtocolsConfigureMessage } from '../../../../src/index.js';
+
 import { validateJsonSchema } from '../../../../src/schema-validator.js';
+import { DwnInterfaceName, DwnMethodName, Message } from '../../../../src/core/message.js';
+import type { ProtocolDefinition, ProtocolsConfigureMessage } from '../../../../src/interfaces/protocols/types.js';
 
 describe('ProtocolsConfigure schema definition', () => {
   it('should throw if unknown actor is encountered in allow rule', async () => {
-    const protocolDefinition = {
+    const protocolDefinition: ProtocolDefinition = {
       labels: {
         email: {
           schema: 'email'
@@ -15,8 +16,8 @@ describe('ProtocolsConfigure schema definition', () => {
         email: {
           allow: [
             {
-              actor: "unknown",
-              actions: ['write']
+              actor   : 'unknown',
+              actions : ['write']
             }
           ]
         }

--- a/tests/vectors/protocol-definitions/credential-issuance.json
+++ b/tests/vectors/protocol-definitions/credential-issuance.json
@@ -9,23 +9,21 @@
   },
   "records": {
     "credentialApplication": {
-      "allow": {
-        "anyone": {
-          "to": [
-            "write"
-          ]
+      "allow": [
+        {
+          "actor": "anyone",
+          "actions": ["write"]
         }
-      },
+      ],
       "records": {
         "credentialResponse": {
-          "allow": {
-            "recipient": {
-              "of": "credentialApplication",
-              "to": [
-                "write"
-              ]
+          "allow": [
+            {
+              "actor": "recipient",
+              "protocolPath": "credentialApplication",
+              "actions": ["write"]
             }
-          }
+          ]
         }
       }
     }

--- a/tests/vectors/protocol-definitions/dex.json
+++ b/tests/vectors/protocol-definitions/dex.json
@@ -12,33 +12,30 @@
   },
   "records": {
     "ask": {
-      "allow": {
-        "anyone": {
-          "to": [
-            "write"
-          ]
+      "allow": [
+        {
+          "actor": "anyone",
+          "actions": ["write"]
         }
-      },
+      ],
       "records": {
         "offer": {
-          "allow": {
-            "recipient": {
-              "of": "ask",
-              "to": [
-                "write"
-              ]
+          "allow": [
+            {
+              "actor": "recipient",
+              "protocolPath": "ask",
+              "actions": ["write"]
             }
-          },
+          ],
           "records": {
             "fulfillment": {
-              "allow": {
-                "recipient": {
-                  "of": "ask/offer",
-                  "to": [
-                    "write"
-                  ]
+              "allow": [
+                {
+                  "actor": "recipient",
+                  "protocolPath": "ask/offer",
+                  "actions": ["write"]
                 }
-              }
+              ]
             }
           }
         }

--- a/tests/vectors/protocol-definitions/email.json
+++ b/tests/vectors/protocol-definitions/email.json
@@ -6,38 +6,40 @@
   },
   "records": {
     "email": {
-      "allow": {
-        "anyone": {
-          "to": [
-            "write"
-          ]
+      "allow": [
+        {
+          "actor": "anyone",
+          "actions": ["write"]
         },
-        "author": {
-          "of": "email",
-          "to": ["read"]
+        {
+          "actor": "author",
+          "protocolPath": "email",
+          "actions": ["read"]
         },
-        "recipient": {
-          "of": "email",
-          "to": ["read"]
+        {
+          "actor": "recipient",
+          "protocolPath": "email",
+          "actions": ["read"]
         }
-      },
+      ],
       "records": {
         "email": {
-          "allow": {
-            "anyone": {
-              "to": [
-                "write"
-              ]
+          "allow": [
+            {
+              "actor": "anyone",
+              "actions": ["write"]
             },
-            "author": {
-              "of": "email/email",
-              "to": ["read"]
+            {
+              "actor": "author",
+              "protocolPath": "email/email",
+              "actions": ["read"]
             },
-            "recipient": {
-              "of": "email/email",
-              "to": ["read"]
+            {
+              "actor": "recipient",
+              "protocolpath": "email/email",
+              "actions": ["read"]
             }
-          }
+          ]
         }
       }
     }

--- a/tests/vectors/protocol-definitions/message.json
+++ b/tests/vectors/protocol-definitions/message.json
@@ -6,13 +6,12 @@
   },
   "records": {
     "message": {
-      "allow": {
-        "anyone": {
-          "to": [
-            "write"
-          ]
+      "allow": [
+        {
+          "actor": "anyone",
+          "actions": ["write"]
         }
-      }
+      ]
     }
   }
 }

--- a/tests/vectors/protocol-definitions/social-media.json
+++ b/tests/vectors/protocol-definitions/social-media.json
@@ -7,49 +7,58 @@
   },
   "records": {
     "message": {
-      "allow": {
-        "anyone": { "to": ["write"] }
-      },
+      "allow": [
+        {
+          "actor": "anyone",
+          "actions": ["write"]
+        }
+      ],
       "records": {
         "reply": {
-          "allow": {
-            "recipient": {
-              "of": "message",
-              "to": ["write"]
+          "allow": [
+            {
+              "actor": "recipient",
+              "protocolPath": "message",
+              "actions": ["write"]
             }
-          }
+          ]
         }
       }
     },
     "image": {
-      "allow": {
-        "anyone": {
-          "to": ["read", "write"]
+      "allow": [
+        {
+          "actor": "anyone",
+          "actions": ["read", "write"]
         }
-      },
+      ],
       "records": {
         "caption": {
-          "allow": {
-            "anyone": {
-              "to": ["read"]
+          "allow": [
+            {
+              "actor": "anyone",
+              "actions": ["read"]
             },
-            "author": {
-              "of": "image",
-              "to": ["write"]
+            {
+              "actor": "author",
+              "protocolPath": "image",
+              "actions": ["write"]
             }
-          }
+          ]
         },
         "reply": {
-          "allow": {
-            "author": {
-              "of": "image",
-              "to": ["read"]
+          "allow": [
+            {
+              "actor": "author",
+              "protocolPath": "image",
+              "actions": ["read"]
             },
-            "recipient": {
-              "of": "image",
-              "to": ["write"]
+            {
+              "actor": "recipient",
+              "protocolPath": "image",
+              "actions": ["write"]
             }
-          }
+          ]
         }
       }
     }


### PR DESCRIPTION
Addresses one aspect of #326

A shortcoming of the existing protocol allow rule structure is that we can only specify one rule per actor. For example, this means cannot create both a rule allowing `author` of `image` to `write` and a rule `author` of `image/reply` to `read`. By refactoring `allow` to be an array, protocol allow rules become more flexible.