### PR TITLE
Require protocol uri in protocol definition

### DIFF
--- a/json-schemas/protocol-definition.json
+++ b/json-schemas/protocol-definition.json
@@ -4,10 +4,14 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "protocol",
     "recordDefinitions",
     "records"
   ],
   "properties": {
+    "protocol": {
+      "type": "string"
+    },
     "recordDefinitions": {
       "type": "array",
       "minItems": 1,

--- a/src/interfaces/protocols/types.ts
+++ b/src/interfaces/protocols/types.ts
@@ -10,6 +10,7 @@ export type ProtocolsConfigureDescriptor = {
 };
 
 export type ProtocolDefinition = {
+  protocol: string,
   recordDefinitions: ProtocolRecordDefinition[];
   records: {
     [key: string]: ProtocolRuleSet;

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1062,7 +1062,8 @@ describe('RecordsWriteHandler.handle()', () => {
         const alice = await DidKeyResolver.generate();
 
         const protocolDefinition = {
-          recordDefinitions: [
+          protocol          : 'https://example.com',
+          recordDefinitions : [
             {
               id          : 'image',
               schema      : 'https://example.com/schema',
@@ -1220,7 +1221,8 @@ describe('RecordsWriteHandler.handle()', () => {
         // write a protocol definition without an explicit allow rule
         const protocol = 'private-protocol';
         const protocolDefinition: ProtocolDefinition = {
-          recordDefinitions: [
+          protocol          : 'private-note.com',
+          recordDefinitions : [
             {
               id     : 'privateNote',
               schema : 'private-note'

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -238,6 +238,7 @@ export class TestDataGenerator {
       const generatedLabel = 'record' + TestDataGenerator.randomString(10);
 
       definition = {
+        protocol          : 'test-protocol',
         recordDefinitions : [],
         records           : {}
       };

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -7,7 +7,8 @@ import type { ProtocolDefinition, ProtocolsConfigureMessage } from '../../../../
 describe('ProtocolsConfigure schema definition', () => {
   it('should throw if unknown actor is encountered in allow rule', async () => {
     const protocolDefinition: ProtocolDefinition = {
-      recordDefinitions: [{
+      protocol          : 'email.com',
+      recordDefinitions : [{
         id     : 'email',
         schema : 'email'
       }],

--- a/tests/vectors/protocol-definitions/credential-issuance.json
+++ b/tests/vectors/protocol-definitions/credential-issuance.json
@@ -1,4 +1,5 @@
 {
+  "protocol": "https://identity.foundation/credential-issuance",
   "recordDefinitions": [
     {
       "id": "credentialApplication",

--- a/tests/vectors/protocol-definitions/dex.json
+++ b/tests/vectors/protocol-definitions/dex.json
@@ -1,4 +1,5 @@
 {
+  "protocol": "https://tbd/website/tbdex",
   "recordDefinitions": [
     {
       "id": "ask",

--- a/tests/vectors/protocol-definitions/email.json
+++ b/tests/vectors/protocol-definitions/email.json
@@ -1,4 +1,5 @@
 {
+  "protocol": "https://example.com/email",
   "recordDefinitions": [
     {
       "id": "email",

--- a/tests/vectors/protocol-definitions/message.json
+++ b/tests/vectors/protocol-definitions/message.json
@@ -1,4 +1,5 @@
 {
+  "protocol": "http://message.me/protocol",
   "recordDefinitions": [
     {
       "id": "message",

--- a/tests/vectors/protocol-definitions/social-media.json
+++ b/tests/vectors/protocol-definitions/social-media.json
@@ -1,4 +1,5 @@
 {
+  "protocol": "http://socialmedia.com",
   "recordDefinitions": [
     {
       "id": "message",


### PR DESCRIPTION
Require URL to protocol inside the definition itself. We do NOT normalize this URL because we are not indexing on it. For indexing, we still use the `protocol` field pass in the descriptor of messages such as `RecordsWrite`, `ProtocolsConfigure`, and `ProtocolsQuery`.