### PR TITLE
Turn StorageController into a class

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.19%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.89%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.15%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.19%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.18%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.89%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.15%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.18%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.17%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.85%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-91.97%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.17%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.18%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.89%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.18%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.18%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.18%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.89%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.18%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.18%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.19%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.9%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.2%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.19%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.19%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.9%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.2%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.19%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.19%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.89%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.15%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.19%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -352,7 +352,10 @@ export class ProtocolAuthorization {
    * @throws {Error} if fails verification
    */
   private static async verifyActionCondition(
-    tenant: string, incomingMessage: RecordsRead | RecordsWrite, storageController: StorageController): Promise<void> {
+    tenant: string,
+    incomingMessage: RecordsRead | RecordsWrite,
+    storageController: StorageController
+  ): Promise<void> {
     if (incomingMessage.message.descriptor.method === DwnMethodName.Read) {
       // Currently no conditions for reads
     } else if (incomingMessage.message.descriptor.method === DwnMethodName.Write) {

--- a/src/dwn.ts
+++ b/src/dwn.ts
@@ -48,11 +48,11 @@ export class Dwn {
       [DwnInterfaceName.Messages + DwnMethodName.Get]        : new MessagesGetHandler(this.didResolver, storageController),
       [DwnInterfaceName.Permissions + DwnMethodName.Request] : new PermissionsRequestHandler(this.didResolver, storageController),
       [DwnInterfaceName.Protocols + DwnMethodName.Configure] : new ProtocolsConfigureHandler(this.didResolver, storageController),
-      [DwnInterfaceName.Protocols + DwnMethodName.Query] : new ProtocolsQueryHandler(this.didResolver, storageController),
-      [DwnInterfaceName.Records + DwnMethodName.Delete]  : new RecordsDeleteHandler(this.didResolver, storageController),
-      [DwnInterfaceName.Records + DwnMethodName.Query] : new RecordsQueryHandler(this.didResolver, storageController),
-      [DwnInterfaceName.Records + DwnMethodName.Read]  : new RecordsReadHandler(this.didResolver, storageController),
-      [DwnInterfaceName.Records + DwnMethodName.Write] : new RecordsWriteHandler(this.didResolver, storageController),
+      [DwnInterfaceName.Protocols + DwnMethodName.Query]     : new ProtocolsQueryHandler(this.didResolver, storageController),
+      [DwnInterfaceName.Records + DwnMethodName.Delete]      : new RecordsDeleteHandler(this.didResolver, storageController),
+      [DwnInterfaceName.Records + DwnMethodName.Query]       : new RecordsQueryHandler(this.didResolver, storageController),
+      [DwnInterfaceName.Records + DwnMethodName.Read]        : new RecordsReadHandler(this.didResolver, storageController),
+      [DwnInterfaceName.Records + DwnMethodName.Write]       : new RecordsWriteHandler(this.didResolver, storageController),
     };
   }
 

--- a/src/dwn.ts
+++ b/src/dwn.ts
@@ -23,6 +23,7 @@ import { RecordsDeleteHandler } from './interfaces/records/handlers/records-dele
 import { RecordsQueryHandler } from './interfaces/records/handlers/records-query.js';
 import { RecordsReadHandler } from './interfaces/records/handlers/records-read.js';
 import { RecordsWriteHandler } from './interfaces/records/handlers/records-write.js';
+import { StorageController } from './store/storage-controller.js';
 import { DwnInterfaceName, DwnMethodName, Message } from './core/message.js';
 
 export class Dwn {
@@ -40,18 +41,18 @@ export class Dwn {
     this.eventLog = config.eventLog!;
     this.tenantGate = config.tenantGate!;
 
+    const storageController = new StorageController(this.messageStore, this.dataStore, this.eventLog);
+
     this.methodHandlers = {
       [DwnInterfaceName.Events + DwnMethodName.Get]          : new EventsGetHandler(this.didResolver, this.eventLog),
-      [DwnInterfaceName.Messages + DwnMethodName.Get]        : new MessagesGetHandler(this.didResolver, this.messageStore, this.dataStore),
-      [DwnInterfaceName.Permissions + DwnMethodName.Request] : new PermissionsRequestHandler(this.didResolver, this.messageStore, this.dataStore),
-      [DwnInterfaceName.Protocols + DwnMethodName.Configure] : new ProtocolsConfigureHandler(
-        this.didResolver, this.messageStore, this.dataStore, this.eventLog),
-      [DwnInterfaceName.Protocols + DwnMethodName.Query] : new ProtocolsQueryHandler(this.didResolver, this.messageStore, this.dataStore),
-      [DwnInterfaceName.Records + DwnMethodName.Delete]  : new RecordsDeleteHandler(
-        this.didResolver, this.messageStore, this.dataStore, this.eventLog),
-      [DwnInterfaceName.Records + DwnMethodName.Query] : new RecordsQueryHandler(this.didResolver, this.messageStore, this.dataStore),
-      [DwnInterfaceName.Records + DwnMethodName.Read]  : new RecordsReadHandler(this.didResolver, this.messageStore, this.dataStore),
-      [DwnInterfaceName.Records + DwnMethodName.Write] : new RecordsWriteHandler(this.didResolver, this.messageStore, this.dataStore, this.eventLog),
+      [DwnInterfaceName.Messages + DwnMethodName.Get]        : new MessagesGetHandler(this.didResolver, storageController),
+      [DwnInterfaceName.Permissions + DwnMethodName.Request] : new PermissionsRequestHandler(this.didResolver, storageController),
+      [DwnInterfaceName.Protocols + DwnMethodName.Configure] : new ProtocolsConfigureHandler(this.didResolver, storageController),
+      [DwnInterfaceName.Protocols + DwnMethodName.Query] : new ProtocolsQueryHandler(this.didResolver, storageController),
+      [DwnInterfaceName.Records + DwnMethodName.Delete]  : new RecordsDeleteHandler(this.didResolver, storageController),
+      [DwnInterfaceName.Records + DwnMethodName.Query] : new RecordsQueryHandler(this.didResolver, storageController),
+      [DwnInterfaceName.Records + DwnMethodName.Read]  : new RecordsReadHandler(this.didResolver, storageController),
+      [DwnInterfaceName.Records + DwnMethodName.Write] : new RecordsWriteHandler(this.didResolver, storageController),
     };
   }
 

--- a/src/interfaces/messages/handlers/messages-get.ts
+++ b/src/interfaces/messages/handlers/messages-get.ts
@@ -36,7 +36,7 @@ export class MessagesGetHandler implements MethodHandler {
     const messageCids = new Set(message.descriptor.messageCids);
 
     for (const messageCid of messageCids) {
-      const promise = this.storageController.MessageStore.get(tenant, messageCid)
+      const promise = this.storageController.getMessage(tenant, messageCid)
         .then(message => {
           return { messageCid, message };
         })
@@ -70,7 +70,7 @@ export class MessagesGetHandler implements MethodHandler {
 
       if (dataCid !== undefined && dataSize! <= DwnConstant.maxDataSizeAllowedToBeEncoded) {
         const messageCid = await Message.getCid(message);
-        const result = await this.storageController.get(tenant, messageCid, dataCid);
+        const result = await this.storageController.getData(tenant, messageCid, dataCid);
 
         if (result) {
           const dataBytes = await DataStream.toBytes(result.dataStream);

--- a/src/interfaces/messages/handlers/messages-get.ts
+++ b/src/interfaces/messages/handlers/messages-get.ts
@@ -1,7 +1,6 @@
-import type { DataStore } from '../../../store/data-store.js';
 import type { DidResolver } from '../../../did/did-resolver.js';
-import type { MessageStore } from '../../../store/message-store.js';
 import type { MethodHandler } from '../../types.js';
+import type { StorageController } from '../../../store/storage-controller.js';
 import type { MessagesGetMessage, MessagesGetReply, MessagesGetReplyEntry } from '../types.js';
 
 import { DataStream } from '../../../utils/data-stream.js';
@@ -15,7 +14,7 @@ import { DwnInterfaceName, DwnMethodName, Message } from '../../../core/message.
 type HandleArgs = { tenant: string, message: MessagesGetMessage };
 
 export class MessagesGetHandler implements MethodHandler {
-  constructor(private didResolver: DidResolver, private messageStore: MessageStore, private dataStore: DataStore) {}
+  constructor(private didResolver: DidResolver, private storageController: StorageController) {}
 
   public async handle({ tenant, message }: HandleArgs): Promise<MessagesGetReply> {
     let messagesGet: MessagesGet;
@@ -37,7 +36,7 @@ export class MessagesGetHandler implements MethodHandler {
     const messageCids = new Set(message.descriptor.messageCids);
 
     for (const messageCid of messageCids) {
-      const promise = this.messageStore.get(tenant, messageCid)
+      const promise = this.storageController.MessageStore.get(tenant, messageCid)
         .then(message => {
           return { messageCid, message };
         })
@@ -71,7 +70,7 @@ export class MessagesGetHandler implements MethodHandler {
 
       if (dataCid !== undefined && dataSize! <= DwnConstant.maxDataSizeAllowedToBeEncoded) {
         const messageCid = await Message.getCid(message);
-        const result = await this.dataStore.get(tenant, messageCid, dataCid);
+        const result = await this.storageController.get(tenant, messageCid, dataCid);
 
         if (result) {
           const dataBytes = await DataStream.toBytes(result.dataStream);

--- a/src/interfaces/permissions/handlers/permissions-request.ts
+++ b/src/interfaces/permissions/handlers/permissions-request.ts
@@ -35,7 +35,7 @@ export class PermissionsRequestHandler implements MethodHandler {
       author,
       ... message.descriptor
     };
-    await this.storageController.put(tenant, message, index as any); // FIXME
+    await this.storageController.putMessageStore(tenant, message, index as any); // FIXME
 
     return new MessageReply({
       status: { code: 202, detail: 'Accepted' }

--- a/src/interfaces/permissions/handlers/permissions-request.ts
+++ b/src/interfaces/permissions/handlers/permissions-request.ts
@@ -35,7 +35,7 @@ export class PermissionsRequestHandler implements MethodHandler {
       author,
       ... message.descriptor
     };
-    await this.storageController.putMessage(tenant, message, index as any); // FIXME
+    await this.storageController.putMessageWithoutData(tenant, message, index as any); // FIXME
 
     return new MessageReply({
       status: { code: 202, detail: 'Accepted' }

--- a/src/interfaces/permissions/handlers/permissions-request.ts
+++ b/src/interfaces/permissions/handlers/permissions-request.ts
@@ -35,7 +35,7 @@ export class PermissionsRequestHandler implements MethodHandler {
       author,
       ... message.descriptor
     };
-    await this.storageController.putMessageStore(tenant, message, index as any); // FIXME
+    await this.storageController.putMessage(tenant, message, index as any); // FIXME
 
     return new MessageReply({
       status: { code: 202, detail: 'Accepted' }

--- a/src/interfaces/permissions/handlers/permissions-request.ts
+++ b/src/interfaces/permissions/handlers/permissions-request.ts
@@ -1,6 +1,8 @@
+import type { DidResolver } from '../../../index.js';
 import type { MethodHandler } from '../../types.js';
 import type { PermissionsRequestMessage } from '../types.js';
-import type { DataStore, DidResolver, MessageStore } from '../../../index.js';
+import type { StorageController } from '../../../store/storage-controller.js';
+
 
 import { canonicalAuth } from '../../../core/auth.js';
 import { MessageReply } from '../../../core/message-reply.js';
@@ -8,7 +10,7 @@ import { PermissionsRequest } from '../messages/permissions-request.js';
 
 export class PermissionsRequestHandler implements MethodHandler {
 
-  constructor(private didResolver: DidResolver, private messageStore: MessageStore,private dataStore: DataStore) { }
+  constructor(private didResolver: DidResolver, private storageController: StorageController) { }
 
   public async handle({
     tenant,
@@ -33,7 +35,7 @@ export class PermissionsRequestHandler implements MethodHandler {
       author,
       ... message.descriptor
     };
-    await this.messageStore.put(tenant, message, index as any); // FIXME
+    await this.storageController.put(tenant, message, index as any); // FIXME
 
     return new MessageReply({
       status: { code: 202, detail: 'Accepted' }

--- a/src/interfaces/protocols/handlers/protocols-configure.ts
+++ b/src/interfaces/protocols/handlers/protocols-configure.ts
@@ -60,7 +60,7 @@ export class ProtocolsConfigureHandler implements MethodHandler {
 
       // FIXME: indexes, Property 'dataSize' is incompatible with index signature.
       // Type 'number' is not assignable to type 'string'.
-      await this.storageController.putWithData(tenant, message, indexes as any, dataStream);
+      await this.storageController.putMessageWithData(tenant, message, indexes as any, dataStream);
 
       messageReply = new MessageReply({
         status: { code: 202, detail: 'Accepted' }

--- a/src/interfaces/protocols/handlers/protocols-configure.ts
+++ b/src/interfaces/protocols/handlers/protocols-configure.ts
@@ -39,7 +39,7 @@ export class ProtocolsConfigureHandler implements MethodHandler {
       method    : DwnMethodName.Configure,
       protocol  : message.descriptor.protocol
     };
-    const existingMessages = await this.storageController.MessageStore.query(tenant, query) as ProtocolsConfigureMessage[];
+    const existingMessages = await this.storageController.queryMessageStore(tenant, query) as ProtocolsConfigureMessage[];
 
     // find lexicographically the largest message, and if the incoming message is the largest
     let newestMessage = await Message.getMessageWithLargestCid(existingMessages);

--- a/src/interfaces/protocols/handlers/protocols-configure.ts
+++ b/src/interfaces/protocols/handlers/protocols-configure.ts
@@ -60,7 +60,7 @@ export class ProtocolsConfigureHandler implements MethodHandler {
 
       // FIXME: indexes, Property 'dataSize' is incompatible with index signature.
       // Type 'number' is not assignable to type 'string'.
-      await this.storageController.put(tenant, message, indexes as any, dataStream);
+      await this.storageController.putWithData(tenant, message, indexes as any, dataStream);
 
       messageReply = new MessageReply({
         status: { code: 202, detail: 'Accepted' }
@@ -78,7 +78,7 @@ export class ProtocolsConfigureHandler implements MethodHandler {
         const messageCid = await Message.getCid(message);
         deletedMessageCids.push(messageCid);
 
-        await this.storageController.delete(tenant, message);
+        await this.storageController.deleteMessage(tenant, message);
       }
     }
 

--- a/src/interfaces/protocols/handlers/protocols-configure.ts
+++ b/src/interfaces/protocols/handlers/protocols-configure.ts
@@ -39,7 +39,7 @@ export class ProtocolsConfigureHandler implements MethodHandler {
       method    : DwnMethodName.Configure,
       protocol  : message.descriptor.protocol
     };
-    const existingMessages = await this.storageController.queryMessageStore(tenant, query) as ProtocolsConfigureMessage[];
+    const existingMessages = await this.storageController.queryMessages(tenant, query) as ProtocolsConfigureMessage[];
 
     // find lexicographically the largest message, and if the incoming message is the largest
     let newestMessage = await Message.getMessageWithLargestCid(existingMessages);
@@ -82,7 +82,7 @@ export class ProtocolsConfigureHandler implements MethodHandler {
       }
     }
 
-    await this.storageController.deleteEventsByCid(tenant, deletedMessageCids);
+    await this.storageController.deleteEvents(tenant, deletedMessageCids);
 
     return messageReply;
   };

--- a/src/interfaces/protocols/handlers/protocols-query.ts
+++ b/src/interfaces/protocols/handlers/protocols-query.ts
@@ -40,7 +40,7 @@ export class ProtocolsQueryHandler implements MethodHandler {
     };
     removeUndefinedProperties(query);
 
-    const messages = await this.storageController.query(tenant, query);
+    const messages = await this.storageController.queryMessageStore(tenant, query);
 
     // strip away `authorization` property for each record before responding
     const entries: QueryResultEntry[] = [];

--- a/src/interfaces/protocols/handlers/protocols-query.ts
+++ b/src/interfaces/protocols/handlers/protocols-query.ts
@@ -40,7 +40,7 @@ export class ProtocolsQueryHandler implements MethodHandler {
     };
     removeUndefinedProperties(query);
 
-    const messages = await this.storageController.queryMessageStore(tenant, query);
+    const messages = await this.storageController.queryMessages(tenant, query);
 
     // strip away `authorization` property for each record before responding
     const entries: QueryResultEntry[] = [];

--- a/src/interfaces/protocols/handlers/protocols-query.ts
+++ b/src/interfaces/protocols/handlers/protocols-query.ts
@@ -1,7 +1,8 @@
+import type { DidResolver, } from '../../../index.js';
 import type { MethodHandler } from '../../types.js';
 import type { ProtocolsQueryMessage } from '../types.js';
 import type { QueryResultEntry } from '../../../core/types.js';
-import type { DataStore, DidResolver, MessageStore } from '../../../index.js';
+import type { StorageController } from '../../../store/storage-controller.js';
 
 import { canonicalAuth } from '../../../core/auth.js';
 import { MessageReply } from '../../../core/message-reply.js';
@@ -12,7 +13,7 @@ import { DwnInterfaceName, DwnMethodName } from '../../../core/message.js';
 
 export class ProtocolsQueryHandler implements MethodHandler {
 
-  constructor(private didResolver: DidResolver, private messageStore: MessageStore,private dataStore: DataStore) { }
+  constructor(private didResolver: DidResolver, private storageController: StorageController) { }
 
   public async handle({
     tenant,
@@ -39,7 +40,7 @@ export class ProtocolsQueryHandler implements MethodHandler {
     };
     removeUndefinedProperties(query);
 
-    const messages = await this.messageStore.query(tenant, query);
+    const messages = await this.storageController.query(tenant, query);
 
     // strip away `authorization` property for each record before responding
     const entries: QueryResultEntry[] = [];

--- a/src/interfaces/records/handlers/records-delete.ts
+++ b/src/interfaces/records/handlers/records-delete.ts
@@ -41,7 +41,7 @@ export class RecordsDeleteHandler implements MethodHandler {
       interface : DwnInterfaceName.Records,
       recordId  : message.descriptor.recordId
     };
-    const existingMessages = await this.storageController.queryMessageStore(tenant, query) as TimestampedMessage[];
+    const existingMessages = await this.storageController.queryMessages(tenant, query) as TimestampedMessage[];
 
     // find which message is the newest, and if the incoming message is the newest
     const newestExistingMessage = await RecordsWrite.getNewestMessage(existingMessages);
@@ -60,10 +60,10 @@ export class RecordsDeleteHandler implements MethodHandler {
     if (incomingMessageIsNewest) {
       const indexes = await constructIndexes(tenant, recordsDelete);
 
-      await this.storageController.putMessageStore(tenant, message, indexes);
+      await this.storageController.putMessage(tenant, message, indexes);
 
       const messageCid = await Message.getCid(message);
-      await this.storageController.appendEventLog(tenant, messageCid);
+      await this.storageController.appendEvents(tenant, messageCid);
 
       messageReply = new MessageReply({
         status: { code: 202, detail: 'Accepted' }

--- a/src/interfaces/records/handlers/records-delete.ts
+++ b/src/interfaces/records/handlers/records-delete.ts
@@ -4,7 +4,6 @@ import type { RecordsDeleteMessage } from '../types.js';
 import type { StorageController } from '../../../store/storage-controller.js';
 import type { TimestampedMessage } from '../../../core/types.js';
 
-
 import { authenticate } from '../../../core/auth.js';
 import { deleteAllOlderMessagesButKeepInitialWrite } from '../records-interface.js';
 import { MessageReply } from '../../../core/message-reply.js';

--- a/src/interfaces/records/handlers/records-delete.ts
+++ b/src/interfaces/records/handlers/records-delete.ts
@@ -41,7 +41,7 @@ export class RecordsDeleteHandler implements MethodHandler {
       interface : DwnInterfaceName.Records,
       recordId  : message.descriptor.recordId
     };
-    const existingMessages = await this.storageController.MessageStore.query(tenant, query) as TimestampedMessage[];
+    const existingMessages = await this.storageController.queryMessageStore(tenant, query) as TimestampedMessage[];
 
     // find which message is the newest, and if the incoming message is the newest
     const newestExistingMessage = await RecordsWrite.getNewestMessage(existingMessages);
@@ -60,7 +60,7 @@ export class RecordsDeleteHandler implements MethodHandler {
     if (incomingMessageIsNewest) {
       const indexes = await constructIndexes(tenant, recordsDelete);
 
-      await this.storageController.put(tenant, message, indexes);
+      await this.storageController.putMessageStore(tenant, message, indexes);
 
       const messageCid = await Message.getCid(message);
       await this.storageController.appendEventLog(tenant, messageCid);

--- a/src/interfaces/records/handlers/records-delete.ts
+++ b/src/interfaces/records/handlers/records-delete.ts
@@ -60,7 +60,7 @@ export class RecordsDeleteHandler implements MethodHandler {
     if (incomingMessageIsNewest) {
       const indexes = await constructIndexes(tenant, recordsDelete);
 
-      await this.storageController.putMessage(tenant, message, indexes);
+      await this.storageController.putMessageWithoutData(tenant, message, indexes);
 
       const messageCid = await Message.getCid(message);
       await this.storageController.appendEvent(tenant, messageCid);

--- a/src/interfaces/records/handlers/records-delete.ts
+++ b/src/interfaces/records/handlers/records-delete.ts
@@ -63,7 +63,7 @@ export class RecordsDeleteHandler implements MethodHandler {
       await this.storageController.putMessage(tenant, message, indexes);
 
       const messageCid = await Message.getCid(message);
-      await this.storageController.appendEvents(tenant, messageCid);
+      await this.storageController.appendEvent(tenant, messageCid);
 
       messageReply = new MessageReply({
         status: { code: 202, detail: 'Accepted' }

--- a/src/interfaces/records/handlers/records-delete.ts
+++ b/src/interfaces/records/handlers/records-delete.ts
@@ -41,7 +41,7 @@ export class RecordsDeleteHandler implements MethodHandler {
       interface : DwnInterfaceName.Records,
       recordId  : message.descriptor.recordId
     };
-    const existingMessages = await this.storageController.query(tenant, query) as TimestampedMessage[];
+    const existingMessages = await this.storageController.MessageStore.query(tenant, query) as TimestampedMessage[];
 
     // find which message is the newest, and if the incoming message is the newest
     const newestExistingMessage = await RecordsWrite.getNewestMessage(existingMessages);

--- a/src/interfaces/records/handlers/records-query.ts
+++ b/src/interfaces/records/handlers/records-query.ts
@@ -1,12 +1,12 @@
 import type { DidResolver } from '../../../index.js';
 import type { MethodHandler } from '../../types.js';
+import type { RecordsWriteMessageWithOptionalEncodedData } from '../../../store/storage-controller.js';
+import type { StorageController } from '../../../store/storage-controller.js';
 import type { RecordsQueryMessage, RecordsQueryReplyEntry, RecordsWriteMessage } from '../types.js';
 
 import { authenticate } from '../../../core/auth.js';
 import { lexicographicalCompare } from '../../../utils/string.js';
 import { MessageReply } from '../../../core/message-reply.js';
-import type { RecordsWriteMessageWithOptionalEncodedData } from '../../../store/storage-controller.js';
-import type { StorageController } from '../../../store/storage-controller.js';
 
 import { DateSort, RecordsQuery } from '../messages/records-query.js';
 import { DwnInterfaceName, DwnMethodName } from '../../../core/message.js';

--- a/src/interfaces/records/handlers/records-query.ts
+++ b/src/interfaces/records/handlers/records-query.ts
@@ -1,19 +1,19 @@
+import type { DidResolver } from '../../../index.js';
 import type { MethodHandler } from '../../types.js';
-import type { DataStore, DidResolver, MessageStore } from '../../../index.js';
 import type { RecordsQueryMessage, RecordsQueryReplyEntry, RecordsWriteMessage } from '../types.js';
 
 import { authenticate } from '../../../core/auth.js';
 import { lexicographicalCompare } from '../../../utils/string.js';
 import { MessageReply } from '../../../core/message-reply.js';
 import type { RecordsWriteMessageWithOptionalEncodedData } from '../../../store/storage-controller.js';
-import { StorageController } from '../../../store/storage-controller.js';
+import type { StorageController } from '../../../store/storage-controller.js';
 
 import { DateSort, RecordsQuery } from '../messages/records-query.js';
 import { DwnInterfaceName, DwnMethodName } from '../../../core/message.js';
 
 export class RecordsQueryHandler implements MethodHandler {
 
-  constructor(private didResolver: DidResolver, private messageStore: MessageStore, private dataStore: DataStore) { }
+  constructor(private didResolver: DidResolver, private storageController: StorageController) { }
 
   public async handle({
     tenant,
@@ -69,7 +69,7 @@ export class RecordsQueryHandler implements MethodHandler {
       method            : DwnMethodName.Write,
       isLatestBaseState : true
     };
-    const records = await StorageController.query(this.messageStore, this.dataStore, tenant, filter);
+    const records = await this.storageController.query(tenant, filter);
     return records;
   }
 
@@ -99,7 +99,7 @@ export class RecordsQueryHandler implements MethodHandler {
       published         : true,
       isLatestBaseState : true
     };
-    const publishedRecords = await StorageController.query(this.messageStore, this.dataStore, tenant, filter);
+    const publishedRecords = await this.storageController.query(tenant, filter);
     return publishedRecords;
   }
 
@@ -119,7 +119,7 @@ export class RecordsQueryHandler implements MethodHandler {
       isLatestBaseState : true,
       published         : false
     };
-    const unpublishedRecordsForRequester = await StorageController.query(this.messageStore, this.dataStore, tenant, filter);
+    const unpublishedRecordsForRequester = await this.storageController.query(tenant, filter);
     return unpublishedRecordsForRequester;
   }
 
@@ -139,7 +139,7 @@ export class RecordsQueryHandler implements MethodHandler {
       isLatestBaseState : true,
       published         : false
     };
-    const unpublishedRecordsForRequester = await StorageController.query(this.messageStore, this.dataStore, tenant, filter);
+    const unpublishedRecordsForRequester = await this.storageController.query(tenant, filter);
     return unpublishedRecordsForRequester;
   }
 }

--- a/src/interfaces/records/handlers/records-query.ts
+++ b/src/interfaces/records/handlers/records-query.ts
@@ -69,7 +69,7 @@ export class RecordsQueryHandler implements MethodHandler {
       method            : DwnMethodName.Write,
       isLatestBaseState : true
     };
-    const records = await this.storageController.query(tenant, filter);
+    const records = await this.storageController.queryRecordsWrites(tenant, filter);
     return records;
   }
 
@@ -99,7 +99,7 @@ export class RecordsQueryHandler implements MethodHandler {
       published         : true,
       isLatestBaseState : true
     };
-    const publishedRecords = await this.storageController.query(tenant, filter);
+    const publishedRecords = await this.storageController.queryRecordsWrites(tenant, filter);
     return publishedRecords;
   }
 
@@ -119,7 +119,7 @@ export class RecordsQueryHandler implements MethodHandler {
       isLatestBaseState : true,
       published         : false
     };
-    const unpublishedRecordsForRequester = await this.storageController.query(tenant, filter);
+    const unpublishedRecordsForRequester = await this.storageController.queryRecordsWrites(tenant, filter);
     return unpublishedRecordsForRequester;
   }
 
@@ -139,7 +139,7 @@ export class RecordsQueryHandler implements MethodHandler {
       isLatestBaseState : true,
       published         : false
     };
-    const unpublishedRecordsForRequester = await this.storageController.query(tenant, filter);
+    const unpublishedRecordsForRequester = await this.storageController.queryRecordsWrites(tenant, filter);
     return unpublishedRecordsForRequester;
   }
 }

--- a/src/interfaces/records/handlers/records-read.ts
+++ b/src/interfaces/records/handlers/records-read.ts
@@ -53,7 +53,7 @@ export class RecordsReadHandler implements MethodHandler {
 
     const newestRecordsWrite = newestExistingMessage as RecordsWriteMessage;
     try {
-      await this.storageController.authorizeRecordsRead(tenant, recordsRead, await RecordsWrite.parse(newestRecordsWrite));
+      await recordsRead.authorize(tenant, await RecordsWrite.parse(newestRecordsWrite), this.storageController);
     } catch (error) {
       return MessageReply.fromError(error, 401);
     }

--- a/src/interfaces/records/handlers/records-read.ts
+++ b/src/interfaces/records/handlers/records-read.ts
@@ -53,7 +53,7 @@ export class RecordsReadHandler implements MethodHandler {
 
     const newestRecordsWrite = newestExistingMessage as RecordsWriteMessage;
     try {
-      await recordsRead.authorize(tenant, await RecordsWrite.parse(newestRecordsWrite), this.storageController.MessageStore);
+      await this.storageController.authorizeRecordsRead(tenant, recordsRead, await RecordsWrite.parse(newestRecordsWrite));
     } catch (error) {
       return MessageReply.fromError(error, 401);
     }

--- a/src/interfaces/records/handlers/records-read.ts
+++ b/src/interfaces/records/handlers/records-read.ts
@@ -40,7 +40,7 @@ export class RecordsReadHandler implements MethodHandler {
       interface : DwnInterfaceName.Records,
       recordId  : message.descriptor.recordId
     };
-    const existingMessages = await this.storageController.query(tenant, query) as TimestampedMessage[];
+    const existingMessages = await this.storageController.queryMessageStore(tenant, query) as TimestampedMessage[];
 
     const newestExistingMessage = await RecordsWrite.getNewestMessage(existingMessages);
 

--- a/src/interfaces/records/handlers/records-read.ts
+++ b/src/interfaces/records/handlers/records-read.ts
@@ -10,6 +10,7 @@ import { MessageReply } from '../../../core/message-reply.js';
 import { RecordsRead } from '../messages/records-read.js';
 import { RecordsWrite } from '../messages/records-write.js';
 import { DwnInterfaceName, DwnMethodName } from '../../../core/message.js';
+
 export class RecordsReadHandler implements MethodHandler {
 
   constructor(private didResolver: DidResolver, private storageController: StorageController) { }

--- a/src/interfaces/records/handlers/records-read.ts
+++ b/src/interfaces/records/handlers/records-read.ts
@@ -40,7 +40,7 @@ export class RecordsReadHandler implements MethodHandler {
       interface : DwnInterfaceName.Records,
       recordId  : message.descriptor.recordId
     };
-    const existingMessages = await this.storageController.queryMessageStore(tenant, query) as TimestampedMessage[];
+    const existingMessages = await this.storageController.queryMessages(tenant, query) as TimestampedMessage[];
 
     const newestExistingMessage = await RecordsWrite.getNewestMessage(existingMessages);
 
@@ -59,7 +59,7 @@ export class RecordsReadHandler implements MethodHandler {
     }
 
     const messageCid = await Message.getCid(newestRecordsWrite);
-    const result = await this.storageController.get(tenant, messageCid, newestRecordsWrite.descriptor.dataCid);
+    const result = await this.storageController.getData(tenant, messageCid, newestRecordsWrite.descriptor.dataCid);
 
     if (result?.dataStream === undefined) {
       return new MessageReply({

--- a/src/interfaces/records/handlers/records-write.ts
+++ b/src/interfaces/records/handlers/records-write.ts
@@ -74,7 +74,7 @@ export class RecordsWriteHandler implements MethodHandler {
       const indexes = await constructRecordsWriteIndexes(recordsWrite, isLatestBaseState);
 
       try {
-        await this.storageController.putWithData(tenant, message, indexes, dataStream);
+        await this.storageController.putMessageWithData(tenant, message, indexes, dataStream);
       } catch (error) {
         const e = error as any;
         if (e.code === DwnErrorCode.MessageStoreDataCidMismatch ||

--- a/src/interfaces/records/handlers/records-write.ts
+++ b/src/interfaces/records/handlers/records-write.ts
@@ -74,7 +74,7 @@ export class RecordsWriteHandler implements MethodHandler {
       const indexes = await constructRecordsWriteIndexes(recordsWrite, isLatestBaseState);
 
       try {
-        await this.storageController.put(tenant, message, indexes, dataStream);
+        await this.storageController.putWithData(tenant, message, indexes, dataStream);
       } catch (error) {
         const e = error as any;
         if (e.code === DwnErrorCode.MessageStoreDataCidMismatch ||

--- a/src/interfaces/records/handlers/records-write.ts
+++ b/src/interfaces/records/handlers/records-write.ts
@@ -41,7 +41,7 @@ export class RecordsWriteHandler implements MethodHandler {
       interface : DwnInterfaceName.Records,
       recordId  : message.recordId
     };
-    const existingMessages = await this.storageController.queryMessageStore(tenant, query) as TimestampedMessage[];
+    const existingMessages = await this.storageController.queryMessages(tenant, query) as TimestampedMessage[];
 
     // if the incoming write is not the initial write, then it must not modify any immutable properties defined by the initial write
     const newMessageIsInitialWrite = await recordsWrite.isInitialWrite();

--- a/src/interfaces/records/handlers/records-write.ts
+++ b/src/interfaces/records/handlers/records-write.ts
@@ -41,7 +41,7 @@ export class RecordsWriteHandler implements MethodHandler {
       interface : DwnInterfaceName.Records,
       recordId  : message.recordId
     };
-    const existingMessages = await this.storageController.query(tenant, query) as TimestampedMessage[];
+    const existingMessages = await this.storageController.queryMessageStore(tenant, query) as TimestampedMessage[];
 
     // if the incoming write is not the initial write, then it must not modify any immutable properties defined by the initial write
     const newMessageIsInitialWrite = await recordsWrite.isInitialWrite();

--- a/src/interfaces/records/handlers/records-write.ts
+++ b/src/interfaces/records/handlers/records-write.ts
@@ -31,7 +31,7 @@ export class RecordsWriteHandler implements MethodHandler {
     // authentication & authorization
     try {
       await authenticate(message.authorization, this.didResolver);
-      await recordsWrite.authorize(tenant, this.storageController.MessageStore);
+      await this.storageController.authorizeRecordsWrite(tenant, recordsWrite);
     } catch (e) {
       return MessageReply.fromError(e, 401);
     }

--- a/src/interfaces/records/handlers/records-write.ts
+++ b/src/interfaces/records/handlers/records-write.ts
@@ -31,7 +31,7 @@ export class RecordsWriteHandler implements MethodHandler {
     // authentication & authorization
     try {
       await authenticate(message.authorization, this.didResolver);
-      await this.storageController.authorizeRecordsWrite(tenant, recordsWrite);
+      await recordsWrite.authorize(tenant, this.storageController);
     } catch (e) {
       return MessageReply.fromError(e, 401);
     }

--- a/src/interfaces/records/messages/records-read.ts
+++ b/src/interfaces/records/messages/records-read.ts
@@ -1,7 +1,7 @@
 import type { BaseMessage } from '../../../core/types.js';
-import type { MessageStore } from '../../../store/message-store.js';
 import type { RecordsWrite } from './records-write.js';
 import type { SignatureInput } from '../../../jose/jws/general/types.js';
+import type { StorageController } from '../../../store/storage-controller.js';
 import type { RecordsReadDescriptor, RecordsReadMessage } from '../types.js';
 
 import { getCurrentTimeInHighPrecision } from '../../../utils/time.js';
@@ -52,7 +52,7 @@ export class RecordsRead extends Message<RecordsReadMessage> {
     return new RecordsRead(message);
   }
 
-  public async authorize(tenant: string, newestRecordsWrite: RecordsWrite, messageStore: MessageStore): Promise<void> {
+  public async authorize(tenant: string, newestRecordsWrite: RecordsWrite, storageController: StorageController): Promise<void> {
     const { descriptor } = newestRecordsWrite.message;
     // if author/requester is the same as the target tenant, we can directly grant access
     if (this.author === tenant) {
@@ -61,7 +61,7 @@ export class RecordsRead extends Message<RecordsReadMessage> {
       // authentication is not required for published data
       return;
     } else if (descriptor.protocol !== undefined) {
-      await ProtocolAuthorization.authorize(tenant, this, this.author, messageStore);
+      await ProtocolAuthorization.authorize(tenant, this, this.author, storageController);
     } else {
       throw new Error('message failed authorization');
     }

--- a/src/interfaces/records/messages/records-write.ts
+++ b/src/interfaces/records/messages/records-write.ts
@@ -1,7 +1,7 @@
 import type { BaseMessage } from '../../../core/types.js';
 import type { KeyDerivationScheme } from '../../../index.js';
-import type { MessageStore } from '../../../store/message-store.js';
 import type { PublicJwk } from '../../../jose/types.js';
+import type { StorageController } from '../../../store/storage-controller.js';
 import type {
   EncryptedKey,
   EncryptionProperty,
@@ -302,10 +302,10 @@ export class RecordsWrite extends Message<RecordsWriteMessage> {
     return recordsWrite;
   }
 
-  public async authorize(tenant: string, messageStore: MessageStore): Promise<void> {
+  public async authorize(tenant: string, storageController: StorageController): Promise<void> {
     if (this.message.descriptor.protocol !== undefined) {
       // NOTE: `author` definitely exists because of the earlier `authenticate()` call
-      await ProtocolAuthorization.authorize(tenant, this, this.author!, messageStore);
+      await ProtocolAuthorization.authorize(tenant, this, this.author!, storageController);
     } else {
       await authorize(tenant, this);
     }

--- a/src/interfaces/records/records-interface.ts
+++ b/src/interfaces/records/records-interface.ts
@@ -35,13 +35,13 @@ export async function deleteAllOlderMessagesButKeepInitialWrite(
         const existingRecordsWrite = await RecordsWrite.parse(message as RecordsWriteMessage);
         const isLatestBaseState = false;
         const indexes = await constructRecordsWriteIndexes(existingRecordsWrite, isLatestBaseState);
-        await storageController.putMessageStore(tenant, message, indexes);
+        await storageController.putMessage(tenant, message, indexes);
       } else {
         const messageCid = await Message.getCid(message);
         deletedMessageCids.push(messageCid);
       }
     }
 
-    await storageController.deleteEventsByCid(tenant, deletedMessageCids);
+    await storageController.deleteEvents(tenant, deletedMessageCids);
   }
 }

--- a/src/interfaces/records/records-interface.ts
+++ b/src/interfaces/records/records-interface.ts
@@ -14,7 +14,7 @@ export async function deleteAllOlderMessagesButKeepInitialWrite(
   tenant: string,
   existingMessages: TimestampedMessage[],
   comparedToMessage: TimestampedMessage,
-  storageController: StorageController,
+  storageController: StorageController
 ): Promise<void> {
   const deletedMessageCids: string[] = [];
 

--- a/src/interfaces/records/records-interface.ts
+++ b/src/interfaces/records/records-interface.ts
@@ -26,7 +26,7 @@ export async function deleteAllOlderMessagesButKeepInitialWrite(
       // the easiest implementation here is delete each old messages
       // and re-create it with the right index (isLatestBaseState = 'false') if the message is the initial write,
       // but there is room for better/more efficient implementation here
-      await storageController.delete(tenant, message);
+      await storageController.deleteMessage(tenant, message);
 
       // if the existing message is the initial write
       // we actually need to keep it BUT, need to ensure the message is no longer marked as the latest state
@@ -35,7 +35,7 @@ export async function deleteAllOlderMessagesButKeepInitialWrite(
         const existingRecordsWrite = await RecordsWrite.parse(message as RecordsWriteMessage);
         const isLatestBaseState = false;
         const indexes = await constructRecordsWriteIndexes(existingRecordsWrite, isLatestBaseState);
-        await storageController.putMessage(tenant, message, indexes);
+        await storageController.putMessageWithoutData(tenant, message, indexes);
       } else {
         const messageCid = await Message.getCid(message);
         deletedMessageCids.push(messageCid);

--- a/src/interfaces/records/records-interface.ts
+++ b/src/interfaces/records/records-interface.ts
@@ -35,7 +35,7 @@ export async function deleteAllOlderMessagesButKeepInitialWrite(
         const existingRecordsWrite = await RecordsWrite.parse(message as RecordsWriteMessage);
         const isLatestBaseState = false;
         const indexes = await constructRecordsWriteIndexes(existingRecordsWrite, isLatestBaseState);
-        await storageController.put(tenant, message, indexes);
+        await storageController.putMessageStore(tenant, message, indexes);
       } else {
         const messageCid = await Message.getCid(message);
         deletedMessageCids.push(messageCid);

--- a/src/store/message-store.ts
+++ b/src/store/message-store.ts
@@ -22,7 +22,7 @@ export interface MessageStore {
   put(
     tenant: string,
     messageJson: BaseMessage,
-    indexes: { [key: string]: string },
+    indexes: Record<string, string>,
     options?: MessageStoreOptions
   ): Promise<void>;
 

--- a/src/store/storage-controller.ts
+++ b/src/store/storage-controller.ts
@@ -1,8 +1,8 @@
 import type { EventLog } from '../event-log/event-log.js';
-import type { MessageStore, MessageStoreOptions } from './message-store.js';
 import type { Readable } from 'readable-stream';
 import type { BaseMessage, Filter } from '../core/types.js';
 import type { DataStore, GetResult } from './data-store.js';
+import type { MessageStore, MessageStoreOptions } from './message-store.js';
 
 import { DwnConstant } from '../core/dwn-constant.js';
 import { Message } from '../core/message.js';
@@ -126,6 +126,10 @@ export class StorageController {
 
   public queryMessageStore(tenant: string, filter: Filter, options?: MessageStoreOptions): Promise<BaseMessage[]> {
     return this.messageStore.query(tenant, filter, options);
+  }
+
+  public putMessageStore(tenant: string, messageJson: BaseMessage, indexes, options?): Promise<void> {
+    return this.messageStore.put(tenant, messageJson, indexes, options);
   }
 
   public get(tenant: string, messageCid: string, dataCid: string): Promise<GetResult|undefined> {

--- a/src/store/storage-controller.ts
+++ b/src/store/storage-controller.ts
@@ -1,9 +1,9 @@
 import type { EventLog } from '../event-log/event-log.js';
 import type { Readable } from 'readable-stream';
+import type { RecordsWriteMessage } from '../index.js';
 import type { BaseMessage, Filter } from '../core/types.js';
 import type { DataStore, GetResult } from './data-store.js';
 import type { MessageStore, MessageStoreOptions } from './message-store.js';
-import type { RecordsRead, RecordsWrite, RecordsWriteMessage } from '../index.js';
 
 import { DwnConstant } from '../core/dwn-constant.js';
 import { Message } from '../core/message.js';
@@ -130,7 +130,8 @@ export class StorageController {
     tenant: string,
     messageJson: BaseMessage,
     indexes: Record<string, string>,
-    options?: MessageStoreOptions): Promise<void> {
+    options?: MessageStoreOptions
+  ): Promise<void> {
     return this.messageStore.put(tenant, messageJson, indexes, options);
   }
 
@@ -146,16 +147,8 @@ export class StorageController {
     return this.eventLog.append(tenant, messageCid);
   }
 
-  public deleteEvents(tenant: string, deletedMessageCids: any): Promise<number>|undefined {
+  public deleteEvents(tenant: string, deletedMessageCids: string[]): Promise<number>|undefined {
     return this.eventLog.deleteEventsByCid(tenant, deletedMessageCids);
-  }
-
-  public authorizeRecordsRead(tenant: string, recordsRead: RecordsRead, newestRecordsWrite: RecordsWrite): Promise<void> {
-    return recordsRead.authorize(tenant, newestRecordsWrite, this.messageStore);
-  }
-
-  public authorizeRecordsWrite(tenant: string, recordsWrite: RecordsWrite): Promise<void> {
-    return recordsWrite.authorize(tenant, this.messageStore);
   }
 }
 

--- a/src/store/storage-controller.ts
+++ b/src/store/storage-controller.ts
@@ -60,7 +60,7 @@ export class StorageController {
    * @throws {DwnError} with `DwnErrorCode.MessageStoreDataSizeMismatch`
    *                    if `dataSize` in `descriptor` given mismatches the actual data size
    */
-  public async putWithData(
+  public async putMessageWithData(
     tenant: string,
     message: BaseMessage,
     indexes: Record<string, string>,

--- a/src/store/storage-controller.ts
+++ b/src/store/storage-controller.ts
@@ -15,7 +15,7 @@ import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
  */
 export class StorageController {
 
-  constructor(private messageStore: MessageStore, private dataStore: DataStore, private eventLog?: EventLog) {}
+  constructor(private messageStore: MessageStore, private dataStore: DataStore, private eventLog: EventLog) {}
 
   /**
    * Puts the given message and data in storage.
@@ -124,24 +124,28 @@ export class StorageController {
 
   public get MessageStore(): MessageStore { return this.messageStore; }
 
-  public queryMessageStore(tenant: string, filter: Filter, options?: MessageStoreOptions): Promise<BaseMessage[]> {
+  public queryMessages(tenant: string, filter: Filter, options?: MessageStoreOptions): Promise<BaseMessage[]> {
     return this.messageStore.query(tenant, filter, options);
   }
 
-  public putMessageStore(tenant: string, messageJson: BaseMessage, indexes, options?): Promise<void> {
+  public putMessage(tenant: string, messageJson: BaseMessage, indexes, options?): Promise<void> {
     return this.messageStore.put(tenant, messageJson, indexes, options);
   }
 
-  public get(tenant: string, messageCid: string, dataCid: string): Promise<GetResult|undefined> {
+  public getMessage(tenant: string, messageCid: string): Promise<BaseMessage|undefined> {
+    return this.messageStore.get(tenant, messageCid);
+  }
+
+  public getData(tenant: string, messageCid: string, dataCid: string): Promise<GetResult|undefined> {
     return this.dataStore.get(tenant, messageCid, dataCid);
   }
 
-  public deleteEventsByCid(tenant: string, deletedMessageCids: any): void {
-    if (this.eventLog) { this.eventLog.deleteEventsByCid(tenant, deletedMessageCids); }
+  public appendEvents(tenant: string, messageCid: string): Promise<string>|undefined {
+    return this.eventLog.append(tenant, messageCid);
   }
 
-  public appendEventLog(tenant: string, messageCid: string): Promise<string> | undefined {
-    if (this.eventLog) { return this.eventLog.append(tenant, messageCid); }
+  public deleteEvents(tenant: string, deletedMessageCids: any): Promise<number>|undefined {
+    return this.eventLog.deleteEventsByCid(tenant, deletedMessageCids);
   }
 }
 

--- a/src/store/storage-controller.ts
+++ b/src/store/storage-controller.ts
@@ -81,7 +81,7 @@ export class StorageController {
     }
 
     await this.messageStore.put(tenant, message, indexes);
-    if (this.eventLog) { await this.eventLog.append(tenant, messageCid); }
+    await this.eventLog.append(tenant, messageCid);
   }
 
   public async query(

--- a/src/store/storage-controller.ts
+++ b/src/store/storage-controller.ts
@@ -1,9 +1,9 @@
+import type { DataStore, } from './data-store.js';
 import type { EventLog } from '../event-log/event-log.js';
+import type { MessageStore } from './message-store.js';
 import type { Readable } from 'readable-stream';
 import type { RecordsWriteMessage } from '../index.js';
 import type { BaseMessage, Filter } from '../core/types.js';
-import type { DataStore, GetResult } from './data-store.js';
-import type { MessageStore, MessageStoreOptions } from './message-store.js';
 
 import { DwnConstant } from '../core/dwn-constant.js';
 import { Message } from '../core/message.js';
@@ -13,9 +13,43 @@ import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 /**
  * A class that provides an abstraction for the usage of BlockStore and DataStore.
  */
+
 export class StorageController {
 
-  constructor(private messageStore: MessageStore, private dataStore: DataStore, private eventLog: EventLog) {}
+  constructor(private messageStore: MessageStore, private dataStore: DataStore, private eventLog: EventLog) { }
+
+  public appendEvent(...args: Parameters<typeof this.eventLog.append>): ReturnType<typeof this.eventLog.append> {
+    return this.eventLog.append.apply(this.eventLog, args);
+  }
+
+  public deleteEvents(...args: Parameters<typeof this.eventLog.deleteEventsByCid>): ReturnType<typeof this.eventLog.deleteEventsByCid> {
+    return this.eventLog.deleteEventsByCid.apply(this.eventLog, args);
+  }
+
+  public getData(...args: Parameters<typeof this.dataStore.get>): ReturnType<typeof this.dataStore.get> {
+    return this.dataStore.get.apply(this.dataStore, args);
+  }
+
+  public getMessage(...args: Parameters<typeof this.messageStore.get>): ReturnType<typeof this.messageStore.get> {
+    return this.messageStore.get.apply(this.messageStore, args);
+  }
+
+  public async deleteMessage(
+    tenant: string,
+    message: BaseMessage
+  ): Promise<void> {
+    const messageCid = await Message.getCid(message);
+
+    if (message.descriptor.dataCid !== undefined) {
+      await this.dataStore.delete(tenant, messageCid, message.descriptor.dataCid);
+    }
+
+    await this.messageStore.delete(tenant, messageCid);
+  }
+
+  public putMessageWithoutData(...args: Parameters<typeof this.messageStore.put>): ReturnType<typeof this.messageStore.put> {
+    return this.messageStore.put.apply(this.messageStore, args);
+  }
 
   /**
    * Puts the given message and data in storage.
@@ -26,10 +60,10 @@ export class StorageController {
    * @throws {DwnError} with `DwnErrorCode.MessageStoreDataSizeMismatch`
    *                    if `dataSize` in `descriptor` given mismatches the actual data size
    */
-  public async put(
+  public async putWithData(
     tenant: string,
     message: BaseMessage,
-    indexes: { [key: string]: string },
+    indexes: Record<string, string>,
     dataStream?: Readable
   ): Promise<void> {
     const messageCid = await Message.getCid(message);
@@ -80,11 +114,15 @@ export class StorageController {
       }
     }
 
-    await this.messageStore.put(tenant, message, indexes);
-    await this.eventLog.append(tenant, messageCid);
+    await this.putMessageWithoutData(tenant, message, indexes);
+    await this.appendEvent(tenant, messageCid);
   }
 
-  public async query(
+  public queryMessages(...args: Parameters<typeof this.messageStore.query>): ReturnType<typeof this.messageStore.query> {
+    return this.messageStore.query.apply(this.messageStore, args);
+  }
+
+  public async queryRecordsWrites(
     tenant: string,
     filter: Filter
   ): Promise<RecordsWriteMessageWithOptionalEncodedData[]> {
@@ -107,48 +145,6 @@ export class StorageController {
     }
 
     return messages;
-  }
-
-  public async delete(
-    tenant: string,
-    message: BaseMessage
-  ): Promise<void> {
-    const messageCid = await Message.getCid(message);
-
-    if (message.descriptor.dataCid !== undefined) {
-      await this.dataStore.delete(tenant, messageCid, message.descriptor.dataCid);
-    }
-
-    await this.messageStore.delete(tenant, messageCid);
-  }
-
-  public getMessage(tenant: string, messageCid: string): Promise<BaseMessage|undefined> {
-    return this.messageStore.get(tenant, messageCid);
-  }
-
-  public putMessage(
-    tenant: string,
-    messageJson: BaseMessage,
-    indexes: Record<string, string>,
-    options?: MessageStoreOptions
-  ): Promise<void> {
-    return this.messageStore.put(tenant, messageJson, indexes, options);
-  }
-
-  public queryMessages(tenant: string, filter: Filter, options?: MessageStoreOptions): Promise<BaseMessage[]> {
-    return this.messageStore.query(tenant, filter, options);
-  }
-
-  public getData(tenant: string, messageCid: string, dataCid: string): Promise<GetResult|undefined> {
-    return this.dataStore.get(tenant, messageCid, dataCid);
-  }
-
-  public appendEvent(tenant: string, messageCid: string): Promise<string>|undefined {
-    return this.eventLog.append(tenant, messageCid);
-  }
-
-  public deleteEvents(tenant: string, deletedMessageCids: string[]): Promise<number>|undefined {
-    return this.eventLog.deleteEventsByCid(tenant, deletedMessageCids);
   }
 }
 

--- a/src/store/storage-controller.ts
+++ b/src/store/storage-controller.ts
@@ -1,5 +1,5 @@
 import type { EventLog } from '../event-log/event-log.js';
-import type { MessageStore } from './message-store.js';
+import type { MessageStore, MessageStoreOptions } from './message-store.js';
 import type { Readable } from 'readable-stream';
 import type { BaseMessage, Filter } from '../core/types.js';
 import type { DataStore, GetResult } from './data-store.js';
@@ -123,6 +123,10 @@ export class StorageController {
   }
 
   public get MessageStore(): MessageStore { return this.messageStore; }
+
+  public queryMessageStore(tenant: string, filter: Filter, options?: MessageStoreOptions): Promise<BaseMessage[]> {
+    return this.messageStore.query(tenant, filter, options);
+  }
 
   public get(tenant: string, messageCid: string, dataCid: string): Promise<GetResult|undefined> {
     return this.dataStore.get(tenant, messageCid, dataCid);

--- a/src/store/storage-controller.ts
+++ b/src/store/storage-controller.ts
@@ -142,7 +142,7 @@ export class StorageController {
     return this.dataStore.get(tenant, messageCid, dataCid);
   }
 
-  public appendEvents(tenant: string, messageCid: string): Promise<string>|undefined {
+  public appendEvent(tenant: string, messageCid: string): Promise<string>|undefined {
     return this.eventLog.append(tenant, messageCid);
   }
 

--- a/tests/interfaces/messages/handlers/messages-get.spec.ts
+++ b/tests/interfaces/messages/handlers/messages-get.spec.ts
@@ -192,7 +192,7 @@ describe('MessagesGetHandler.handle()', () => {
     messageStore.get.rejects('internal db error');
 
     const dataStore = sinon.createStubInstance(DataStoreLevel);
-    const storageController = new StorageController(messageStore, dataStore);
+    const storageController = new StorageController(messageStore, dataStore, eventLog);
     const messagesGetHandler = new MessagesGetHandler(didResolver, storageController);
 
     const alice = await DidKeyResolver.generate();

--- a/tests/interfaces/messages/handlers/messages-get.spec.ts
+++ b/tests/interfaces/messages/handlers/messages-get.spec.ts
@@ -15,7 +15,6 @@ import {
 
 import sinon from 'sinon';
 import { StorageController } from '../../../../src/store/storage-controller.js';
-import { da } from 'date-fns/locale';
 
 describe('MessagesGetHandler.handle()', () => {
   let dwn: Dwn;

--- a/tests/interfaces/messages/handlers/messages-get.spec.ts
+++ b/tests/interfaces/messages/handlers/messages-get.spec.ts
@@ -14,6 +14,8 @@ import {
 } from '../../../../src/index.js';
 
 import sinon from 'sinon';
+import { StorageController } from '../../../../src/store/storage-controller.js';
+import { da } from 'date-fns/locale';
 
 describe('MessagesGetHandler.handle()', () => {
   let dwn: Dwn;
@@ -191,8 +193,8 @@ describe('MessagesGetHandler.handle()', () => {
     messageStore.get.rejects('internal db error');
 
     const dataStore = sinon.createStubInstance(DataStoreLevel);
-
-    const messagesGetHandler = new MessagesGetHandler(didResolver, messageStore, dataStore);
+    const storageController = new StorageController(messageStore, dataStore);
+    const messagesGetHandler = new MessagesGetHandler(didResolver, storageController);
 
     const alice = await DidKeyResolver.generate();
     const { recordsWrite } = await TestDataGenerator.generateRecordsWrite({ requester: alice });

--- a/tests/interfaces/records/handlers/records-delete.spec.ts
+++ b/tests/interfaces/records/handlers/records-delete.spec.ts
@@ -11,10 +11,10 @@ import { EventLogLevel } from '../../../../src/event-log/event-log-level.js';
 import { Message } from '../../../../src/core/message.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
 import { RecordsDeleteHandler } from '../../../../src/interfaces/records/handlers/records-delete.js';
+import { StorageController } from '../../../../src/store/storage-controller.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
 import { DidResolver, Dwn, Encoder, Jws, RecordsDelete, RecordsWrite } from '../../../../src/index.js';
-import { StorageController } from '../../../../src/store/storage-controller.js';
 
 chai.use(chaiAsPromised);
 

--- a/tests/interfaces/records/handlers/records-delete.spec.ts
+++ b/tests/interfaces/records/handlers/records-delete.spec.ts
@@ -14,6 +14,7 @@ import { RecordsDeleteHandler } from '../../../../src/interfaces/records/handler
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
 import { DidResolver, Dwn, Encoder, Jws, RecordsDelete, RecordsWrite } from '../../../../src/index.js';
+import { StorageController } from '../../../../src/store/storage-controller.js';
 
 chai.use(chaiAsPromised);
 
@@ -586,8 +587,9 @@ describe('RecordsDeleteHandler.handle()', () => {
     const didResolver = TestStubGenerator.createDidResolverStub(mismatchingPersona);
     const messageStore = sinon.createStubInstance(MessageStoreLevel);
     const dataStore = sinon.createStubInstance(DataStoreLevel);
+    const storageController = new StorageController(messageStore, dataStore, eventLog);
+    const recordsDeleteHandler = new RecordsDeleteHandler(didResolver, storageController);
 
-    const recordsDeleteHandler = new RecordsDeleteHandler(didResolver, messageStore, dataStore, eventLog);
     const reply = await recordsDeleteHandler.handle({ tenant, message });
     expect(reply.status.code).to.equal(401);
   });
@@ -599,8 +601,8 @@ describe('RecordsDeleteHandler.handle()', () => {
     // setting up a stub method resolver & message store
     const messageStore = sinon.createStubInstance(MessageStoreLevel);
     const dataStore = sinon.createStubInstance(DataStoreLevel);
-
-    const recordsDeleteHandler = new RecordsDeleteHandler(didResolver, messageStore, dataStore, eventLog);
+    const storageController = new StorageController(messageStore, dataStore, eventLog);
+    const recordsDeleteHandler = new RecordsDeleteHandler(didResolver, storageController);
 
     // stub the `parse()` function to throw an error
     sinon.stub(RecordsDelete, 'parse').throws('anyError');

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -849,7 +849,9 @@ describe('RecordsQueryHandler.handle()', () => {
     const didResolver = TestStubGenerator.createDidResolverStub(mismatchingPersona);
     const messageStore = sinon.createStubInstance(MessageStoreLevel);
     const dataStore = sinon.createStubInstance(DataStoreLevel);
-    const storageController = new StorageController(messageStore, dataStore);
+    const storageController = new StorageController(messageStore, dataStore, new EventLogLevel({
+      location: 'TEST-EVENTLOG'
+    }));
 
     const recordsQueryHandler = new RecordsQueryHandler(didResolver, storageController);
     const reply = await recordsQueryHandler.handle({ tenant, message });
@@ -865,7 +867,9 @@ describe('RecordsQueryHandler.handle()', () => {
     const didResolver = TestStubGenerator.createDidResolverStub(requester);
     const messageStore = sinon.createStubInstance(MessageStoreLevel);
     const dataStore = sinon.createStubInstance(DataStoreLevel);
-    const storageController = new StorageController(messageStore, dataStore);
+    const storageController = new StorageController(messageStore, dataStore, new EventLogLevel({
+      location: 'TEST-EVENTLOG'
+    }));
 
     const recordsQueryHandler = new RecordsQueryHandler(didResolver, storageController);
 

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -480,10 +480,10 @@ describe('RecordsQueryHandler.handle()', () => {
 
       const storageController = new StorageController(messageStore, dataStore, eventLog);
 
-      await storageController.putWithData(alice.did, record1Data.message, additionalIndexes1, record1Data.dataStream);
-      await storageController.putWithData(alice.did, record2Data.message, additionalIndexes2, record2Data.dataStream);
-      await storageController.putWithData(alice.did, record3Data.message, additionalIndexes3, record3Data.dataStream);
-      await storageController.putWithData(alice.did, record4Data.message, additionalIndexes4, record4Data.dataStream);
+      await storageController.putMessageWithData(alice.did, record1Data.message, additionalIndexes1, record1Data.dataStream);
+      await storageController.putMessageWithData(alice.did, record2Data.message, additionalIndexes2, record2Data.dataStream);
+      await storageController.putMessageWithData(alice.did, record3Data.message, additionalIndexes3, record3Data.dataStream);
+      await storageController.putMessageWithData(alice.did, record4Data.message, additionalIndexes4, record4Data.dataStream);
 
       // test correctness for Bob's query
       const bobQueryMessageData = await TestDataGenerator.generateRecordsQuery({

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -480,10 +480,10 @@ describe('RecordsQueryHandler.handle()', () => {
 
       const storageController = new StorageController(messageStore, dataStore, eventLog);
 
-      await storageController.put(alice.did, record1Data.message, additionalIndexes1, record1Data.dataStream);
-      await storageController.put(alice.did, record2Data.message, additionalIndexes2, record2Data.dataStream);
-      await storageController.put(alice.did, record3Data.message, additionalIndexes3, record3Data.dataStream);
-      await storageController.put(alice.did, record4Data.message, additionalIndexes4, record4Data.dataStream);
+      await storageController.putWithData(alice.did, record1Data.message, additionalIndexes1, record1Data.dataStream);
+      await storageController.putWithData(alice.did, record2Data.message, additionalIndexes2, record2Data.dataStream);
+      await storageController.putWithData(alice.did, record3Data.message, additionalIndexes3, record3Data.dataStream);
+      await storageController.putWithData(alice.did, record4Data.message, additionalIndexes4, record4Data.dataStream);
 
       // test correctness for Bob's query
       const bobQueryMessageData = await TestDataGenerator.generateRecordsQuery({

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -477,10 +477,13 @@ describe('RecordsQueryHandler.handle()', () => {
       const additionalIndexes2 = await constructRecordsWriteIndexes(record2Data.recordsWrite, true);
       const additionalIndexes3 = await constructRecordsWriteIndexes(record3Data.recordsWrite, true);
       const additionalIndexes4 = await constructRecordsWriteIndexes(record4Data.recordsWrite, true);
-      await StorageController.put(messageStore, dataStore, eventLog, alice.did, record1Data.message, additionalIndexes1, record1Data.dataStream);
-      await StorageController.put(messageStore, dataStore, eventLog, alice.did, record2Data.message, additionalIndexes2, record2Data.dataStream);
-      await StorageController.put(messageStore, dataStore, eventLog, alice.did, record3Data.message, additionalIndexes3, record3Data.dataStream);
-      await StorageController.put(messageStore, dataStore, eventLog, alice.did, record4Data.message, additionalIndexes4, record4Data.dataStream);
+
+      const storageController = new StorageController(messageStore, dataStore, eventLog);
+
+      await storageController.put(alice.did, record1Data.message, additionalIndexes1, record1Data.dataStream);
+      await storageController.put(alice.did, record2Data.message, additionalIndexes2, record2Data.dataStream);
+      await storageController.put(alice.did, record3Data.message, additionalIndexes3, record3Data.dataStream);
+      await storageController.put(alice.did, record4Data.message, additionalIndexes4, record4Data.dataStream);
 
       // test correctness for Bob's query
       const bobQueryMessageData = await TestDataGenerator.generateRecordsQuery({
@@ -846,8 +849,9 @@ describe('RecordsQueryHandler.handle()', () => {
     const didResolver = TestStubGenerator.createDidResolverStub(mismatchingPersona);
     const messageStore = sinon.createStubInstance(MessageStoreLevel);
     const dataStore = sinon.createStubInstance(DataStoreLevel);
+    const storageController = new StorageController(messageStore, dataStore);
 
-    const recordsQueryHandler = new RecordsQueryHandler(didResolver, messageStore, dataStore);
+    const recordsQueryHandler = new RecordsQueryHandler(didResolver, storageController);
     const reply = await recordsQueryHandler.handle({ tenant, message });
 
     expect(reply.status.code).to.equal(401);
@@ -861,7 +865,9 @@ describe('RecordsQueryHandler.handle()', () => {
     const didResolver = TestStubGenerator.createDidResolverStub(requester);
     const messageStore = sinon.createStubInstance(MessageStoreLevel);
     const dataStore = sinon.createStubInstance(DataStoreLevel);
-    const recordsQueryHandler = new RecordsQueryHandler(didResolver, messageStore, dataStore);
+    const storageController = new StorageController(messageStore, dataStore);
+
+    const recordsQueryHandler = new RecordsQueryHandler(didResolver, storageController);
 
     // stub the `parse()` function to throw an error
     sinon.stub(RecordsQuery, 'parse').throws('anyError');

--- a/tests/interfaces/records/handlers/records-read.spec.ts
+++ b/tests/interfaces/records/handlers/records-read.spec.ts
@@ -18,6 +18,7 @@ import { HdKey } from '../../../../src/utils/hd-key.js';
 import { KeyDerivationScheme } from '../../../../src/utils/hd-key.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
 import { RecordsReadHandler } from '../../../../src/interfaces/records/handlers/records-read.js';
+import { StorageController } from '../../../../src/store/storage-controller.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
 
@@ -478,8 +479,8 @@ describe('RecordsReadHandler.handle()', () => {
     const didResolver = TestStubGenerator.createDidResolverStub(mismatchingPersona);
     const messageStore = sinon.createStubInstance(MessageStoreLevel);
     const dataStore = sinon.createStubInstance(DataStoreLevel);
-
-    const recordsReadHandler = new RecordsReadHandler(didResolver, messageStore, dataStore);
+    const storageController = new StorageController(messageStore, dataStore);
+    const recordsReadHandler = new RecordsReadHandler(didResolver, storageController);
     const reply = await recordsReadHandler.handle({ tenant: alice.did, message: recordsRead.message });
     expect(reply.status.code).to.equal(401);
   });
@@ -494,8 +495,8 @@ describe('RecordsReadHandler.handle()', () => {
     // setting up a stub method resolver & message store
     const messageStore = sinon.createStubInstance(MessageStoreLevel);
     const dataStore = sinon.createStubInstance(DataStoreLevel);
-
-    const recordsReadHandler = new RecordsReadHandler(didResolver, messageStore, dataStore);
+    const storageController = new StorageController(messageStore, dataStore);
+    const recordsReadHandler = new RecordsReadHandler(didResolver, storageController);
 
     // stub the `parse()` function to throw an error
     sinon.stub(RecordsRead, 'parse').throws('anyError');

--- a/tests/interfaces/records/handlers/records-read.spec.ts
+++ b/tests/interfaces/records/handlers/records-read.spec.ts
@@ -479,7 +479,7 @@ describe('RecordsReadHandler.handle()', () => {
     const didResolver = TestStubGenerator.createDidResolverStub(mismatchingPersona);
     const messageStore = sinon.createStubInstance(MessageStoreLevel);
     const dataStore = sinon.createStubInstance(DataStoreLevel);
-    const storageController = new StorageController(messageStore, dataStore);
+    const storageController = new StorageController(messageStore, dataStore, eventLog);
     const recordsReadHandler = new RecordsReadHandler(didResolver, storageController);
     const reply = await recordsReadHandler.handle({ tenant: alice.did, message: recordsRead.message });
     expect(reply.status.code).to.equal(401);
@@ -495,7 +495,7 @@ describe('RecordsReadHandler.handle()', () => {
     // setting up a stub method resolver & message store
     const messageStore = sinon.createStubInstance(MessageStoreLevel);
     const dataStore = sinon.createStubInstance(DataStoreLevel);
-    const storageController = new StorageController(messageStore, dataStore);
+    const storageController = new StorageController(messageStore, dataStore, eventLog);
     const recordsReadHandler = new RecordsReadHandler(didResolver, storageController);
 
     // stub the `parse()` function to throw an error

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1679,7 +1679,7 @@ describe('RecordsWriteHandler.handle()', () => {
     });
   });
 
-  it('should throw if `storageController.putWithData()` throws unknown error', async () => {
+  it('should throw if `storageController.putMessageWithData()` throws unknown error', async () => {
     const { requester, message, dataStream } = await TestDataGenerator.generateRecordsWrite();
     const tenant = requester.did;
 
@@ -1692,11 +1692,11 @@ describe('RecordsWriteHandler.handle()', () => {
     const storageControllerStub = new StorageController(messageStoreStub, dataStoreStub, eventLog);
 
     // simulate throwing unexpected error
-    sinon.stub(storageControllerStub, 'putWithData').throws(new Error('an unknown error in storageController.putWithData()'));
+    sinon.stub(storageControllerStub, 'putMessageWithData').throws(new Error('an unknown error in storageController.putMessageWithData()'));
 
     const recordsWriteHandler = new RecordsWriteHandler(didResolverStub, storageControllerStub);
 
     const handlerPromise = recordsWriteHandler.handle({ tenant, message, dataStream: dataStream! });
-    await expect(handlerPromise).to.be.rejectedWith('an unknown error in storageController.putWithData()');
+    await expect(handlerPromise).to.be.rejectedWith('an unknown error in storageController.putMessageWithData()');
   });
 });

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1679,7 +1679,7 @@ describe('RecordsWriteHandler.handle()', () => {
     });
   });
 
-  it('should throw if `storageController.put()` throws unknown error', async () => {
+  it('should throw if `storageController.putWithData()` throws unknown error', async () => {
     const { requester, message, dataStream } = await TestDataGenerator.generateRecordsWrite();
     const tenant = requester.did;
 
@@ -1692,11 +1692,11 @@ describe('RecordsWriteHandler.handle()', () => {
     const storageControllerStub = new StorageController(messageStoreStub, dataStoreStub, eventLog);
 
     // simulate throwing unexpected error
-    sinon.stub(storageControllerStub, 'put').throws(new Error('an unknown error in messageStore.put()'));
+    sinon.stub(storageControllerStub, 'putWithData').throws(new Error('an unknown error in storageController.putWithData()'));
 
     const recordsWriteHandler = new RecordsWriteHandler(didResolverStub, storageControllerStub);
 
     const handlerPromise = recordsWriteHandler.handle({ tenant, message, dataStream: dataStream! });
-    await expect(handlerPromise).to.be.rejectedWith('an unknown error in messageStore.put()');
+    await expect(handlerPromise).to.be.rejectedWith('an unknown error in storageController.putWithData()');
   });
 });

--- a/tests/interfaces/records/messages/records-write.spec.ts
+++ b/tests/interfaces/records/messages/records-write.spec.ts
@@ -8,9 +8,10 @@ import chai, { expect } from 'chai';
 import { DwnErrorCode } from '../../../../src/core/dwn-error.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
 import { RecordsWrite } from '../../../../src/interfaces/records/messages/records-write.js';
+import { StorageController } from '../../../../src/store/storage-controller.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
+import { DataStoreLevel, EventLogLevel, Jws, KeyDerivationScheme } from '../../../../src/index.js';
 import { getCurrentTimeInHighPrecision, sleep } from '../../../../src/utils/time.js';
-import { Jws, KeyDerivationScheme } from '../../../../src/index.js';
 
 
 chai.use(chaiAsPromised);
@@ -39,8 +40,12 @@ describe('RecordsWrite', () => {
       expect(message.recordId).to.equal(options.recordId);
 
       const messageStoreStub = sinon.createStubInstance(MessageStoreLevel);
+      const dataStoreStub = sinon.createStubInstance(DataStoreLevel);
+      const eventLog = new EventLogLevel({ location: 'TEST-EVENTLOG' });
 
-      await recordsWrite.authorize(alice.did, messageStoreStub);
+      const storageControllerStub = new StorageController(messageStoreStub, dataStoreStub, eventLog);
+
+      await recordsWrite.authorize(alice.did, storageControllerStub);
     });
 
     it('should be able to auto-fill `datePublished` when `published` set to `true` but `datePublished` not given', async () => {


### PR DESCRIPTION
Refactor the `(messageStore, dataStore, eventlog)` tuple into a single instance of `StorageController`, which addresses #288 

### Pending questions:

~~* Should StorageController use `BaseMessage` instead of the more specific `RecordsWriteMessageWithOptionalEncodedData`?~~
~~* Settle on method names for new methods in `StorageController`, i.e. how best to differentiate between operations (`get`, `put`) and the different stores (`messageStore` vs `dataStore`)~~

cc. @thehenrytsai @mistermoe 