### PR TITLE
Rename and flatten protocol action rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.22%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.96%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.02%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.22%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.22%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.94%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.02%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.22%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.22%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.93%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.02%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.22%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.22%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.94%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.02%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.22%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.22%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.94%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.02%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.22%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.22%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.93%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.02%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.22%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/json-schemas/protocol-rule-set.json
+++ b/json-schemas/protocol-rule-set.json
@@ -4,14 +4,14 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "allow": {
+    "actions": {
       "type": "array",
       "minItems": 1,
       "items": {
         "type": "object",
         "required": [
           "actor",
-          "actions"
+          "can"
         ],
         "properties": {
           "actor": {
@@ -22,10 +22,10 @@
               "recipient"
             ]
           },
-          "protocolPath": {
+          "of": {
             "type": "string"
           },
-          "actions": {
+          "can": {
             "type": "array",
             "minItems": 1,
             "items": {

--- a/json-schemas/protocol-rule-set.json
+++ b/json-schemas/protocol-rule-set.json
@@ -13,6 +13,7 @@
           "actor",
           "can"
         ],
+        "additionalProperties": false,
         "properties": {
           "actor": {
             "type": "string",
@@ -26,15 +27,11 @@
             "type": "string"
           },
           "can": {
-            "type": "array",
-            "minItems": 1,
-            "items": {
-              "type": "string",
-              "enum": [
-                "read",
-                "write"
-              ]
-            }
+            "type": "string",
+            "enum": [
+              "read",
+              "write"
+            ]
           }
         }
       }

--- a/json-schemas/protocol-rule-set.json
+++ b/json-schemas/protocol-rule-set.json
@@ -10,12 +10,12 @@
       "items": {
         "type": "object",
         "required": [
-          "actor",
+          "who",
           "can"
         ],
         "additionalProperties": false,
         "properties": {
-          "actor": {
+          "who": {
             "type": "string",
             "enum": [
               "anyone",

--- a/json-schemas/protocol-rule-set.json
+++ b/json-schemas/protocol-rule-set.json
@@ -4,7 +4,7 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "actions": {
+    "$actions": {
       "type": "array",
       "minItems": 1,
       "items": {

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -290,7 +290,7 @@ export class ProtocolAuthorization {
     inboundMessageRuleSet: ProtocolRuleSet,
     ancestorMessageChain: RecordsWriteMessage[],
   ): void {
-    const allowRules = inboundMessageRuleSet.allow;
+    const allowRules = inboundMessageRuleSet.actions;
 
     if (allowRules === undefined) {
       // if no allow rule is defined, owner of DWN can do everything
@@ -305,32 +305,32 @@ export class ProtocolAuthorization {
     for (const allowRule of allowRules) {
       switch (allowRule.actor) {
       case ProtocolActor.Anyone:
-        allowRule.actions.forEach((operation) => allowedActions.add(operation));
+        allowRule.can.forEach((operation) => allowedActions.add(operation));
         break;
       case ProtocolActor.Author:
         const messageForAuthorCheck = ProtocolAuthorization.getMessage(
           ancestorMessageChain,
-          allowRule.protocolPath!,
+          allowRule.of!,
         );
 
         if (messageForAuthorCheck !== undefined) {
           const expectedRequesterDid = Message.getAuthor(messageForAuthorCheck);
 
           if (requesterDid === expectedRequesterDid) {
-            allowRule.actions.forEach(action => allowedActions.add(action));
+            allowRule.can.forEach(action => allowedActions.add(action));
           }
         }
         break;
       case ProtocolActor.Recipient:
         const messageForRecipientCheck = ProtocolAuthorization.getMessage(
           ancestorMessageChain,
-            allowRule.protocolPath!,
+            allowRule.of!,
         );
         if (messageForRecipientCheck !== undefined) {
           const expectedRequesterDid = messageForRecipientCheck.descriptor.recipient;
 
           if (requesterDid === expectedRequesterDid) {
-            allowRule.actions.forEach(action => allowedActions.add(action));
+            allowRule.can.forEach(action => allowedActions.add(action));
           }
         }
         break;

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -303,7 +303,7 @@ export class ProtocolAuthorization {
 
     const allowedActions = new Set<string>();
     for (const allowRule of actionRules) {
-      switch (allowRule.actor) {
+      switch (allowRule.who) {
       case ProtocolActor.Anyone:
         allowedActions.add(allowRule.can);
         break;

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -290,7 +290,7 @@ export class ProtocolAuthorization {
     inboundMessageRuleSet: ProtocolRuleSet,
     ancestorMessageChain: RecordsWriteMessage[],
   ): void {
-    const actionRules = inboundMessageRuleSet.actions;
+    const actionRules = inboundMessageRuleSet.$actions;
 
     if (actionRules === undefined) {
       // if no allow rule is defined, owner of DWN can do everything

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -290,9 +290,9 @@ export class ProtocolAuthorization {
     inboundMessageRuleSet: ProtocolRuleSet,
     ancestorMessageChain: RecordsWriteMessage[],
   ): void {
-    const allowRules = inboundMessageRuleSet.actions;
+    const actionRules = inboundMessageRuleSet.actions;
 
-    if (allowRules === undefined) {
+    if (actionRules === undefined) {
       // if no allow rule is defined, owner of DWN can do everything
       if (requesterDid === tenant) {
         return;
@@ -302,10 +302,10 @@ export class ProtocolAuthorization {
     }
 
     const allowedActions = new Set<string>();
-    for (const allowRule of allowRules) {
+    for (const allowRule of actionRules) {
       switch (allowRule.actor) {
       case ProtocolActor.Anyone:
-        allowRule.can.forEach((operation) => allowedActions.add(operation));
+        allowedActions.add(allowRule.can);
         break;
       case ProtocolActor.Author:
         const messageForAuthorCheck = ProtocolAuthorization.getMessage(
@@ -317,7 +317,7 @@ export class ProtocolAuthorization {
           const expectedRequesterDid = Message.getAuthor(messageForAuthorCheck);
 
           if (requesterDid === expectedRequesterDid) {
-            allowRule.can.forEach(action => allowedActions.add(action));
+            allowedActions.add(allowRule.can);
           }
         }
         break;
@@ -330,12 +330,12 @@ export class ProtocolAuthorization {
           const expectedRequesterDid = messageForRecipientCheck.descriptor.recipient;
 
           if (requesterDid === expectedRequesterDid) {
-            allowRule.can.forEach(action => allowedActions.add(action));
+            allowedActions.add(allowRule.can);
           }
         }
         break;
         // default:
-        //    This is handled by protocol-rule-set.json validator
+        //    JSON schema validations ensure that there are no other cases
       }
     }
 

--- a/src/interfaces/protocols/types.ts
+++ b/src/interfaces/protocols/types.ts
@@ -35,7 +35,7 @@ export enum ProtocolAction {
 
 export type ProtocolRuleSet = {
   $actions?: {
-    actor: string,
+    who: string,
     of?: string,
     can: string
   }[];

--- a/src/interfaces/protocols/types.ts
+++ b/src/interfaces/protocols/types.ts
@@ -37,7 +37,7 @@ export type ProtocolRuleSet = {
   actions?: {
     actor: string,
     of?: string,
-    can: string[]
+    can: string
   }[];
   records?: {
     [key: string]: ProtocolRuleSet;

--- a/src/interfaces/protocols/types.ts
+++ b/src/interfaces/protocols/types.ts
@@ -34,7 +34,7 @@ export enum ProtocolAction {
 }
 
 export type ProtocolRuleSet = {
-  actions?: {
+  $actions?: {
     actor: string,
     of?: string,
     can: string

--- a/src/interfaces/protocols/types.ts
+++ b/src/interfaces/protocols/types.ts
@@ -34,10 +34,10 @@ export enum ProtocolAction {
 }
 
 export type ProtocolRuleSet = {
-  allow?: {
+  actions?: {
     actor: string,
-    protocolPath?: string,
-    actions: string[]
+    of?: string,
+    can: string[]
   }[];
   records?: {
     [key: string]: ProtocolRuleSet;

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1073,8 +1073,8 @@ describe('RecordsWriteHandler.handle()', () => {
             image: {
               $actions: [
                 {
-                  actor : 'anyone',
-                  can   : 'write'
+                  who : 'anyone',
+                  can : 'write'
                 }
               ]
             }
@@ -1277,7 +1277,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const invalidProtocolDefinition = { ...credentialIssuanceProtocolDefinition };
         const allowRuleIndex =
           invalidProtocolDefinition.records.credentialApplication.records.credentialResponse.$actions
-            .findIndex((allowRule) => allowRule.actor === ProtocolActor.Recipient);
+            .findIndex((allowRule) => allowRule.who === ProtocolActor.Recipient);
         invalidProtocolDefinition.records.credentialApplication.records.credentialResponse
           .$actions[allowRuleIndex].of
             = 'credentialResponse';

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1074,7 +1074,7 @@ describe('RecordsWriteHandler.handle()', () => {
               actions: [
                 {
                   actor : 'anyone',
-                  can   : ['write']
+                  can   : 'write'
                 }
               ]
             }

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1071,7 +1071,7 @@ describe('RecordsWriteHandler.handle()', () => {
           ],
           records: {
             image: {
-              actions: [
+              $actions: [
                 {
                   actor : 'anyone',
                   can   : 'write'
@@ -1276,10 +1276,10 @@ describe('RecordsWriteHandler.handle()', () => {
         // create an invalid ancestor path that is longer than possible
         const invalidProtocolDefinition = { ...credentialIssuanceProtocolDefinition };
         const allowRuleIndex =
-          invalidProtocolDefinition.records.credentialApplication.records.credentialResponse.actions
+          invalidProtocolDefinition.records.credentialApplication.records.credentialResponse.$actions
             .findIndex((allowRule) => allowRule.actor === ProtocolActor.Recipient);
         invalidProtocolDefinition.records.credentialApplication.records.credentialResponse
-          .actions[allowRuleIndex].of
+          .$actions[allowRuleIndex].of
             = 'credentialResponse';
         // this is invalid as the root ancestor can only be `credentialApplication` based on record structure
 

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1061,8 +1061,8 @@ describe('RecordsWriteHandler.handle()', () => {
       it('should fail authorization if given `dataFormat` is mismatching with the dataFormats in protocol definition', async () => {
         const alice = await DidKeyResolver.generate();
 
-        const protocolDefinition = {
-          recordDefinitions: [
+        const protocolDefinition: ProtocolDefinition = {
+          recordDefinitions : [
             {
               id          : 'image',
               schema      : 'https://example.com/schema',
@@ -1071,10 +1071,10 @@ describe('RecordsWriteHandler.handle()', () => {
           ],
           records: {
             image: {
-              allow: [
+              actions: [
                 {
-                  actor   : 'anyone',
-                  actions : ['write']
+                  actor : 'anyone',
+                  can   : ['write']
                 }
               ]
             }
@@ -1276,10 +1276,10 @@ describe('RecordsWriteHandler.handle()', () => {
         // create an invalid ancestor path that is longer than possible
         const invalidProtocolDefinition = { ...credentialIssuanceProtocolDefinition };
         const allowRuleIndex =
-          invalidProtocolDefinition.records.credentialApplication.records.credentialResponse.allow
+          invalidProtocolDefinition.records.credentialApplication.records.credentialResponse.actions
             .findIndex((allowRule) => allowRule.actor === ProtocolActor.Recipient);
         invalidProtocolDefinition.records.credentialApplication.records.credentialResponse
-          .allow[allowRuleIndex].protocolPath
+          .actions[allowRuleIndex].of
             = 'credentialResponse';
         // this is invalid as the root ancestor can only be `credentialApplication` based on record structure
 

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1062,7 +1062,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const alice = await DidKeyResolver.generate();
 
         const protocolDefinition: ProtocolDefinition = {
-          recordDefinitions : [
+          recordDefinitions: [
             {
               id          : 'image',
               schema      : 'https://example.com/schema',

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -15,8 +15,8 @@ describe('ProtocolsConfigure schema definition', () => {
         email: {
           $actions: [
             {
-              actor : 'unknown',
-              can   : 'write'
+              who : 'unknown',
+              can : 'write'
             }
           ]
         }

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -13,10 +13,10 @@ describe('ProtocolsConfigure schema definition', () => {
       }],
       records: {
         email: {
-          allow: [
+          actions: [
             {
-              actor   : 'unknown',
-              actions : ['write']
+              actor : 'unknown',
+              can   : ['write']
             }
           ]
         }

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -13,7 +13,7 @@ describe('ProtocolsConfigure schema definition', () => {
       }],
       records: {
         email: {
-          actions: [
+          $actions: [
             {
               actor : 'unknown',
               can   : 'write'

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -16,7 +16,7 @@ describe('ProtocolsConfigure schema definition', () => {
           actions: [
             {
               actor : 'unknown',
-              can   : ['write']
+              can   : 'write'
             }
           ]
         }

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -42,7 +42,7 @@ describe('ProtocolsConfigure schema definition', () => {
 
     expect(() => {
       Message.validateJsonSchema(message);
-    }).throws('actor: must be equal to one of the allowed values');
+    }).throws('who: must be equal to one of the allowed values');
   });
 
   describe('rule-set tests', () => {

--- a/tests/vectors/protocol-definitions/credential-issuance.json
+++ b/tests/vectors/protocol-definitions/credential-issuance.json
@@ -11,7 +11,7 @@
   ],
   "records": {
     "credentialApplication": {
-      "actions": [
+      "$actions": [
         {
           "actor": "anyone",
           "can": "write"
@@ -19,7 +19,7 @@
       ],
       "records": {
         "credentialResponse": {
-          "actions": [
+          "$actions": [
             {
               "actor": "recipient",
               "of": "credentialApplication",

--- a/tests/vectors/protocol-definitions/credential-issuance.json
+++ b/tests/vectors/protocol-definitions/credential-issuance.json
@@ -13,7 +13,7 @@
     "credentialApplication": {
       "$actions": [
         {
-          "actor": "anyone",
+          "who": "anyone",
           "can": "write"
         }
       ],
@@ -21,7 +21,7 @@
         "credentialResponse": {
           "$actions": [
             {
-              "actor": "recipient",
+              "who": "recipient",
               "of": "credentialApplication",
               "can": "write"
             }

--- a/tests/vectors/protocol-definitions/credential-issuance.json
+++ b/tests/vectors/protocol-definitions/credential-issuance.json
@@ -11,19 +11,19 @@
   ],
   "records": {
     "credentialApplication": {
-      "allow": [
+      "actions": [
         {
           "actor": "anyone",
-          "actions": ["write"]
+          "can": ["write"]
         }
       ],
       "records": {
         "credentialResponse": {
-          "allow": [
+          "actions": [
             {
               "actor": "recipient",
-              "protocolPath": "credentialApplication",
-              "actions": ["write"]
+              "of": "credentialApplication",
+              "can": ["write"]
             }
           ]
         }

--- a/tests/vectors/protocol-definitions/credential-issuance.json
+++ b/tests/vectors/protocol-definitions/credential-issuance.json
@@ -14,7 +14,7 @@
       "actions": [
         {
           "actor": "anyone",
-          "can": ["write"]
+          "can": "write"
         }
       ],
       "records": {
@@ -23,7 +23,7 @@
             {
               "actor": "recipient",
               "of": "credentialApplication",
-              "can": ["write"]
+              "can": "write"
             }
           ]
         }

--- a/tests/vectors/protocol-definitions/dex.json
+++ b/tests/vectors/protocol-definitions/dex.json
@@ -17,7 +17,7 @@
     "ask": {
       "$actions": [
         {
-          "actor": "anyone",
+          "who": "anyone",
           "can": "write"
         }
       ],
@@ -25,7 +25,7 @@
         "offer": {
           "$actions": [
             {
-              "actor": "recipient",
+              "who": "recipient",
               "of": "ask",
               "can": "write"
             }
@@ -34,7 +34,7 @@
             "fulfillment": {
               "$actions": [
                 {
-                  "actor": "recipient",
+                  "who": "recipient",
                   "of": "ask/offer",
                   "can": "write"
                 }

--- a/tests/vectors/protocol-definitions/dex.json
+++ b/tests/vectors/protocol-definitions/dex.json
@@ -15,28 +15,28 @@
   ],
   "records": {
     "ask": {
-      "allow": [
+      "actions": [
         {
           "actor": "anyone",
-          "actions": ["write"]
+          "can": ["write"]
         }
       ],
       "records": {
         "offer": {
-          "allow": [
+          "actions": [
             {
               "actor": "recipient",
-              "protocolPath": "ask",
-              "actions": ["write"]
+              "of": "ask",
+              "can": ["write"]
             }
           ],
           "records": {
             "fulfillment": {
-              "allow": [
+              "actions": [
                 {
                   "actor": "recipient",
-                  "protocolPath": "ask/offer",
-                  "actions": ["write"]
+                  "of": "ask/offer",
+                  "can": ["write"]
                 }
               ]
             }

--- a/tests/vectors/protocol-definitions/dex.json
+++ b/tests/vectors/protocol-definitions/dex.json
@@ -15,7 +15,7 @@
   ],
   "records": {
     "ask": {
-      "actions": [
+      "$actions": [
         {
           "actor": "anyone",
           "can": "write"
@@ -23,7 +23,7 @@
       ],
       "records": {
         "offer": {
-          "actions": [
+          "$actions": [
             {
               "actor": "recipient",
               "of": "ask",
@@ -32,7 +32,7 @@
           ],
           "records": {
             "fulfillment": {
-              "actions": [
+              "$actions": [
                 {
                   "actor": "recipient",
                   "of": "ask/offer",

--- a/tests/vectors/protocol-definitions/dex.json
+++ b/tests/vectors/protocol-definitions/dex.json
@@ -18,7 +18,7 @@
       "actions": [
         {
           "actor": "anyone",
-          "can": ["write"]
+          "can": "write"
         }
       ],
       "records": {
@@ -27,7 +27,7 @@
             {
               "actor": "recipient",
               "of": "ask",
-              "can": ["write"]
+              "can": "write"
             }
           ],
           "records": {
@@ -36,7 +36,7 @@
                 {
                   "actor": "recipient",
                   "of": "ask/offer",
-                  "can": ["write"]
+                  "can": "write"
                 }
               ]
             }

--- a/tests/vectors/protocol-definitions/email.json
+++ b/tests/vectors/protocol-definitions/email.json
@@ -7,38 +7,38 @@
   ],
   "records": {
     "email": {
-      "allow": [
+      "actions": [
         {
           "actor": "anyone",
-          "actions": ["write"]
+          "can": ["write"]
         },
         {
           "actor": "author",
-          "protocolPath": "email",
-          "actions": ["read"]
+          "of": "email",
+          "can": ["read"]
         },
         {
           "actor": "recipient",
-          "protocolPath": "email",
-          "actions": ["read"]
+          "of": "email",
+          "can": ["read"]
         }
       ],
       "records": {
         "email": {
-          "allow": [
+          "actions": [
             {
               "actor": "anyone",
-              "actions": ["write"]
+              "can": ["write"]
             },
             {
               "actor": "author",
-              "protocolPath": "email/email",
-              "actions": ["read"]
+              "of": "email/email",
+              "can": ["read"]
             },
             {
               "actor": "recipient",
               "protocolpath": "email/email",
-              "actions": ["read"]
+              "can": ["read"]
             }
           ]
         }

--- a/tests/vectors/protocol-definitions/email.json
+++ b/tests/vectors/protocol-definitions/email.json
@@ -10,17 +10,17 @@
       "actions": [
         {
           "actor": "anyone",
-          "can": ["write"]
+          "can": "write"
         },
         {
           "actor": "author",
           "of": "email",
-          "can": ["read"]
+          "can": "read"
         },
         {
           "actor": "recipient",
           "of": "email",
-          "can": ["read"]
+          "can": "read"
         }
       ],
       "records": {
@@ -28,17 +28,17 @@
           "actions": [
             {
               "actor": "anyone",
-              "can": ["write"]
+              "can": "write"
             },
             {
               "actor": "author",
               "of": "email/email",
-              "can": ["read"]
+              "can": "read"
             },
             {
               "actor": "recipient",
-              "protocolpath": "email/email",
-              "can": ["read"]
+              "of": "email/email",
+              "can": "read"
             }
           ]
         }

--- a/tests/vectors/protocol-definitions/email.json
+++ b/tests/vectors/protocol-definitions/email.json
@@ -7,7 +7,7 @@
   ],
   "records": {
     "email": {
-      "actions": [
+      "$actions": [
         {
           "actor": "anyone",
           "can": "write"
@@ -25,7 +25,7 @@
       ],
       "records": {
         "email": {
-          "actions": [
+          "$actions": [
             {
               "actor": "anyone",
               "can": "write"

--- a/tests/vectors/protocol-definitions/email.json
+++ b/tests/vectors/protocol-definitions/email.json
@@ -9,16 +9,16 @@
     "email": {
       "$actions": [
         {
-          "actor": "anyone",
+          "who": "anyone",
           "can": "write"
         },
         {
-          "actor": "author",
+          "who": "author",
           "of": "email",
           "can": "read"
         },
         {
-          "actor": "recipient",
+          "who": "recipient",
           "of": "email",
           "can": "read"
         }
@@ -27,16 +27,16 @@
         "email": {
           "$actions": [
             {
-              "actor": "anyone",
+              "who": "anyone",
               "can": "write"
             },
             {
-              "actor": "author",
+              "who": "author",
               "of": "email/email",
               "can": "read"
             },
             {
-              "actor": "recipient",
+              "who": "recipient",
               "of": "email/email",
               "can": "read"
             }

--- a/tests/vectors/protocol-definitions/message.json
+++ b/tests/vectors/protocol-definitions/message.json
@@ -7,7 +7,7 @@
   ],
   "records": {
     "message": {
-      "actions": [
+      "$actions": [
         {
           "actor": "anyone",
           "can": "write"

--- a/tests/vectors/protocol-definitions/message.json
+++ b/tests/vectors/protocol-definitions/message.json
@@ -10,7 +10,7 @@
       "actions": [
         {
           "actor": "anyone",
-          "can": ["write"]
+          "can": "write"
         }
       ]
     }

--- a/tests/vectors/protocol-definitions/message.json
+++ b/tests/vectors/protocol-definitions/message.json
@@ -9,7 +9,7 @@
     "message": {
       "$actions": [
         {
-          "actor": "anyone",
+          "who": "anyone",
           "can": "write"
         }
       ]

--- a/tests/vectors/protocol-definitions/message.json
+++ b/tests/vectors/protocol-definitions/message.json
@@ -7,10 +7,10 @@
   ],
   "records": {
     "message": {
-      "allow": [
+      "actions": [
         {
           "actor": "anyone",
-          "actions": ["write"]
+          "can": ["write"]
         }
       ]
     }

--- a/tests/vectors/protocol-definitions/social-media.json
+++ b/tests/vectors/protocol-definitions/social-media.json
@@ -22,7 +22,7 @@
       "actions": [
         {
           "actor": "anyone",
-          "can": ["write"]
+          "can": "write"
         }
       ],
       "records": {
@@ -31,7 +31,7 @@
             {
               "actor": "recipient",
               "of": "message",
-              "can": ["write"]
+              "can": "write"
             }
           ]
         }
@@ -41,7 +41,11 @@
       "actions": [
         {
           "actor": "anyone",
-          "can": ["read", "write"]
+          "can": "read"
+        },
+        {
+          "actor": "anyone",
+          "can": "write"
         }
       ],
       "records": {
@@ -49,12 +53,12 @@
           "actions": [
             {
               "actor": "anyone",
-              "can": ["read"]
+              "can": "read"
             },
             {
               "actor": "author",
               "of": "image",
-              "can": ["write"]
+              "can": "write"
             }
           ]
         },
@@ -63,12 +67,12 @@
             {
               "actor": "author",
               "of": "image",
-              "can": ["read"]
+              "can": "read"
             },
             {
               "actor": "recipient",
               "of": "image",
-              "can": ["write"]
+              "can": "write"
             }
           ]
         }

--- a/tests/vectors/protocol-definitions/social-media.json
+++ b/tests/vectors/protocol-definitions/social-media.json
@@ -19,7 +19,7 @@
   ],
   "records": {
     "message": {
-      "actions": [
+      "$actions": [
         {
           "actor": "anyone",
           "can": "write"
@@ -27,7 +27,7 @@
       ],
       "records": {
         "reply": {
-          "actions": [
+          "$actions": [
             {
               "actor": "recipient",
               "of": "message",
@@ -38,7 +38,7 @@
       }
     },
     "image": {
-      "actions": [
+      "$actions": [
         {
           "actor": "anyone",
           "can": "read"
@@ -50,7 +50,7 @@
       ],
       "records": {
         "caption": {
-          "actions": [
+          "$actions": [
             {
               "actor": "anyone",
               "can": "read"
@@ -63,7 +63,7 @@
           ]
         },
         "reply": {
-          "actions": [
+          "$actions": [
             {
               "actor": "author",
               "of": "image",

--- a/tests/vectors/protocol-definitions/social-media.json
+++ b/tests/vectors/protocol-definitions/social-media.json
@@ -19,56 +19,56 @@
   ],
   "records": {
     "message": {
-      "allow": [
+      "actions": [
         {
           "actor": "anyone",
-          "actions": ["write"]
+          "can": ["write"]
         }
       ],
       "records": {
         "reply": {
-          "allow": [
+          "actions": [
             {
               "actor": "recipient",
-              "protocolPath": "message",
-              "actions": ["write"]
+              "of": "message",
+              "can": ["write"]
             }
           ]
         }
       }
     },
     "image": {
-      "allow": [
+      "actions": [
         {
           "actor": "anyone",
-          "actions": ["read", "write"]
+          "can": ["read", "write"]
         }
       ],
       "records": {
         "caption": {
-          "allow": [
+          "actions": [
             {
               "actor": "anyone",
-              "actions": ["read"]
+              "can": ["read"]
             },
             {
               "actor": "author",
-              "protocolPath": "image",
-              "actions": ["write"]
+              "of": "image",
+              "can": ["write"]
             }
           ]
         },
         "reply": {
-          "allow": [
+          "actions": [
             {
               "actor": "author",
-              "protocolPath": "image",
-              "actions": ["read"]
+              "of": "image",
+              "can": ["read"]
             },
             {
               "actor": "recipient",
-              "protocolPath": "image",
-              "actions": ["write"]
+              "of": "image",
+              "can": ["write"]
             }
           ]
         }

--- a/tests/vectors/protocol-definitions/social-media.json
+++ b/tests/vectors/protocol-definitions/social-media.json
@@ -21,7 +21,7 @@
     "message": {
       "$actions": [
         {
-          "actor": "anyone",
+          "who": "anyone",
           "can": "write"
         }
       ],
@@ -29,7 +29,7 @@
         "reply": {
           "$actions": [
             {
-              "actor": "recipient",
+              "who": "recipient",
               "of": "message",
               "can": "write"
             }
@@ -40,11 +40,11 @@
     "image": {
       "$actions": [
         {
-          "actor": "anyone",
+          "who": "anyone",
           "can": "read"
         },
         {
-          "actor": "anyone",
+          "who": "anyone",
           "can": "write"
         }
       ],
@@ -52,11 +52,11 @@
         "caption": {
           "$actions": [
             {
-              "actor": "anyone",
+              "who": "anyone",
               "can": "read"
             },
             {
-              "actor": "author",
+              "who": "author",
               "of": "image",
               "can": "write"
             }
@@ -65,12 +65,12 @@
         "reply": {
           "$actions": [
             {
-              "actor": "author",
+              "who": "author",
               "of": "image",
               "can": "read"
             },
             {
-              "actor": "recipient",
+              "who": "recipient",
               "of": "image",
               "can": "write"
             }


### PR DESCRIPTION
We decided to move back to this semantic naming pattern (e.g. `of`, `can`). And we noticed that flattening the `can` field (previously `actions`) from an array into a single string makes future changes to the protocol DSL simpler.