### PR TITLE
Protocol definition semantic fields: protocolPath -> of, actions -> can

### DIFF
--- a/json-schemas/protocol-rule-set.json
+++ b/json-schemas/protocol-rule-set.json
@@ -11,7 +11,7 @@
         "type": "object",
         "required": [
           "actor",
-          "actions"
+          "can"
         ],
         "properties": {
           "actor": {
@@ -22,10 +22,10 @@
               "recipient"
             ]
           },
-          "protocolPath": {
+          "of": {
             "type": "string"
           },
-          "actions": {
+          "can": {
             "type": "array",
             "minItems": 1,
             "items": {

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -305,32 +305,32 @@ export class ProtocolAuthorization {
     for (const allowRule of allowRules) {
       switch (allowRule.actor) {
       case ProtocolActor.Anyone:
-        allowRule.actions.forEach((operation) => allowedActions.add(operation));
+        allowRule.can.forEach((operation) => allowedActions.add(operation));
         break;
       case ProtocolActor.Author:
         const messageForAuthorCheck = ProtocolAuthorization.getMessage(
           ancestorMessageChain,
-          allowRule.protocolPath!,
+          allowRule.of!,
         );
 
         if (messageForAuthorCheck !== undefined) {
           const expectedRequesterDid = Message.getAuthor(messageForAuthorCheck);
 
           if (requesterDid === expectedRequesterDid) {
-            allowRule.actions.forEach(action => allowedActions.add(action));
+            allowRule.can.forEach(action => allowedActions.add(action));
           }
         }
         break;
       case ProtocolActor.Recipient:
         const messageForRecipientCheck = ProtocolAuthorization.getMessage(
           ancestorMessageChain,
-            allowRule.protocolPath!,
+            allowRule.of!,
         );
         if (messageForRecipientCheck !== undefined) {
           const expectedRequesterDid = messageForRecipientCheck.descriptor.recipient;
 
           if (requesterDid === expectedRequesterDid) {
-            allowRule.actions.forEach(action => allowedActions.add(action));
+            allowRule.can.forEach(action => allowedActions.add(action));
           }
         }
         break;

--- a/src/interfaces/protocols/types.ts
+++ b/src/interfaces/protocols/types.ts
@@ -36,8 +36,8 @@ export enum ProtocolAction {
 export type ProtocolRuleSet = {
   allow?: {
     actor: string,
-    protocolPath?: string,
-    actions: string[]
+    of?: string,
+    can: string[]
   }[];
   records?: {
     [key: string]: ProtocolRuleSet;

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1073,8 +1073,8 @@ describe('RecordsWriteHandler.handle()', () => {
             image: {
               allow: [
                 {
-                  actor   : 'anyone',
-                  actions : ['write']
+                  actor : 'anyone',
+                  can   : ['write']
                 }
               ]
             }
@@ -1279,7 +1279,7 @@ describe('RecordsWriteHandler.handle()', () => {
           invalidProtocolDefinition.records.credentialApplication.records.credentialResponse.allow
             .findIndex((allowRule) => allowRule.actor === ProtocolActor.Recipient);
         invalidProtocolDefinition.records.credentialApplication.records.credentialResponse
-          .allow[allowRuleIndex].protocolPath
+          .allow[allowRuleIndex].of
             = 'credentialResponse';
         // this is invalid as the root ancestor can only be `credentialApplication` based on record structure
 

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -15,8 +15,8 @@ describe('ProtocolsConfigure schema definition', () => {
         email: {
           allow: [
             {
-              actor   : 'unknown',
-              actions : ['write']
+              actor : 'unknown',
+              can   : ['write']
             }
           ]
         }

--- a/tests/vectors/protocol-definitions/credential-issuance.json
+++ b/tests/vectors/protocol-definitions/credential-issuance.json
@@ -14,7 +14,7 @@
       "allow": [
         {
           "actor": "anyone",
-          "actions": ["write"]
+          "can": ["write"]
         }
       ],
       "records": {
@@ -22,8 +22,8 @@
           "allow": [
             {
               "actor": "recipient",
-              "protocolPath": "credentialApplication",
-              "actions": ["write"]
+              "of": "credentialApplication",
+              "can": ["write"]
             }
           ]
         }

--- a/tests/vectors/protocol-definitions/dex.json
+++ b/tests/vectors/protocol-definitions/dex.json
@@ -18,7 +18,7 @@
       "allow": [
         {
           "actor": "anyone",
-          "actions": ["write"]
+          "can": ["write"]
         }
       ],
       "records": {
@@ -26,8 +26,8 @@
           "allow": [
             {
               "actor": "recipient",
-              "protocolPath": "ask",
-              "actions": ["write"]
+              "of": "ask",
+              "can": ["write"]
             }
           ],
           "records": {
@@ -35,8 +35,8 @@
               "allow": [
                 {
                   "actor": "recipient",
-                  "protocolPath": "ask/offer",
-                  "actions": ["write"]
+                  "of": "ask/offer",
+                  "can": ["write"]
                 }
               ]
             }

--- a/tests/vectors/protocol-definitions/email.json
+++ b/tests/vectors/protocol-definitions/email.json
@@ -10,17 +10,17 @@
       "allow": [
         {
           "actor": "anyone",
-          "actions": ["write"]
+          "can": ["write"]
         },
         {
           "actor": "author",
-          "protocolPath": "email",
-          "actions": ["read"]
+          "of": "email",
+          "can": ["read"]
         },
         {
           "actor": "recipient",
-          "protocolPath": "email",
-          "actions": ["read"]
+          "of": "email",
+          "can": ["read"]
         }
       ],
       "records": {
@@ -28,17 +28,17 @@
           "allow": [
             {
               "actor": "anyone",
-              "actions": ["write"]
+              "can": ["write"]
             },
             {
               "actor": "author",
-              "protocolPath": "email/email",
-              "actions": ["read"]
+              "of": "email/email",
+              "can": ["read"]
             },
             {
               "actor": "recipient",
               "protocolpath": "email/email",
-              "actions": ["read"]
+              "can": ["read"]
             }
           ]
         }

--- a/tests/vectors/protocol-definitions/message.json
+++ b/tests/vectors/protocol-definitions/message.json
@@ -10,7 +10,7 @@
       "allow": [
         {
           "actor": "anyone",
-          "actions": ["write"]
+          "can": ["write"]
         }
       ]
     }

--- a/tests/vectors/protocol-definitions/social-media.json
+++ b/tests/vectors/protocol-definitions/social-media.json
@@ -22,7 +22,7 @@
       "allow": [
         {
           "actor": "anyone",
-          "actions": ["write"]
+          "can": ["write"]
         }
       ],
       "records": {
@@ -30,8 +30,8 @@
           "allow": [
             {
               "actor": "recipient",
-              "protocolPath": "message",
-              "actions": ["write"]
+              "of": "message",
+              "can": ["write"]
             }
           ]
         }
@@ -41,7 +41,7 @@
       "allow": [
         {
           "actor": "anyone",
-          "actions": ["read", "write"]
+          "can": ["read", "write"]
         }
       ],
       "records": {
@@ -49,12 +49,12 @@
           "allow": [
             {
               "actor": "anyone",
-              "actions": ["read"]
+              "can": ["read"]
             },
             {
               "actor": "author",
-              "protocolPath": "image",
-              "actions": ["write"]
+              "of": "image",
+              "can": ["write"]
             }
           ]
         },
@@ -62,13 +62,13 @@
           "allow": [
             {
               "actor": "author",
-              "protocolPath": "image",
-              "actions": ["read"]
+              "of": "image",
+              "can": ["read"]
             },
             {
               "actor": "recipient",
-              "protocolPath": "image",
-              "actions": ["write"]
+              "of": "image",
+              "can": ["write"]
             }
           ]
         }


### PR DESCRIPTION
@csuwildcat :)

Final decision, we like this naming convention better. Some reasons (other than vibes):
* We anticipate other properties that take a protocol path -- e.g. `under` -- so `protocolPath` is too generic of a property name.
* `can` is better than `to` because `to` has two potential meanings in English. First, preceding an infinite, e.g. "to be or not to be". Second, as a preposition, e.g. "from the moon to the stars". This overloading is not my favorite.