### PR TITLE
#333 #326 Refactor protocol recordTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.19%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.89%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.02%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.19%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.19%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.88%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.02%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.19%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.18%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.88%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.18%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.19%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.89%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.02%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.19%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.17%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.85%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.97%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.17%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.18%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.88%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.18%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.19%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.88%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.02%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.19%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.18%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.86%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.02%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.18%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.22%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.95%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.02%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.22%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.22%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.96%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.02%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.22%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/json-schemas/protocol-definition.json
+++ b/json-schemas/protocol-definition.json
@@ -4,25 +4,29 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "labels",
+    "recordTypes",
     "records"
   ],
   "properties": {
-    "labels": {
-      "type": "object",
-      "patternProperties": {
-        ".*": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "schema": {
+    "recordTypes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "schema": {
+            "type": "string"
+          },
+          "dataFormats": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
               "type": "string"
-            },
-            "dataFormats": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
             }
           }
         }

--- a/json-schemas/protocol-definition.json
+++ b/json-schemas/protocol-definition.json
@@ -4,11 +4,11 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "recordTypes",
+    "recordDefinitions",
     "records"
   ],
   "properties": {
-    "recordTypes": {
+    "recordDefinitions": {
       "type": "array",
       "minItems": 1,
       "items": {

--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -23,6 +23,8 @@ export enum DwnErrorCode {
   ProtocolAuthorizationIncorrectDataFormat = 'ProtocolAuthorizationIncorrectDataFormat',
   ProtocolAuthorizationIncorrectProtocolPath = 'ProtocolAuthorizationIncorrectProtocolPath',
   ProtocolAuthorizationInvalidSchema = 'ProtocolAuthorizationInvalidSchema',
+  ProtocolAuthorizationInvalidRecordType = 'ProtocolAuthorizationInvalidRecordType',
+  ProtocolAuthorizationMissingRuleSet = 'ProtocolAuthorizationMissingRuleSet',
   RecordsDecryptNoMatchingKeyDerivationScheme = 'RecordsDecryptNoMatchingKeyDerivationScheme',
   RecordsDeriveLeafPrivateKeyUnSupportedCurve = 'RecordsDeriveLeafPrivateKeyUnSupportedCurve',
   RecordsDeriveLeafPublicKeyUnSupportedCurve = 'RecordsDeriveLeafPublicKeyUnSupportedCurve',

--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -23,7 +23,7 @@ export enum DwnErrorCode {
   ProtocolAuthorizationIncorrectDataFormat = 'ProtocolAuthorizationIncorrectDataFormat',
   ProtocolAuthorizationIncorrectProtocolPath = 'ProtocolAuthorizationIncorrectProtocolPath',
   ProtocolAuthorizationInvalidSchema = 'ProtocolAuthorizationInvalidSchema',
-  ProtocolAuthorizationInvalidRecordType = 'ProtocolAuthorizationInvalidRecordType',
+  ProtocolAuthorizationInvalidRecordDefinition = 'ProtocolAuthorizationInvalidRecordDefinition',
   ProtocolAuthorizationMissingRuleSet = 'ProtocolAuthorizationMissingRuleSet',
   RecordsDecryptNoMatchingKeyDerivationScheme = 'RecordsDecryptNoMatchingKeyDerivationScheme',
   RecordsDeriveLeafPrivateKeyUnSupportedCurve = 'RecordsDeriveLeafPrivateKeyUnSupportedCurve',

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -394,12 +394,12 @@ export class ProtocolAuthorization {
 
     let i = 0;
     while (true) {
-      const expectedAncestorType = expectedAncestors[i];
+      const expectedDefinitionId = expectedAncestors[i];
       const ancestorMessage = ancestorMessageChain[i];
 
-      const actualAncestorDefinitionId = ProtocolAuthorization.getRecordDefinitionId(ancestorMessage.descriptor.protocolPath!);
-      if (actualAncestorDefinitionId !== expectedAncestorType) {
-        throw new Error(`mismatching record schema: expecting ${expectedAncestorType} but actual ${actualAncestorDefinitionId}`);
+      const actualDefinitionId = ProtocolAuthorization.getRecordDefinitionId(ancestorMessage.descriptor.protocolPath!);
+      if (actualDefinitionId !== expectedDefinitionId) {
+        throw new Error(`mismatching record schema: expecting ${expectedDefinitionId} but actual ${actualDefinitionId}`);
       }
 
       // we have found the message if we are looking at the last message specified by the path

--- a/src/interfaces/protocols/messages/protocols-configure.ts
+++ b/src/interfaces/protocols/messages/protocols-configure.ts
@@ -45,9 +45,10 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
 
   private static validateDefinitionNormalized(definition: ProtocolDefinition): void {
     // validate schema url normalized
-    for (const labelKey in definition.labels) {
-      const schema = definition.labels[labelKey].schema;
-      validateSchemaUrlNormalized(schema);
+    for (const recordType of definition.recordTypes) {
+      if (recordType.schema !== undefined) {
+        validateSchemaUrlNormalized(recordType.schema);
+      }
     }
   }
 
@@ -55,8 +56,10 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
     const definitionCopy = { ...definition };
 
     // Normalize schema url
-    for (const labelKey in definition.labels) {
-      definitionCopy.labels[labelKey].schema = normalizeSchemaUrl(definitionCopy.labels[labelKey].schema);
+    for (const recordType of definition.recordTypes) {
+      if (recordType.schema !== undefined) {
+        recordType.schema = normalizeSchemaUrl(recordType.schema);
+      }
     }
 
     return definitionCopy;

--- a/src/interfaces/protocols/messages/protocols-configure.ts
+++ b/src/interfaces/protocols/messages/protocols-configure.ts
@@ -45,9 +45,9 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
 
   private static validateDefinitionNormalized(definition: ProtocolDefinition): void {
     // validate schema url normalized
-    for (const recordType of definition.recordTypes) {
-      if (recordType.schema !== undefined) {
-        validateSchemaUrlNormalized(recordType.schema);
+    for (const recordDefinition of definition.recordDefinitions) {
+      if (recordDefinition.schema !== undefined) {
+        validateSchemaUrlNormalized(recordDefinition.schema);
       }
     }
   }
@@ -56,9 +56,9 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
     const definitionCopy = { ...definition };
 
     // Normalize schema url
-    for (const recordType of definition.recordTypes) {
-      if (recordType.schema !== undefined) {
-        recordType.schema = normalizeSchemaUrl(recordType.schema);
+    for (const recordDefinition of definition.recordDefinitions) {
+      if (recordDefinition.schema !== undefined) {
+        recordDefinition.schema = normalizeSchemaUrl(recordDefinition.schema);
       }
     }
 

--- a/src/interfaces/protocols/types.ts
+++ b/src/interfaces/protocols/types.ts
@@ -10,13 +10,13 @@ export type ProtocolsConfigureDescriptor = {
 };
 
 export type ProtocolDefinition = {
-  recordTypes: ProtocolRecordType[];
+  recordDefinitions: ProtocolRecordDefinition[];
   records: {
     [key: string]: ProtocolRuleSet;
   };
 };
 
-export type ProtocolRecordType = {
+export type ProtocolRecordDefinition = {
   id: string,
   schema?: string,
   dataFormats?: string[],

--- a/src/interfaces/protocols/types.ts
+++ b/src/interfaces/protocols/types.ts
@@ -10,15 +10,16 @@ export type ProtocolsConfigureDescriptor = {
 };
 
 export type ProtocolDefinition = {
-  labels: {
-    [key: string]: {
-      schema: string,
-      dataFormats?: string[],
-    };
-  };
+  recordTypes: ProtocolRecordType[];
   records: {
     [key: string]: ProtocolRuleSet;
   };
+};
+
+export type ProtocolRecordType = {
+  id: string,
+  schema?: string,
+  dataFormats?: string[],
 };
 
 export enum ProtocolActor {

--- a/src/utils/protocols.ts
+++ b/src/utils/protocols.ts
@@ -1,12 +1,12 @@
-import type { ProtocolDefinition, ProtocolRecordType } from '../interfaces/protocols/types.js';
+import type { ProtocolDefinition, ProtocolRecordDefinition } from '../interfaces/protocols/types.js';
 
 export class Protocols {
-  public static getRecordType(
+  public static getRecordDefinition(
     protocolDefinition: ProtocolDefinition,
-    recordTypeId: string
-  ): ProtocolRecordType | undefined {
-    return protocolDefinition.recordTypes.find(({ id }) =>
-      id === recordTypeId
+    recordDefinitionId: string
+  ): ProtocolRecordDefinition | undefined {
+    return protocolDefinition.recordDefinitions.find(({ id }) =>
+      id === recordDefinitionId
     );
   }
 }

--- a/src/utils/protocols.ts
+++ b/src/utils/protocols.ts
@@ -1,0 +1,12 @@
+import type { ProtocolDefinition, ProtocolRecordType } from '../interfaces/protocols/types.js';
+
+export class Protocols {
+  public static getRecordType(
+    protocolDefinition: ProtocolDefinition,
+    recordTypeId: string
+  ): ProtocolRecordType | undefined {
+    return protocolDefinition.recordTypes.find(({ id }) =>
+      id === recordTypeId
+    );
+  }
+}

--- a/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
@@ -177,7 +177,7 @@ describe('ProtocolsConfigureHandler.handle()', () => {
       });
 
       // overwrite schema because #create auto-normalizes schema
-      Protocols.getRecordType(protocolsConfig.message.descriptor.definition, 'ask')!.schema = 'ask';
+      Protocols.getRecordDefinition(protocolsConfig.message.descriptor.definition, 'ask')!.schema = 'ask';
 
       // Re-create auth because we altered the descriptor after signing
       protocolsConfig.message.authorization = await Message.signAsAuthorization(

--- a/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
@@ -135,11 +135,11 @@ describe('ProtocolsConfigureHandler.handle()', () => {
       expect(reply.status.code).to.equal(200);
       expect(reply.entries?.length).to.equal(1);
 
-      const initialDefinition = JSON.stringify(middleWrite.message.descriptor.definition);
-      const expectedDefinition = JSON.stringify(newestWrite.message.descriptor.definition);
-      const actualDefinition = JSON.stringify(reply.entries![0]['descriptor']['definition']);
-      expect(actualDefinition).to.not.equal(initialDefinition);
-      expect(actualDefinition).to.equal(expectedDefinition);
+      const initialDefinition = middleWrite.message.descriptor.definition;
+      const expectedDefinition = newestWrite.message.descriptor.definition;
+      const actualDefinition = reply.entries![0]['descriptor']['definition'];
+      expect(actualDefinition).to.not.deep.equal(initialDefinition);
+      expect(actualDefinition).to.deep.equal(expectedDefinition);
     });
 
     it('should return 400 if protocol is not normalized', async () => {
@@ -176,7 +176,7 @@ describe('ProtocolsConfigureHandler.handle()', () => {
       });
 
       // overwrite schema because #create auto-normalizes schema
-      protocolsConfig.message.descriptor.definition.labels.ask.schema = 'ask';
+      protocolsConfig.message.descriptor.definition.recordTypes.find(({ id }) => id === 'ask')!.schema = 'ask';
 
       // Re-create auth because we altered the descriptor after signing
       protocolsConfig.message.authorization = await Message.signAsAuthorization(

--- a/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
@@ -13,6 +13,7 @@ import { GeneralJwsSigner } from '../../../../src/jose/jws/general/signer.js';
 import { lexicographicalCompare } from '../../../../src/utils/string.js';
 import { Message } from '../../../../src/core/message.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
+import { Protocols } from '../../../../src/utils/protocols.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
 
@@ -176,7 +177,7 @@ describe('ProtocolsConfigureHandler.handle()', () => {
       });
 
       // overwrite schema because #create auto-normalizes schema
-      protocolsConfig.message.descriptor.definition.recordTypes.find(({ id }) => id === 'ask')!.schema = 'ask';
+      Protocols.getRecordType(protocolsConfig.message.descriptor.definition, 'ask')!.schema = 'ask';
 
       // Re-create auth because we altered the descriptor after signing
       protocolsConfig.message.authorization = await Message.signAsAuthorization(

--- a/tests/interfaces/protocols/messages/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols/messages/protocols-configure.spec.ts
@@ -49,7 +49,7 @@ describe('ProtocolsConfigure', () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const nonnormalizedDexProtocol = { ...dexProtocolDefinition };
-      Protocols.getRecordType(nonnormalizedDexProtocol, 'ask')!.schema = 'ask';
+      Protocols.getRecordDefinition(nonnormalizedDexProtocol, 'ask')!.schema = 'ask';
 
       const options = {
         recipient                   : alice.did,
@@ -62,7 +62,7 @@ describe('ProtocolsConfigure', () => {
       const protocolsConfig = await ProtocolsConfigure.create(options);
 
       const message = protocolsConfig.message as ProtocolsConfigureMessage;
-      expect(Protocols.getRecordType(message.descriptor.definition, 'ask')?.schema).to.eq('http://ask');
+      expect(Protocols.getRecordDefinition(message.descriptor.definition, 'ask')?.schema).to.eq('http://ask');
     });
   });
 });

--- a/tests/interfaces/protocols/messages/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols/messages/protocols-configure.spec.ts
@@ -48,7 +48,7 @@ describe('ProtocolsConfigure', () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const nonnormalizedDexProtocol = { ...dexProtocolDefinition };
-      nonnormalizedDexProtocol.labels.ask.schema = 'ask';
+      nonnormalizedDexProtocol.recordTypes.find(({ id }) => id === 'ask')!.schema = 'ask';
 
       const options = {
         recipient                   : alice.did,
@@ -62,7 +62,7 @@ describe('ProtocolsConfigure', () => {
 
       const message = protocolsConfig.message as ProtocolsConfigureMessage;
 
-      expect(message.descriptor.definition.labels.ask.schema).to.eq('http://ask');
+      expect(message.descriptor.definition.recordTypes.find(({ id }) => id === 'ask')?.schema).to.eq('http://ask');
     });
   });
 });

--- a/tests/interfaces/protocols/messages/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols/messages/protocols-configure.spec.ts
@@ -5,6 +5,7 @@ import type { ProtocolsConfigureMessage } from '../../../../src/index.js';
 
 import dexProtocolDefinition from '../../../vectors/protocol-definitions/dex.json' assert { type: 'json' };
 import { getCurrentTimeInHighPrecision } from '../../../../src/utils/time.js';
+import { Protocols } from '../../../../src/utils/protocols.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { Jws, ProtocolsConfigure } from '../../../../src/index.js';
 
@@ -48,7 +49,7 @@ describe('ProtocolsConfigure', () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const nonnormalizedDexProtocol = { ...dexProtocolDefinition };
-      nonnormalizedDexProtocol.recordTypes.find(({ id }) => id === 'ask')!.schema = 'ask';
+      Protocols.getRecordType(nonnormalizedDexProtocol, 'ask')!.schema = 'ask';
 
       const options = {
         recipient                   : alice.did,
@@ -61,8 +62,7 @@ describe('ProtocolsConfigure', () => {
       const protocolsConfig = await ProtocolsConfigure.create(options);
 
       const message = protocolsConfig.message as ProtocolsConfigureMessage;
-
-      expect(message.descriptor.definition.recordTypes.find(({ id }) => id === 'ask')?.schema).to.eq('http://ask');
+      expect(Protocols.getRecordType(message.descriptor.definition, 'ask')?.schema).to.eq('http://ask');
     });
   });
 });

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -17,6 +17,7 @@ import { EventLogLevel } from '../../../../src/event-log/event-log-level.js';
 import { Jws } from '../../../../src/utils/jws.js';
 import { Message } from '../../../../src/core/message.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
+import { Protocols } from '../../../../src/utils/protocols.js';
 import { RecordsQueryHandler } from '../../../../src/interfaces/records/handlers/records-query.js';
 import { StorageController } from '../../../../src/store/storage-controller.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
@@ -683,7 +684,7 @@ describe('RecordsQueryHandler.handle()', () => {
           }]
         };
 
-        const schema = emailProtocolDefinition.recordTypes.find(({ id }) => id === 'email')!.schema;
+        const schema = Protocols.getRecordType(emailProtocolDefinition, 'email')!.schema;
         const { message, dataStream } = await TestDataGenerator.generateRecordsWrite(
           {
             requester    : bob,

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -683,12 +683,12 @@ describe('RecordsQueryHandler.handle()', () => {
           }]
         };
 
-        const schema = emailProtocolDefinition.labels.email.schema;
+        const schema = emailProtocolDefinition.recordTypes.find(({ id }) => id === 'email')!.schema;
         const { message, dataStream } = await TestDataGenerator.generateRecordsWrite(
           {
             requester    : bob,
             protocol,
-            protocolPath : 'email', // this comes from `labels` in protocol definition
+            protocolPath : 'email', // this comes from `recordTypes` in protocol definition
             schema,
             data         : bobMessageEncryptedBytes,
             encryptionInput

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -684,12 +684,12 @@ describe('RecordsQueryHandler.handle()', () => {
           }]
         };
 
-        const schema = Protocols.getRecordType(emailProtocolDefinition, 'email')!.schema;
+        const schema = Protocols.getRecordDefinition(emailProtocolDefinition, 'email')!.schema;
         const { message, dataStream } = await TestDataGenerator.generateRecordsWrite(
           {
             requester    : bob,
             protocol,
-            protocolPath : 'email', // this comes from `recordTypes` in protocol definition
+            protocolPath : 'email', // this comes from `recordDefinitions` in protocol definition
             schema,
             data         : bobMessageEncryptedBytes,
             encryptionInput

--- a/tests/interfaces/records/handlers/records-read.spec.ts
+++ b/tests/interfaces/records/handlers/records-read.spec.ts
@@ -178,8 +178,8 @@ describe('RecordsReadHandler.handle()', () => {
         const imageRecordsWrite = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           protocol,
-          protocolPath : 'image', // this comes from `labels` in protocol definition
-          schema       : protocolDefinition.labels.image.schema,
+          protocolPath : 'image', // this comes from `recordTypes` in protocol definition
+          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'image')!.schema,
           data         : encodedImage,
           recipientDid : alice.did
         });
@@ -220,8 +220,8 @@ describe('RecordsReadHandler.handle()', () => {
         const emailRecordsWrite = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           protocol,
-          protocolPath : 'email', // this comes from `labels` in protocol definition
-          schema       : protocolDefinition.labels.email.schema,
+          protocolPath : 'email', // this comes from `recordTypes` in protocol definition
+          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'email')!.schema,
           data         : encodedEmail,
           recipientDid : bob.did
         });
@@ -270,8 +270,8 @@ describe('RecordsReadHandler.handle()', () => {
         const emailRecordsWrite = await TestDataGenerator.generateRecordsWrite({
           requester    : bob,
           protocol,
-          protocolPath : 'email', // this comes from `labels` in protocol definition
-          schema       : protocolDefinition.labels.email.schema,
+          protocolPath : 'email', // this comes from `recordTypes` in protocol definition
+          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'email')!.schema,
           data         : encodedEmail,
           recipientDid : alice.did
         });
@@ -367,7 +367,7 @@ describe('RecordsReadHandler.handle()', () => {
     });
 
     describe('encryption scenarios', () => {
-      it('should only be able to decrypt record with a correct derived private key - `protocols` derivation scheme', async () => {
+      it('should only be able to decrypt record with a correct derived private key', async () => {
         // scenario, Bob writes into Alice's DWN an encrypted "email", alice is able to decrypt it
 
         // creating Alice and Bob persona and setting up a stub DID resolver
@@ -409,8 +409,8 @@ describe('RecordsReadHandler.handle()', () => {
           {
             requester    : bob,
             protocol,
-            protocolPath : 'email', // this comes from `labels` in protocol definition
-            schema       : emailProtocolDefinition.labels.email.schema,
+            protocolPath : 'email', // this comes from `recordTypes` in protocol definition
+            schema       : emailProtocolDefinition.recordTypes.find(({ id }) => id === 'email')!.schema,
             data         : bobMessageEncryptedBytes,
             encryptionInput
           }

--- a/tests/interfaces/records/handlers/records-read.spec.ts
+++ b/tests/interfaces/records/handlers/records-read.spec.ts
@@ -179,8 +179,8 @@ describe('RecordsReadHandler.handle()', () => {
         const imageRecordsWrite = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           protocol,
-          protocolPath : 'image', // this comes from `recordTypes` in protocol definition
-          schema       : Protocols.getRecordType(protocolDefinition, 'image')!.schema,
+          protocolPath : 'image', // this comes from `recordDefinitions` in protocol definition
+          schema       : Protocols.getRecordDefinition(protocolDefinition, 'image')!.schema,
           data         : encodedImage,
           recipientDid : alice.did
         });
@@ -221,8 +221,8 @@ describe('RecordsReadHandler.handle()', () => {
         const emailRecordsWrite = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           protocol,
-          protocolPath : 'email', // this comes from `recordTypes` in protocol definition
-          schema       : Protocols.getRecordType(protocolDefinition, 'email')!.schema,
+          protocolPath : 'email', // this comes from `recordDefinitions` in protocol definition
+          schema       : Protocols.getRecordDefinition(protocolDefinition, 'email')!.schema,
           data         : encodedEmail,
           recipientDid : bob.did
         });
@@ -271,8 +271,8 @@ describe('RecordsReadHandler.handle()', () => {
         const emailRecordsWrite = await TestDataGenerator.generateRecordsWrite({
           requester    : bob,
           protocol,
-          protocolPath : 'email', // this comes from `recordTypes` in protocol definition
-          schema       : Protocols.getRecordType(protocolDefinition, 'email')!.schema,
+          protocolPath : 'email', // this comes from `recordDefinitions` in protocol definition
+          schema       : Protocols.getRecordDefinition(protocolDefinition, 'email')!.schema,
           data         : encodedEmail,
           recipientDid : alice.did
         });
@@ -410,8 +410,8 @@ describe('RecordsReadHandler.handle()', () => {
           {
             requester    : bob,
             protocol,
-            protocolPath : 'email', // this comes from `recordTypes` in protocol definition
-            schema       : Protocols.getRecordType(emailProtocolDefinition, 'email')!.schema,
+            protocolPath : 'email', // this comes from `recordDefinitions` in protocol definition
+            schema       : Protocols.getRecordDefinition(emailProtocolDefinition, 'email')!.schema,
             data         : bobMessageEncryptedBytes,
             encryptionInput
           }

--- a/tests/interfaces/records/handlers/records-read.spec.ts
+++ b/tests/interfaces/records/handlers/records-read.spec.ts
@@ -17,6 +17,7 @@ import { EventLogLevel } from '../../../../src/event-log/event-log-level.js';
 import { HdKey } from '../../../../src/utils/hd-key.js';
 import { KeyDerivationScheme } from '../../../../src/utils/hd-key.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
+import { Protocols } from '../../../../src/utils/protocols.js';
 import { RecordsReadHandler } from '../../../../src/interfaces/records/handlers/records-read.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
@@ -179,7 +180,7 @@ describe('RecordsReadHandler.handle()', () => {
           requester    : alice,
           protocol,
           protocolPath : 'image', // this comes from `recordTypes` in protocol definition
-          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'image')!.schema,
+          schema       : Protocols.getRecordType(protocolDefinition, 'image')!.schema,
           data         : encodedImage,
           recipientDid : alice.did
         });
@@ -221,7 +222,7 @@ describe('RecordsReadHandler.handle()', () => {
           requester    : alice,
           protocol,
           protocolPath : 'email', // this comes from `recordTypes` in protocol definition
-          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'email')!.schema,
+          schema       : Protocols.getRecordType(protocolDefinition, 'email')!.schema,
           data         : encodedEmail,
           recipientDid : bob.did
         });
@@ -271,7 +272,7 @@ describe('RecordsReadHandler.handle()', () => {
           requester    : bob,
           protocol,
           protocolPath : 'email', // this comes from `recordTypes` in protocol definition
-          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'email')!.schema,
+          schema       : Protocols.getRecordType(protocolDefinition, 'email')!.schema,
           data         : encodedEmail,
           recipientDid : alice.did
         });
@@ -410,7 +411,7 @@ describe('RecordsReadHandler.handle()', () => {
             requester    : bob,
             protocol,
             protocolPath : 'email', // this comes from `recordTypes` in protocol definition
-            schema       : emailProtocolDefinition.recordTypes.find(({ id }) => id === 'email')!.schema,
+            schema       : Protocols.getRecordType(emailProtocolDefinition, 'email')!.schema,
             data         : bobMessageEncryptedBytes,
             encryptionInput
           }

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -559,8 +559,8 @@ describe('RecordsWriteHandler.handle()', () => {
 
         const protocol = 'https://identity.foundation/decentralized-web-node/protocols/credential-issuance';
         const protocolDefinition: ProtocolDefinition = credentialIssuanceProtocolDefinition;
-        const credentialApplicationSchema = protocolDefinition.labels.credentialApplication.schema;
-        const credentialResponseSchema = protocolDefinition.labels.credentialResponse.schema;
+        const credentialApplicationSchema = protocolDefinition.recordTypes.find(({ id }) => id === 'credentialApplication')!.schema;
+        const credentialResponseSchema = protocolDefinition.recordTypes.find(({ id }) => id === 'credentialResponse')!.schema;
 
         const alice = await TestDataGenerator.generatePersona();
         const vcIssuer = await TestDataGenerator.generatePersona();
@@ -583,7 +583,7 @@ describe('RecordsWriteHandler.handle()', () => {
           requester    : alice,
           recipientDid : vcIssuer.did,
           protocol,
-          protocolPath : 'credentialApplication', // this comes from `labels` in protocol definition
+          protocolPath : 'credentialApplication', // this comes from `recordTypes` in protocol definition
           schema       : credentialApplicationSchema,
           data         : encodedCredentialApplication
         });
@@ -599,7 +599,7 @@ describe('RecordsWriteHandler.handle()', () => {
             requester    : vcIssuer,
             recipientDid : alice.did,
             protocol,
-            protocolPath : 'credentialApplication/credentialResponse', // this comes from `labels` in protocol definition
+            protocolPath : 'credentialApplication/credentialResponse', // this comes from `recordTypes` in protocol definition
             contextId    : credentialApplicationContextId,
             parentId     : credentialApplicationContextId,
             schema       : credentialResponseSchema,
@@ -649,8 +649,8 @@ describe('RecordsWriteHandler.handle()', () => {
         const imageRecordsWrite = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           protocol,
-          protocolPath : 'image', // this comes from `labels` in protocol definition
-          schema       : socialMediaProtocolDefinition.labels.image.schema,
+          protocolPath : 'image', // this comes from `recordTypes` in protocol definition
+          schema       : socialMediaProtocolDefinition.recordTypes.find(({ id }) => id === 'image')!.schema,
           data         : encodedImage
         });
         const imageReply = await dwn.processMessage(bob.did, imageRecordsWrite.message, imageRecordsWrite.dataStream);
@@ -663,8 +663,8 @@ describe('RecordsWriteHandler.handle()', () => {
         const captionImposter = await TestDataGenerator.generateRecordsWrite({
           requester    : aliceImposter,
           protocol,
-          protocolPath : 'image/caption', // this comes from `labels` in protocol definition
-          schema       : socialMediaProtocolDefinition.labels.caption.schema,
+          protocolPath : 'image/caption', // this comes from `recordTypes` in protocol definition
+          schema       : socialMediaProtocolDefinition.recordTypes.find(({ id }) => id === 'caption')!.schema,
           contextId    : imageContextId,
           parentId     : imageContextId,
           data         : encodedCaptionImposter
@@ -679,7 +679,7 @@ describe('RecordsWriteHandler.handle()', () => {
           requester    : alice,
           protocol,
           protocolPath : 'image/caption',
-          schema       : socialMediaProtocolDefinition.labels.caption.schema,
+          schema       : socialMediaProtocolDefinition.recordTypes.find(({ id }) => id === 'caption')!.schema,
           contextId    : imageContextId,
           parentId     : imageContextId,
           data         : encodedCaption
@@ -726,8 +726,8 @@ describe('RecordsWriteHandler.handle()', () => {
           {
             requester    : bob,
             protocol,
-            protocolPath : 'message', // this comes from `labels` in protocol definition
-            schema       : messageProtocolDefinition.labels.message.schema,
+            protocolPath : 'message', // this comes from `recordTypes` in protocol definition
+            schema       : messageProtocolDefinition.recordTypes.find(({ id }) => id === 'message')!.schema,
             data         : bobData
           }
         );
@@ -791,8 +791,8 @@ describe('RecordsWriteHandler.handle()', () => {
           {
             requester    : bob,
             protocol,
-            protocolPath : 'message', // this comes from `labels` in protocol definition
-            schema       : messageProtocolDefinition.labels.message.schema,
+            protocolPath : 'message', // this comes from `recordTypes` in protocol definition
+            schema       : messageProtocolDefinition.recordTypes.find(({ id }) => id === 'message')!.schema,
             data         : bobData
           }
         );
@@ -816,8 +816,8 @@ describe('RecordsWriteHandler.handle()', () => {
           {
             requester    : carol,
             protocol,
-            protocolPath : 'message', // this comes from `labels` in protocol definition
-            schema       : messageProtocolDefinition.labels.message.schema,
+            protocolPath : 'message', // this comes from `recordTypes` in protocol definition
+            schema       : messageProtocolDefinition.recordTypes.find(({ id }) => id === 'message')!.schema,
             data         : modifiedMessageData,
             recordId     : messageFromBob.message.recordId,
           }
@@ -858,8 +858,8 @@ describe('RecordsWriteHandler.handle()', () => {
           {
             requester    : bob,
             protocol,
-            protocolPath : 'message', // this comes from `labels` in protocol definition
-            schema       : messageProtocolDefinition.labels.message.schema,
+            protocolPath : 'message', // this comes from `recordTypes` in protocol definition
+            schema       : messageProtocolDefinition.recordTypes.find(({ id }) => id === 'message')!.schema,
             data         : bobData
           }
         );
@@ -883,8 +883,8 @@ describe('RecordsWriteHandler.handle()', () => {
             requester    : bob,
             dateCreated  : messageFromBob.message.descriptor.dateCreated,
             protocol,
-            protocolPath : 'message', // this comes from `labels` in protocol definition
-            schema       : messageProtocolDefinition.labels.message.schema,
+            protocolPath : 'message', // this comes from `recordTypes` in protocol definition
+            schema       : messageProtocolDefinition.recordTypes.find(({ id }) => id === 'message')!.schema,
             data         : bobData,
             recordId     : messageFromBob.message.recordId,
             recipientDid : bob.did // this immutable property was Alice's DID initially
@@ -902,8 +902,8 @@ describe('RecordsWriteHandler.handle()', () => {
 
         const protocol = 'https://identity.foundation/decentralized-web-node/protocols/credential-issuance';
         const protocolDefinition = credentialIssuanceProtocolDefinition;
-        const credentialApplicationSchema = protocolDefinition.labels.credentialApplication.schema;
-        const credentialResponseSchema = protocolDefinition.labels.credentialResponse.schema;
+        const credentialApplicationSchema = protocolDefinition.recordTypes.find(({ id }) => id === 'credentialApplication')!.schema;
+        const credentialResponseSchema = protocolDefinition.recordTypes.find(({ id }) => id === 'credentialResponse')!.schema;
 
         const alice = await TestDataGenerator.generatePersona();
         const fakeVcIssuer = await TestDataGenerator.generatePersona();
@@ -927,7 +927,7 @@ describe('RecordsWriteHandler.handle()', () => {
           requester    : alice,
           recipientDid : vcIssuer.did,
           protocol,
-          protocolPath : 'credentialApplication', // this comes from `labels` in protocol definition
+          protocolPath : 'credentialApplication', // this comes from `recordTypes` in protocol definition
           schema       : credentialApplicationSchema,
           data         : encodedCredentialApplication
         });
@@ -943,7 +943,7 @@ describe('RecordsWriteHandler.handle()', () => {
             requester    : fakeVcIssuer,
             recipientDid : alice.did,
             protocol,
-            protocolPath : 'credentialApplication/credentialResponse', // this comes from `labels` in protocol definition
+            protocolPath : 'credentialApplication/credentialResponse', // this comes from `recordTypes` in protocol definition
             contextId    : credentialApplicationContextId,
             parentId     : credentialApplicationContextId,
             schema       : credentialResponseSchema,
@@ -964,7 +964,7 @@ describe('RecordsWriteHandler.handle()', () => {
           requester    : alice,
           recipientDid : alice.did,
           protocol,
-          protocolPath : 'credentialApplication/credentialResponse', // this comes from `labels` in protocol definition
+          protocolPath : 'credentialApplication/credentialResponse', // this comes from `recordTypes` in protocol definition
           data
         });
 
@@ -991,7 +991,7 @@ describe('RecordsWriteHandler.handle()', () => {
           requester    : alice,
           recipientDid : alice.did,
           protocol,
-          protocolPath : 'credentialApplication', // this comes from `labels` in protocol definition
+          protocolPath : 'credentialApplication', // this comes from `recordTypes` in protocol definition
           schema       : 'unexpectedSchema',
           data
         });
@@ -999,6 +999,34 @@ describe('RecordsWriteHandler.handle()', () => {
         const reply = await dwn.processMessage(alice.did, credentialApplication.message, credentialApplication.dataStream);
         expect(reply.status.code).to.equal(401);
         expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationInvalidSchema);
+      });
+
+      it('should fail authorization if given `protocolPath` contains an invalid record type', async () => {
+        const alice = await DidKeyResolver.generate();
+
+        const protocol = 'https://identity.foundation/decentralized-web-node/protocols/credential-issuance';
+        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+          requester          : alice,
+          protocol,
+          protocolDefinition : credentialIssuanceProtocolDefinition
+        });
+
+        const protocolConfigureReply = await dwn.processMessage(alice.did, protocolConfig.message, protocolConfig.dataStream);
+        expect(protocolConfigureReply.status.code).to.equal(202);
+
+
+        const data = Encoder.stringToBytes('any data');
+        const credentialApplication = await TestDataGenerator.generateRecordsWrite({
+          requester    : alice,
+          recipientDid : alice.did,
+          protocol,
+          protocolPath : 'invalidRecordType',
+          data
+        });
+
+        const reply = await dwn.processMessage(alice.did, credentialApplication.message, credentialApplication.dataStream);
+        expect(reply.status.code).to.equal(401);
+        expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationInvalidRecordType);
       });
 
       it('should fail authorization if given `protocolPath` is mismatching with actual path', async () => {
@@ -1019,8 +1047,8 @@ describe('RecordsWriteHandler.handle()', () => {
           requester    : alice,
           recipientDid : alice.did,
           protocol,
-          protocolPath : 'incorrect/protocol/path',
-          schema       : credentialIssuanceProtocolDefinition.labels.credentialApplication.schema,
+          protocolPath : 'credentialApplication/credentialResponse', // incorrect path. correct path is `credentialResponse` because this record has no parent
+          schema       : credentialIssuanceProtocolDefinition.recordTypes.find(({ id }) => id === 'credentialApplication')!.schema,
           data
         });
 
@@ -1033,12 +1061,13 @@ describe('RecordsWriteHandler.handle()', () => {
         const alice = await DidKeyResolver.generate();
 
         const protocolDefinition = {
-          labels: {
-            image: {
+          recordTypes: [
+            {
+              id          : 'image',
               schema      : 'https://example.com/schema',
               dataFormats : ['image/jpeg', 'image/png']
             }
-          },
+          ],
           records: {
             image: {
               allow: [
@@ -1068,7 +1097,7 @@ describe('RecordsWriteHandler.handle()', () => {
           recipientDid : alice.did,
           protocol,
           protocolPath : 'image',
-          schema       : protocolDefinition.labels.image.schema,
+          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'image')!.schema,
           dataFormat   : 'image/jpeg',
           data
         });
@@ -1081,7 +1110,7 @@ describe('RecordsWriteHandler.handle()', () => {
           recipientDid : alice.did,
           protocol,
           protocolPath : 'image',
-          schema       : protocolDefinition.labels.image.schema,
+          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'image')!.schema,
           dataFormat   : 'not/allowed/dataFormat',
           data
         });
@@ -1092,6 +1121,7 @@ describe('RecordsWriteHandler.handle()', () => {
       });
 
       it('should fail authorization if record schema is not allowed at the hierarchical level attempted for the RecordsWrite', async () => {
+        // scenario: Attempt writing of records at 3 levels in the hierarchy to cover all possible cases of missing rule sets
         const alice = await DidKeyResolver.generate();
 
         const protocol = 'https://identity.foundation/decentralized-web-node/protocols/credential-issuance';
@@ -1101,77 +1131,86 @@ describe('RecordsWriteHandler.handle()', () => {
           protocol,
           protocolDefinition
         });
-        const credentialResponseSchema = protocolDefinition.labels.credentialResponse.schema;
+        const credentialApplicationSchema = protocolDefinition.recordTypes.find(({ id }) => id === 'credentialApplication')!.schema;
+        const credentialResponseSchema = protocolDefinition.recordTypes.find(({ id }) => id === 'credentialResponse')!.schema;
 
         const protocolConfigureReply = await dwn.processMessage(alice.did, protocolConfig.message, protocolConfig.dataStream);
         expect(protocolConfigureReply.status.code).to.equal(202);
 
+        // Try and fail to write a 'credentialResponse', which is not allowed at the top level of the record hierarchy
         const data = Encoder.stringToBytes('any data');
-        const credentialApplication = await TestDataGenerator.generateRecordsWrite({
+        const failedCredentialResponse = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : alice.did,
           protocol,
           protocolPath : 'credentialResponse',
-          schema       : credentialResponseSchema, // this is an known schema type, but not allowed for a protocol root record
+          schema       : credentialResponseSchema, // this is a known schema type, but not allowed for a protocol root record
           data
         });
+        const failedCredentialResponseReply = await dwn.processMessage(
+          alice.did, failedCredentialResponse.message, failedCredentialResponse.dataStream);
+        expect(failedCredentialResponseReply.status.code).to.equal(401);
+        expect(failedCredentialResponseReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationMissingRuleSet);
 
-        const reply = await dwn.processMessage(alice.did, credentialApplication.message, credentialApplication.dataStream);
-        expect(reply.status.code).to.equal(401);
-        expect(reply.status.detail).to.contain('not allowed in structure level');
-      });
-
-      it('should fail authorization if record schema is not allowed at the hierarchical level attempted for the RecordsWrite', async () => {
-        const alice = await DidKeyResolver.generate();
-
-        const protocol = 'chatProtocol';
-        const protocolDefinition = {
-          labels: {
-            email: {
-              schema: 'http://emailschema'
-            },
-            sms: {
-              schema: 'http://smsschema'
-            }
-          },
-          records: {
-            email : {},
-            sms   : {}
-          }
-        };
-        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
-          requester: alice,
-          protocol,
-          protocolDefinition
-        });
-
-        const protocolConfigureReply = await dwn.processMessage(alice.did, protocolConfig.message, protocolConfig.dataStream);
-        expect(protocolConfigureReply.status.code).to.equal(202);
-
-        const emailRecordsWrite = await TestDataGenerator.generateRecordsWrite({
+        // Successfully write a 'credentialApplication' at the top level of the of the record hierarchy
+        const credentialApplication = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : alice.did,
           protocol,
-          protocolPath : 'email', // this comes from `labels` in protocol definition
-          schema       : protocolDefinition.labels.email.schema,
-          data         : Encoder.stringToBytes('any data'),
+          protocolPath : 'credentialApplication', // allowed at root level
+          schema       : credentialApplicationSchema,
+          data
         });
-        await dwn.processMessage(alice.did, emailRecordsWrite.message, emailRecordsWrite.dataStream);
+        const credentialApplicationReply = await dwn.processMessage(
+          alice.did, credentialApplication.message, credentialApplication.dataStream);
+        expect(credentialApplicationReply.status.code).to.equal(202);
 
-        const smsSchemaResponse = await TestDataGenerator.generateRecordsWrite({
+        // Try and fail to write another 'credentialApplication' below the first 'credentialApplication'
+        const failedCredentialApplication = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : alice.did,
           protocol,
-          protocolPath : 'email/sms', // this comes from `labels` in protocol definition
-          schema       : protocolDefinition.labels.sms.schema, // SMS are allowed, but not as a child record of emails
-          data         : Encoder.stringToBytes('any other data'),
-          parentId     : emailRecordsWrite.message.recordId,
-          contextId    : await emailRecordsWrite.recordsWrite.getEntryId()
+          protocolPath : 'credentialApplication/credentialApplication', // credentialApplications may not be nested below another credentialApplication
+          schema       : credentialApplicationSchema,
+          contextId    : await credentialApplication.recordsWrite.getEntryId(),
+          parentId     : credentialApplication.message.recordId,
+          data
         });
-        const reply = await dwn.processMessage(alice.did, smsSchemaResponse.message, smsSchemaResponse.dataStream);
+        const failedCredentialApplicationReply2 = await dwn.processMessage(
+          alice.did, failedCredentialApplication.message, failedCredentialApplication.dataStream);
+        expect(failedCredentialApplicationReply2.status.code).to.equal(401);
+        expect(failedCredentialApplicationReply2.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationMissingRuleSet);
 
-        expect(reply.status.code).to.equal(401);
-        expect(reply.status.detail).to.contain('record with schema: \'http://smsschema\' not allowed in structure level 1');
+        // Successfully write a 'credentialResponse' below the 'credentialApplication'
+        const credentialResponse = await TestDataGenerator.generateRecordsWrite({
+          requester    : alice,
+          recipientDid : alice.did,
+          protocol,
+          protocolPath : 'credentialApplication/credentialResponse',
+          schema       : credentialResponseSchema,
+          contextId    : await credentialApplication.recordsWrite.getEntryId(),
+          parentId     : credentialApplication.message.recordId,
+          data
+        });
+        const credentialResponseReply = await dwn.processMessage(alice.did, credentialResponse.message, credentialResponse.dataStream);
+        expect(credentialResponseReply.status.code).to.equal(202);
+
+        // Try and fail to write a 'credentialResponse' below 'credentialApplication/credentialResponse'
+        // Testing case where there is no rule set for any record type at the given level in the hierarchy
+        const nestedCredentialApplication = await TestDataGenerator.generateRecordsWrite({
+          requester    : alice,
+          recipientDid : alice.did,
+          protocol,
+          protocolPath : 'credentialApplication/credentialResponse/credentialApplication',
+          schema       : credentialApplicationSchema,
+          contextId    : await credentialApplication.recordsWrite.getEntryId(),
+          parentId     : credentialResponse.message.recordId,
+          data
+        });
+        const nestedCredentialApplicationReply = await dwn.processMessage(
+          alice.did, nestedCredentialApplication.message, nestedCredentialApplication.dataStream);
+        expect(nestedCredentialApplicationReply.status.code).to.equal(401);
+        expect(nestedCredentialApplicationReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationMissingRuleSet);
       });
 
       it('should only allow DWN owner to write if record does not have an allow rule defined', async () => {
@@ -1180,11 +1219,12 @@ describe('RecordsWriteHandler.handle()', () => {
         // write a protocol definition without an explicit allow rule
         const protocol = 'private-protocol';
         const protocolDefinition: ProtocolDefinition = {
-          labels: {
-            privateNote: {
-              schema: 'private-note'
+          recordTypes: [
+            {
+              id     : 'privateNote',
+              schema : 'private-note'
             }
-          },
+          ],
           records: {
             privateNote: {}
           }
@@ -1204,7 +1244,7 @@ describe('RecordsWriteHandler.handle()', () => {
           requester    : alice,
           recipientDid : alice.did,
           protocol,
-          protocolPath : 'privateNote', // this comes from `labels`
+          protocolPath : 'privateNote', // this comes from `recordTypes`
           schema       : 'private-note',
           data
         });
@@ -1218,7 +1258,7 @@ describe('RecordsWriteHandler.handle()', () => {
           requester    : bob,
           recipientDid : alice.did,
           protocol,
-          protocolPath : 'privateNote', // this comes from `labels`
+          protocolPath : 'privateNote', // this comes from `recordTypes`
           schema       : 'private-note',
           data
         });
@@ -1259,9 +1299,9 @@ describe('RecordsWriteHandler.handle()', () => {
         const messageDataWithIssuerA = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : issuer.did,
-          schema       : credentialIssuanceProtocolDefinition.labels.credentialApplication.schema,
+          schema       : credentialIssuanceProtocolDefinition.recordTypes.find(({ id }) => id === 'credentialApplication')!.schema,
           protocol,
-          protocolPath : 'credentialApplication', // this comes from `labels` in protocol definition
+          protocolPath : 'credentialApplication', // this comes from `recordTypes` in protocol definition
           data
         });
         const contextId = await messageDataWithIssuerA.recordsWrite.getEntryId();
@@ -1273,11 +1313,11 @@ describe('RecordsWriteHandler.handle()', () => {
         const invalidResponseByIssuerA = await TestDataGenerator.generateRecordsWrite({
           requester    : issuer,
           recipientDid : alice.did,
-          schema       : credentialIssuanceProtocolDefinition.labels.credentialResponse.schema,
+          schema       : credentialIssuanceProtocolDefinition.recordTypes.find(({ id }) => id === 'credentialResponse')!.schema,
           contextId,
           parentId     : messageDataWithIssuerA.message.recordId,
           protocol,
-          protocolPath : 'credentialApplication/credentialResponse', // this comes from `labels` in protocol definition
+          protocolPath : 'credentialApplication/credentialResponse', // this comes from `recordTypes` in protocol definition
           data
         });
 
@@ -1312,7 +1352,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const askMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
-          schema       : protocolDefinition.labels.ask.schema,
+          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'ask')!.schema,
           protocol,
           protocolPath : 'ask',
           data
@@ -1325,7 +1365,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const offerMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : pfi,
           recipientDid : alice.did,
-          schema       : protocolDefinition.labels.offer.schema,
+          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'offer')!.schema,
           contextId,
           parentId     : askMessageData.message.recordId,
           protocol,
@@ -1340,7 +1380,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const fulfillmentMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
-          schema       : protocolDefinition.labels.fulfillment.schema,
+          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'fulfillment')!.schema,
           contextId,
           parentId     : offerMessageData.message.recordId,
           protocol,
@@ -1392,7 +1432,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const askMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
-          schema       : protocolDefinition.labels.ask.schema,
+          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'ask')!.schema,
           protocol,
           protocolPath : 'ask',
           data
@@ -1406,7 +1446,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const fulfillmentMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
-          schema       : protocolDefinition.labels.fulfillment.schema,
+          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'fulfillment')!.schema,
           contextId,
           parentId     : 'non-existent-id',
           protocolPath : 'ask/offer/fulfillment',
@@ -1480,7 +1520,7 @@ describe('RecordsWriteHandler.handle()', () => {
           data         : new TextEncoder().encode('data1'),
           protocol     : 'example.com/',
           protocolPath : 'email', // from email protocol
-          schema       : emailProtocolDefinition.labels.email.schema
+          schema       : emailProtocolDefinition.recordTypes.find(({ id }) => id === 'email')!.schema
         });
 
         // overwrite protocol because #create auto-normalizes protocol

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -560,8 +560,8 @@ describe('RecordsWriteHandler.handle()', () => {
 
         const protocol = 'https://identity.foundation/decentralized-web-node/protocols/credential-issuance';
         const protocolDefinition: ProtocolDefinition = credentialIssuanceProtocolDefinition;
-        const credentialApplicationSchema = Protocols.getRecordType(protocolDefinition, 'credentialApplication')!.schema;
-        const credentialResponseSchema = Protocols.getRecordType(protocolDefinition, 'credentialResponse')!.schema;
+        const credentialApplicationSchema = Protocols.getRecordDefinition(protocolDefinition, 'credentialApplication')!.schema;
+        const credentialResponseSchema = Protocols.getRecordDefinition(protocolDefinition, 'credentialResponse')!.schema;
 
         const alice = await TestDataGenerator.generatePersona();
         const vcIssuer = await TestDataGenerator.generatePersona();
@@ -584,7 +584,7 @@ describe('RecordsWriteHandler.handle()', () => {
           requester    : alice,
           recipientDid : vcIssuer.did,
           protocol,
-          protocolPath : 'credentialApplication', // this comes from `recordTypes` in protocol definition
+          protocolPath : 'credentialApplication', // this comes from `recordDefinitions` in protocol definition
           schema       : credentialApplicationSchema,
           data         : encodedCredentialApplication
         });
@@ -600,7 +600,7 @@ describe('RecordsWriteHandler.handle()', () => {
             requester    : vcIssuer,
             recipientDid : alice.did,
             protocol,
-            protocolPath : 'credentialApplication/credentialResponse', // this comes from `recordTypes` in protocol definition
+            protocolPath : 'credentialApplication/credentialResponse', // this comes from `recordDefinitions` in protocol definition
             contextId    : credentialApplicationContextId,
             parentId     : credentialApplicationContextId,
             schema       : credentialResponseSchema,
@@ -650,8 +650,8 @@ describe('RecordsWriteHandler.handle()', () => {
         const imageRecordsWrite = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           protocol,
-          protocolPath : 'image', // this comes from `recordTypes` in protocol definition
-          schema       : Protocols.getRecordType(socialMediaProtocolDefinition, 'image')!.schema,
+          protocolPath : 'image', // this comes from `recordDefinitions` in protocol definition
+          schema       : Protocols.getRecordDefinition(socialMediaProtocolDefinition, 'image')!.schema,
           data         : encodedImage
         });
         const imageReply = await dwn.processMessage(bob.did, imageRecordsWrite.message, imageRecordsWrite.dataStream);
@@ -664,8 +664,8 @@ describe('RecordsWriteHandler.handle()', () => {
         const captionImposter = await TestDataGenerator.generateRecordsWrite({
           requester    : aliceImposter,
           protocol,
-          protocolPath : 'image/caption', // this comes from `recordTypes` in protocol definition
-          schema       : Protocols.getRecordType(socialMediaProtocolDefinition, 'caption')!.schema,
+          protocolPath : 'image/caption', // this comes from `recordDefinitions` in protocol definition
+          schema       : Protocols.getRecordDefinition(socialMediaProtocolDefinition, 'caption')!.schema,
           contextId    : imageContextId,
           parentId     : imageContextId,
           data         : encodedCaptionImposter
@@ -680,7 +680,7 @@ describe('RecordsWriteHandler.handle()', () => {
           requester    : alice,
           protocol,
           protocolPath : 'image/caption',
-          schema       : Protocols.getRecordType(socialMediaProtocolDefinition, 'caption')!.schema,
+          schema       : Protocols.getRecordDefinition(socialMediaProtocolDefinition, 'caption')!.schema,
           contextId    : imageContextId,
           parentId     : imageContextId,
           data         : encodedCaption
@@ -727,8 +727,8 @@ describe('RecordsWriteHandler.handle()', () => {
           {
             requester    : bob,
             protocol,
-            protocolPath : 'message', // this comes from `recordTypes` in protocol definition
-            schema       : Protocols.getRecordType(messageProtocolDefinition, 'message')!.schema,
+            protocolPath : 'message', // this comes from `recordDefinitions` in protocol definition
+            schema       : Protocols.getRecordDefinition(messageProtocolDefinition, 'message')!.schema,
             data         : bobData
           }
         );
@@ -792,8 +792,8 @@ describe('RecordsWriteHandler.handle()', () => {
           {
             requester    : bob,
             protocol,
-            protocolPath : 'message', // this comes from `recordTypes` in protocol definition
-            schema       : Protocols.getRecordType(messageProtocolDefinition, 'message')!.schema,
+            protocolPath : 'message', // this comes from `recordDefinitions` in protocol definition
+            schema       : Protocols.getRecordDefinition(messageProtocolDefinition, 'message')!.schema,
             data         : bobData
           }
         );
@@ -817,8 +817,8 @@ describe('RecordsWriteHandler.handle()', () => {
           {
             requester    : carol,
             protocol,
-            protocolPath : 'message', // this comes from `recordTypes` in protocol definition
-            schema       : Protocols.getRecordType(messageProtocolDefinition, 'message')!.schema,
+            protocolPath : 'message', // this comes from `recordDefinitions` in protocol definition
+            schema       : Protocols.getRecordDefinition(messageProtocolDefinition, 'message')!.schema,
             data         : modifiedMessageData,
             recordId     : messageFromBob.message.recordId,
           }
@@ -859,8 +859,8 @@ describe('RecordsWriteHandler.handle()', () => {
           {
             requester    : bob,
             protocol,
-            protocolPath : 'message', // this comes from `recordTypes` in protocol definition
-            schema       : Protocols.getRecordType(messageProtocolDefinition, 'message')!.schema,
+            protocolPath : 'message', // this comes from `recordDefinitions` in protocol definition
+            schema       : Protocols.getRecordDefinition(messageProtocolDefinition, 'message')!.schema,
             data         : bobData
           }
         );
@@ -884,8 +884,8 @@ describe('RecordsWriteHandler.handle()', () => {
             requester    : bob,
             dateCreated  : messageFromBob.message.descriptor.dateCreated,
             protocol,
-            protocolPath : 'message', // this comes from `recordTypes` in protocol definition
-            schema       : Protocols.getRecordType(messageProtocolDefinition, 'message')!.schema,
+            protocolPath : 'message', // this comes from `recordDefinitions` in protocol definition
+            schema       : Protocols.getRecordDefinition(messageProtocolDefinition, 'message')!.schema,
             data         : bobData,
             recordId     : messageFromBob.message.recordId,
             recipientDid : bob.did // this immutable property was Alice's DID initially
@@ -903,8 +903,8 @@ describe('RecordsWriteHandler.handle()', () => {
 
         const protocol = 'https://identity.foundation/decentralized-web-node/protocols/credential-issuance';
         const protocolDefinition = credentialIssuanceProtocolDefinition;
-        const credentialApplicationSchema = Protocols.getRecordType(protocolDefinition, 'credentialApplication')!.schema;
-        const credentialResponseSchema = Protocols.getRecordType(protocolDefinition, 'credentialResponse')!.schema;
+        const credentialApplicationSchema = Protocols.getRecordDefinition(protocolDefinition, 'credentialApplication')!.schema;
+        const credentialResponseSchema = Protocols.getRecordDefinition(protocolDefinition, 'credentialResponse')!.schema;
 
         const alice = await TestDataGenerator.generatePersona();
         const fakeVcIssuer = await TestDataGenerator.generatePersona();
@@ -928,7 +928,7 @@ describe('RecordsWriteHandler.handle()', () => {
           requester    : alice,
           recipientDid : vcIssuer.did,
           protocol,
-          protocolPath : 'credentialApplication', // this comes from `recordTypes` in protocol definition
+          protocolPath : 'credentialApplication', // this comes from `recordDefinitions` in protocol definition
           schema       : credentialApplicationSchema,
           data         : encodedCredentialApplication
         });
@@ -944,7 +944,7 @@ describe('RecordsWriteHandler.handle()', () => {
             requester    : fakeVcIssuer,
             recipientDid : alice.did,
             protocol,
-            protocolPath : 'credentialApplication/credentialResponse', // this comes from `recordTypes` in protocol definition
+            protocolPath : 'credentialApplication/credentialResponse', // this comes from `recordDefinitions` in protocol definition
             contextId    : credentialApplicationContextId,
             parentId     : credentialApplicationContextId,
             schema       : credentialResponseSchema,
@@ -965,7 +965,7 @@ describe('RecordsWriteHandler.handle()', () => {
           requester    : alice,
           recipientDid : alice.did,
           protocol,
-          protocolPath : 'credentialApplication/credentialResponse', // this comes from `recordTypes` in protocol definition
+          protocolPath : 'credentialApplication/credentialResponse', // this comes from `recordDefinitions` in protocol definition
           data
         });
 
@@ -992,7 +992,7 @@ describe('RecordsWriteHandler.handle()', () => {
           requester    : alice,
           recipientDid : alice.did,
           protocol,
-          protocolPath : 'credentialApplication', // this comes from `recordTypes` in protocol definition
+          protocolPath : 'credentialApplication', // this comes from `recordDefinitions` in protocol definition
           schema       : 'unexpectedSchema',
           data
         });
@@ -1021,13 +1021,13 @@ describe('RecordsWriteHandler.handle()', () => {
           requester    : alice,
           recipientDid : alice.did,
           protocol,
-          protocolPath : 'invalidRecordType',
+          protocolPath : 'invalidRecordDefinition',
           data
         });
 
         const reply = await dwn.processMessage(alice.did, credentialApplication.message, credentialApplication.dataStream);
         expect(reply.status.code).to.equal(401);
-        expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationInvalidRecordType);
+        expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationInvalidRecordDefinition);
       });
 
       it('should fail authorization if given `protocolPath` is mismatching with actual path', async () => {
@@ -1049,7 +1049,7 @@ describe('RecordsWriteHandler.handle()', () => {
           recipientDid : alice.did,
           protocol,
           protocolPath : 'credentialApplication/credentialResponse', // incorrect path. correct path is `credentialResponse` because this record has no parent
-          schema       : Protocols.getRecordType(credentialIssuanceProtocolDefinition, 'credentialApplication')!.schema,
+          schema       : Protocols.getRecordDefinition(credentialIssuanceProtocolDefinition, 'credentialApplication')!.schema,
           data
         });
 
@@ -1062,7 +1062,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const alice = await DidKeyResolver.generate();
 
         const protocolDefinition = {
-          recordTypes: [
+          recordDefinitions: [
             {
               id          : 'image',
               schema      : 'https://example.com/schema',
@@ -1098,7 +1098,7 @@ describe('RecordsWriteHandler.handle()', () => {
           recipientDid : alice.did,
           protocol,
           protocolPath : 'image',
-          schema       : Protocols.getRecordType(protocolDefinition, 'image')!.schema,
+          schema       : Protocols.getRecordDefinition(protocolDefinition, 'image')!.schema,
           dataFormat   : 'image/jpeg',
           data
         });
@@ -1111,7 +1111,7 @@ describe('RecordsWriteHandler.handle()', () => {
           recipientDid : alice.did,
           protocol,
           protocolPath : 'image',
-          schema       : Protocols.getRecordType(protocolDefinition, 'image')!.schema,
+          schema       : Protocols.getRecordDefinition(protocolDefinition, 'image')!.schema,
           dataFormat   : 'not/allowed/dataFormat',
           data
         });
@@ -1132,8 +1132,8 @@ describe('RecordsWriteHandler.handle()', () => {
           protocol,
           protocolDefinition
         });
-        const credentialApplicationSchema = Protocols.getRecordType(protocolDefinition, 'credentialApplication')!.schema;
-        const credentialResponseSchema = Protocols.getRecordType(protocolDefinition, 'credentialResponse')!.schema;
+        const credentialApplicationSchema = Protocols.getRecordDefinition(protocolDefinition, 'credentialApplication')!.schema;
+        const credentialResponseSchema = Protocols.getRecordDefinition(protocolDefinition, 'credentialResponse')!.schema;
 
         const protocolConfigureReply = await dwn.processMessage(alice.did, protocolConfig.message, protocolConfig.dataStream);
         expect(protocolConfigureReply.status.code).to.equal(202);
@@ -1220,7 +1220,7 @@ describe('RecordsWriteHandler.handle()', () => {
         // write a protocol definition without an explicit allow rule
         const protocol = 'private-protocol';
         const protocolDefinition: ProtocolDefinition = {
-          recordTypes: [
+          recordDefinitions: [
             {
               id     : 'privateNote',
               schema : 'private-note'
@@ -1245,7 +1245,7 @@ describe('RecordsWriteHandler.handle()', () => {
           requester    : alice,
           recipientDid : alice.did,
           protocol,
-          protocolPath : 'privateNote', // this comes from `recordTypes`
+          protocolPath : 'privateNote', // this comes from `recordDefinitions`
           schema       : 'private-note',
           data
         });
@@ -1259,7 +1259,7 @@ describe('RecordsWriteHandler.handle()', () => {
           requester    : bob,
           recipientDid : alice.did,
           protocol,
-          protocolPath : 'privateNote', // this comes from `recordTypes`
+          protocolPath : 'privateNote', // this comes from `recordDefinitions`
           schema       : 'private-note',
           data
         });
@@ -1300,9 +1300,9 @@ describe('RecordsWriteHandler.handle()', () => {
         const messageDataWithIssuerA = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : issuer.did,
-          schema       : Protocols.getRecordType(credentialIssuanceProtocolDefinition, 'credentialApplication')!.schema,
+          schema       : Protocols.getRecordDefinition(credentialIssuanceProtocolDefinition, 'credentialApplication')!.schema,
           protocol,
-          protocolPath : 'credentialApplication', // this comes from `recordTypes` in protocol definition
+          protocolPath : 'credentialApplication', // this comes from `recordDefinitions` in protocol definition
           data
         });
         const contextId = await messageDataWithIssuerA.recordsWrite.getEntryId();
@@ -1314,11 +1314,11 @@ describe('RecordsWriteHandler.handle()', () => {
         const invalidResponseByIssuerA = await TestDataGenerator.generateRecordsWrite({
           requester    : issuer,
           recipientDid : alice.did,
-          schema       : Protocols.getRecordType(credentialIssuanceProtocolDefinition, 'credentialResponse')!.schema,
+          schema       : Protocols.getRecordDefinition(credentialIssuanceProtocolDefinition, 'credentialResponse')!.schema,
           contextId,
           parentId     : messageDataWithIssuerA.message.recordId,
           protocol,
-          protocolPath : 'credentialApplication/credentialResponse', // this comes from `recordTypes` in protocol definition
+          protocolPath : 'credentialApplication/credentialResponse', // this comes from `recordDefinitions` in protocol definition
           data
         });
 
@@ -1353,7 +1353,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const askMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
-          schema       : Protocols.getRecordType(protocolDefinition, 'ask')!.schema,
+          schema       : Protocols.getRecordDefinition(protocolDefinition, 'ask')!.schema,
           protocol,
           protocolPath : 'ask',
           data
@@ -1366,7 +1366,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const offerMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : pfi,
           recipientDid : alice.did,
-          schema       : Protocols.getRecordType(protocolDefinition, 'offer')!.schema,
+          schema       : Protocols.getRecordDefinition(protocolDefinition, 'offer')!.schema,
           contextId,
           parentId     : askMessageData.message.recordId,
           protocol,
@@ -1381,7 +1381,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const fulfillmentMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
-          schema       : Protocols.getRecordType(protocolDefinition, 'fulfillment')!.schema,
+          schema       : Protocols.getRecordDefinition(protocolDefinition, 'fulfillment')!.schema,
           contextId,
           parentId     : offerMessageData.message.recordId,
           protocol,
@@ -1433,7 +1433,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const askMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
-          schema       : Protocols.getRecordType(protocolDefinition, 'ask')!.schema,
+          schema       : Protocols.getRecordDefinition(protocolDefinition, 'ask')!.schema,
           protocol,
           protocolPath : 'ask',
           data
@@ -1447,7 +1447,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const fulfillmentMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
-          schema       : Protocols.getRecordType(protocolDefinition, 'fulfillment')!.schema,
+          schema       : Protocols.getRecordDefinition(protocolDefinition, 'fulfillment')!.schema,
           contextId,
           parentId     : 'non-existent-id',
           protocolPath : 'ask/offer/fulfillment',
@@ -1521,7 +1521,7 @@ describe('RecordsWriteHandler.handle()', () => {
           data         : new TextEncoder().encode('data1'),
           protocol     : 'example.com/',
           protocolPath : 'email', // from email protocol
-          schema       : Protocols.getRecordType(emailProtocolDefinition, 'email')!.schema
+          schema       : Protocols.getRecordDefinition(emailProtocolDefinition, 'email')!.schema
         });
 
         // overwrite protocol because #create auto-normalizes protocol

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -27,6 +27,7 @@ import { KeyDerivationScheme } from '../../../../src/index.js';
 import { Message } from '../../../../src/core/message.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
 import { ProtocolActor } from '../../../../src/interfaces/protocols/types.js';
+import { Protocols } from '../../../../src/utils/protocols.js';
 import { RecordsWriteHandler } from '../../../../src/interfaces/records/handlers/records-write.js';
 import { StorageController } from '../../../../src/store/storage-controller.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
@@ -559,8 +560,8 @@ describe('RecordsWriteHandler.handle()', () => {
 
         const protocol = 'https://identity.foundation/decentralized-web-node/protocols/credential-issuance';
         const protocolDefinition: ProtocolDefinition = credentialIssuanceProtocolDefinition;
-        const credentialApplicationSchema = protocolDefinition.recordTypes.find(({ id }) => id === 'credentialApplication')!.schema;
-        const credentialResponseSchema = protocolDefinition.recordTypes.find(({ id }) => id === 'credentialResponse')!.schema;
+        const credentialApplicationSchema = Protocols.getRecordType(protocolDefinition, 'credentialApplication')!.schema;
+        const credentialResponseSchema = Protocols.getRecordType(protocolDefinition, 'credentialResponse')!.schema;
 
         const alice = await TestDataGenerator.generatePersona();
         const vcIssuer = await TestDataGenerator.generatePersona();
@@ -650,7 +651,7 @@ describe('RecordsWriteHandler.handle()', () => {
           requester    : alice,
           protocol,
           protocolPath : 'image', // this comes from `recordTypes` in protocol definition
-          schema       : socialMediaProtocolDefinition.recordTypes.find(({ id }) => id === 'image')!.schema,
+          schema       : Protocols.getRecordType(socialMediaProtocolDefinition, 'image')!.schema,
           data         : encodedImage
         });
         const imageReply = await dwn.processMessage(bob.did, imageRecordsWrite.message, imageRecordsWrite.dataStream);
@@ -664,7 +665,7 @@ describe('RecordsWriteHandler.handle()', () => {
           requester    : aliceImposter,
           protocol,
           protocolPath : 'image/caption', // this comes from `recordTypes` in protocol definition
-          schema       : socialMediaProtocolDefinition.recordTypes.find(({ id }) => id === 'caption')!.schema,
+          schema       : Protocols.getRecordType(socialMediaProtocolDefinition, 'caption')!.schema,
           contextId    : imageContextId,
           parentId     : imageContextId,
           data         : encodedCaptionImposter
@@ -679,7 +680,7 @@ describe('RecordsWriteHandler.handle()', () => {
           requester    : alice,
           protocol,
           protocolPath : 'image/caption',
-          schema       : socialMediaProtocolDefinition.recordTypes.find(({ id }) => id === 'caption')!.schema,
+          schema       : Protocols.getRecordType(socialMediaProtocolDefinition, 'caption')!.schema,
           contextId    : imageContextId,
           parentId     : imageContextId,
           data         : encodedCaption
@@ -727,7 +728,7 @@ describe('RecordsWriteHandler.handle()', () => {
             requester    : bob,
             protocol,
             protocolPath : 'message', // this comes from `recordTypes` in protocol definition
-            schema       : messageProtocolDefinition.recordTypes.find(({ id }) => id === 'message')!.schema,
+            schema       : Protocols.getRecordType(messageProtocolDefinition, 'message')!.schema,
             data         : bobData
           }
         );
@@ -792,7 +793,7 @@ describe('RecordsWriteHandler.handle()', () => {
             requester    : bob,
             protocol,
             protocolPath : 'message', // this comes from `recordTypes` in protocol definition
-            schema       : messageProtocolDefinition.recordTypes.find(({ id }) => id === 'message')!.schema,
+            schema       : Protocols.getRecordType(messageProtocolDefinition, 'message')!.schema,
             data         : bobData
           }
         );
@@ -817,7 +818,7 @@ describe('RecordsWriteHandler.handle()', () => {
             requester    : carol,
             protocol,
             protocolPath : 'message', // this comes from `recordTypes` in protocol definition
-            schema       : messageProtocolDefinition.recordTypes.find(({ id }) => id === 'message')!.schema,
+            schema       : Protocols.getRecordType(messageProtocolDefinition, 'message')!.schema,
             data         : modifiedMessageData,
             recordId     : messageFromBob.message.recordId,
           }
@@ -859,7 +860,7 @@ describe('RecordsWriteHandler.handle()', () => {
             requester    : bob,
             protocol,
             protocolPath : 'message', // this comes from `recordTypes` in protocol definition
-            schema       : messageProtocolDefinition.recordTypes.find(({ id }) => id === 'message')!.schema,
+            schema       : Protocols.getRecordType(messageProtocolDefinition, 'message')!.schema,
             data         : bobData
           }
         );
@@ -884,7 +885,7 @@ describe('RecordsWriteHandler.handle()', () => {
             dateCreated  : messageFromBob.message.descriptor.dateCreated,
             protocol,
             protocolPath : 'message', // this comes from `recordTypes` in protocol definition
-            schema       : messageProtocolDefinition.recordTypes.find(({ id }) => id === 'message')!.schema,
+            schema       : Protocols.getRecordType(messageProtocolDefinition, 'message')!.schema,
             data         : bobData,
             recordId     : messageFromBob.message.recordId,
             recipientDid : bob.did // this immutable property was Alice's DID initially
@@ -902,8 +903,8 @@ describe('RecordsWriteHandler.handle()', () => {
 
         const protocol = 'https://identity.foundation/decentralized-web-node/protocols/credential-issuance';
         const protocolDefinition = credentialIssuanceProtocolDefinition;
-        const credentialApplicationSchema = protocolDefinition.recordTypes.find(({ id }) => id === 'credentialApplication')!.schema;
-        const credentialResponseSchema = protocolDefinition.recordTypes.find(({ id }) => id === 'credentialResponse')!.schema;
+        const credentialApplicationSchema = Protocols.getRecordType(protocolDefinition, 'credentialApplication')!.schema;
+        const credentialResponseSchema = Protocols.getRecordType(protocolDefinition, 'credentialResponse')!.schema;
 
         const alice = await TestDataGenerator.generatePersona();
         const fakeVcIssuer = await TestDataGenerator.generatePersona();
@@ -1048,7 +1049,7 @@ describe('RecordsWriteHandler.handle()', () => {
           recipientDid : alice.did,
           protocol,
           protocolPath : 'credentialApplication/credentialResponse', // incorrect path. correct path is `credentialResponse` because this record has no parent
-          schema       : credentialIssuanceProtocolDefinition.recordTypes.find(({ id }) => id === 'credentialApplication')!.schema,
+          schema       : Protocols.getRecordType(credentialIssuanceProtocolDefinition, 'credentialApplication')!.schema,
           data
         });
 
@@ -1097,7 +1098,7 @@ describe('RecordsWriteHandler.handle()', () => {
           recipientDid : alice.did,
           protocol,
           protocolPath : 'image',
-          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'image')!.schema,
+          schema       : Protocols.getRecordType(protocolDefinition, 'image')!.schema,
           dataFormat   : 'image/jpeg',
           data
         });
@@ -1110,7 +1111,7 @@ describe('RecordsWriteHandler.handle()', () => {
           recipientDid : alice.did,
           protocol,
           protocolPath : 'image',
-          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'image')!.schema,
+          schema       : Protocols.getRecordType(protocolDefinition, 'image')!.schema,
           dataFormat   : 'not/allowed/dataFormat',
           data
         });
@@ -1131,8 +1132,8 @@ describe('RecordsWriteHandler.handle()', () => {
           protocol,
           protocolDefinition
         });
-        const credentialApplicationSchema = protocolDefinition.recordTypes.find(({ id }) => id === 'credentialApplication')!.schema;
-        const credentialResponseSchema = protocolDefinition.recordTypes.find(({ id }) => id === 'credentialResponse')!.schema;
+        const credentialApplicationSchema = Protocols.getRecordType(protocolDefinition, 'credentialApplication')!.schema;
+        const credentialResponseSchema = Protocols.getRecordType(protocolDefinition, 'credentialResponse')!.schema;
 
         const protocolConfigureReply = await dwn.processMessage(alice.did, protocolConfig.message, protocolConfig.dataStream);
         expect(protocolConfigureReply.status.code).to.equal(202);
@@ -1299,7 +1300,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const messageDataWithIssuerA = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : issuer.did,
-          schema       : credentialIssuanceProtocolDefinition.recordTypes.find(({ id }) => id === 'credentialApplication')!.schema,
+          schema       : Protocols.getRecordType(credentialIssuanceProtocolDefinition, 'credentialApplication')!.schema,
           protocol,
           protocolPath : 'credentialApplication', // this comes from `recordTypes` in protocol definition
           data
@@ -1313,7 +1314,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const invalidResponseByIssuerA = await TestDataGenerator.generateRecordsWrite({
           requester    : issuer,
           recipientDid : alice.did,
-          schema       : credentialIssuanceProtocolDefinition.recordTypes.find(({ id }) => id === 'credentialResponse')!.schema,
+          schema       : Protocols.getRecordType(credentialIssuanceProtocolDefinition, 'credentialResponse')!.schema,
           contextId,
           parentId     : messageDataWithIssuerA.message.recordId,
           protocol,
@@ -1352,7 +1353,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const askMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
-          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'ask')!.schema,
+          schema       : Protocols.getRecordType(protocolDefinition, 'ask')!.schema,
           protocol,
           protocolPath : 'ask',
           data
@@ -1365,7 +1366,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const offerMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : pfi,
           recipientDid : alice.did,
-          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'offer')!.schema,
+          schema       : Protocols.getRecordType(protocolDefinition, 'offer')!.schema,
           contextId,
           parentId     : askMessageData.message.recordId,
           protocol,
@@ -1380,7 +1381,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const fulfillmentMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
-          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'fulfillment')!.schema,
+          schema       : Protocols.getRecordType(protocolDefinition, 'fulfillment')!.schema,
           contextId,
           parentId     : offerMessageData.message.recordId,
           protocol,
@@ -1432,7 +1433,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const askMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
-          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'ask')!.schema,
+          schema       : Protocols.getRecordType(protocolDefinition, 'ask')!.schema,
           protocol,
           protocolPath : 'ask',
           data
@@ -1446,7 +1447,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const fulfillmentMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
           recipientDid : pfi.did,
-          schema       : protocolDefinition.recordTypes.find(({ id }) => id === 'fulfillment')!.schema,
+          schema       : Protocols.getRecordType(protocolDefinition, 'fulfillment')!.schema,
           contextId,
           parentId     : 'non-existent-id',
           protocolPath : 'ask/offer/fulfillment',
@@ -1520,7 +1521,7 @@ describe('RecordsWriteHandler.handle()', () => {
           data         : new TextEncoder().encode('data1'),
           protocol     : 'example.com/',
           protocolPath : 'email', // from email protocol
-          schema       : emailProtocolDefinition.recordTypes.find(({ id }) => id === 'email')!.schema
+          schema       : Protocols.getRecordType(emailProtocolDefinition, 'email')!.schema
         });
 
         // overwrite protocol because #create auto-normalizes protocol

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -239,7 +239,7 @@ export class TestDataGenerator {
 
       definition = {
         recordDefinitions : [],
-        records     : {}
+        records           : {}
       };
       definition.recordDefinitions.push({ id: generatedLabel, schema: `test-object` });
       definition.records[generatedLabel] = {};

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -238,10 +238,10 @@ export class TestDataGenerator {
       const generatedLabel = 'record' + TestDataGenerator.randomString(10);
 
       definition = {
-        labels  : {},
-        records : {}
+        recordTypes : [],
+        records     : {}
       };
-      definition.labels[generatedLabel] = { schema: `test-object` };
+      definition.recordTypes.push({ id: generatedLabel, schema: `test-object` });
       definition.records[generatedLabel] = {};
     }
 

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -238,10 +238,10 @@ export class TestDataGenerator {
       const generatedLabel = 'record' + TestDataGenerator.randomString(10);
 
       definition = {
-        recordTypes : [],
+        recordDefinitions : [],
         records     : {}
       };
-      definition.recordTypes.push({ id: generatedLabel, schema: `test-object` });
+      definition.recordDefinitions.push({ id: generatedLabel, schema: `test-object` });
       definition.records[generatedLabel] = {};
     }
 

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -7,7 +7,7 @@ import type { ProtocolDefinition, ProtocolsConfigureMessage } from '../../../../
 describe('ProtocolsConfigure schema definition', () => {
   it('should throw if unknown actor is encountered in allow rule', async () => {
     const protocolDefinition: ProtocolDefinition = {
-      recordTypes: [{
+      recordDefinitions: [{
         id     : 'email',
         schema : 'email'
       }],

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -7,11 +7,10 @@ import type { ProtocolDefinition, ProtocolsConfigureMessage } from '../../../../
 describe('ProtocolsConfigure schema definition', () => {
   it('should throw if unknown actor is encountered in allow rule', async () => {
     const protocolDefinition: ProtocolDefinition = {
-      labels: {
-        email: {
-          schema: 'email'
-        }
-      },
+      recordTypes: [{
+        id     : 'email',
+        schema : 'email'
+      }],
       records: {
         email: {
           allow: [

--- a/tests/vectors/protocol-definitions/credential-issuance.json
+++ b/tests/vectors/protocol-definitions/credential-issuance.json
@@ -1,5 +1,5 @@
 {
-  "recordTypes": [
+  "recordDefinitions": [
     {
       "id": "credentialApplication",
       "schema": "https://identity.foundation/credential-manifest/schemas/credential-application"

--- a/tests/vectors/protocol-definitions/credential-issuance.json
+++ b/tests/vectors/protocol-definitions/credential-issuance.json
@@ -1,12 +1,14 @@
 {
-  "labels": {
-    "credentialApplication": {
+  "recordTypes": [
+    {
+      "id": "credentialApplication",
       "schema": "https://identity.foundation/credential-manifest/schemas/credential-application"
     },
-    "credentialResponse": {
+    {
+      "id": "credentialResponse",
       "schema": "https://identity.foundation/credential-manifest/schemas/credential-response"
     }
-  },
+  ],
   "records": {
     "credentialApplication": {
       "allow": [

--- a/tests/vectors/protocol-definitions/dex.json
+++ b/tests/vectors/protocol-definitions/dex.json
@@ -1,5 +1,5 @@
 {
-  "recordTypes": [
+  "recordDefinitions": [
     {
       "id": "ask",
       "schema": "https://tbd/website/tbdex/ask"

--- a/tests/vectors/protocol-definitions/dex.json
+++ b/tests/vectors/protocol-definitions/dex.json
@@ -1,15 +1,18 @@
 {
-  "labels": {
-    "ask": {
+  "recordTypes": [
+    {
+      "id": "ask",
       "schema": "https://tbd/website/tbdex/ask"
     },
-    "offer": {
+    {
+      "id": "offer",
       "schema": "https://tbd/website/tbdex/offer"
     },
-    "fulfillment": {
+    {
+      "id": "fulfillment",
       "schema": "https://tbd/website/tbdex/fulfillment"
     }
-  },
+  ],
   "records": {
     "ask": {
       "allow": [

--- a/tests/vectors/protocol-definitions/email.json
+++ b/tests/vectors/protocol-definitions/email.json
@@ -1,5 +1,5 @@
 {
-  "recordTypes": [
+  "recordDefinitions": [
     {
       "id": "email",
       "schema": "email"

--- a/tests/vectors/protocol-definitions/email.json
+++ b/tests/vectors/protocol-definitions/email.json
@@ -1,9 +1,10 @@
 {
-  "labels": {
-    "email": {
+  "recordTypes": [
+    {
+      "id": "email",
       "schema": "email"
     }
-  },
+  ],
   "records": {
     "email": {
       "allow": [

--- a/tests/vectors/protocol-definitions/message.json
+++ b/tests/vectors/protocol-definitions/message.json
@@ -1,9 +1,10 @@
 {
-  "labels": {
-    "message": {
+  "recordTypes": [
+    {
+      "id": "message",
       "schema": "http://message.me"
     }
-  },
+  ],
   "records": {
     "message": {
       "allow": [

--- a/tests/vectors/protocol-definitions/message.json
+++ b/tests/vectors/protocol-definitions/message.json
@@ -1,5 +1,5 @@
 {
-  "recordTypes": [
+  "recordDefinitions": [
     {
       "id": "message",
       "schema": "http://message.me"

--- a/tests/vectors/protocol-definitions/social-media.json
+++ b/tests/vectors/protocol-definitions/social-media.json
@@ -1,5 +1,5 @@
 {
-  "recordTypes": [
+  "recordDefinitions": [
     {
       "id": "message",
       "schema": "messageSchema"

--- a/tests/vectors/protocol-definitions/social-media.json
+++ b/tests/vectors/protocol-definitions/social-media.json
@@ -1,10 +1,22 @@
 {
-  "labels": {
-    "message": { "schema": "messageSchema" },
-    "reply": { "schema": "replySchema" },
-    "image": { "schema": "imageSchema" },
-    "caption": { "schema": "captionSchema" }
-  },
+  "recordTypes": [
+    {
+      "id": "message",
+      "schema": "messageSchema"
+    },
+    {
+      "id": "reply",
+      "schema": "replySchema"
+    },
+    {
+      "id": "image",
+      "schema": "imageSchema"
+    },
+    {
+      "id": "caption",
+      "schema": "captionSchema"
+    }
+  ],
   "records": {
     "message": {
       "allow": [


### PR DESCRIPTION
Another step in the refactor outlined in #326. Also, fully addresses feature #333.

## Changes
#326
* Change property `label` to `recordDefinitions`. Make `recordDefinitions` an array, where each element has `id`, `schema`, and `dataFormats`

#333
* Makes `schema` optional in protocol auth'd `RecordsWrites`. (`schema` was previously required for protocol `RecordsWrites`.)

Other
* Remove duplicate tests and flesh out tests for `ProtocolAuthrorization.getRuleSet`, particularly testing for new error code `DwnErrorCode.ProtocolAuthorizationMissingRuleSet`.