### PR TITLE
Add RecordsReadReply to exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export type { EventsGetMessage, EventsGetReply } from './interfaces/events/types
 export type { HooksWriteMessage } from './interfaces/hooks/types.js';
 export type { MessagesGetMessage, MessagesGetReply } from './interfaces/messages/types.js';
 export type { ProtocolDefinition, ProtocolRuleSet, ProtocolsQueryFilter, ProtocolsConfigureMessage, ProtocolsQueryMessage } from './interfaces/protocols/types.js';
-export type { RecordsDeleteMessage, RecordsQueryMessage, RecordsWriteMessage } from './interfaces/records/types.js';
+export type { RecordsDeleteMessage, RecordsQueryMessage, RecordsReadReply, RecordsWriteMessage } from './interfaces/records/types.js';
 export { AllowAllTenantGate, TenantGate } from './core/tenant-gate.js';
 export { Cid } from './utils/cid.js';
 export { DataStore } from './store/data-store.js';


### PR DESCRIPTION
Now that `dwn-server` has been converted to TS (and `web5-js` this week), we'd like to be able to import the `RecordsReadReply` type from `dwn-sdk-js`

For example:
https://github.com/TBD54566975/dwn-server/blob/02c6a01fe783f4e605d7fd0b8b7fdcc8aac9ab97/src/json-rpc-handlers/dwn/process-message.ts#L32-L38