### PR TITLE
Protocol rename records -> structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.21%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.93%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.21%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.63%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.02%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.3%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.63%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/json-schemas/protocol-definition.json
+++ b/json-schemas/protocol-definition.json
@@ -5,7 +5,7 @@
   "additionalProperties": false,
   "required": [
     "types",
-    "records"
+    "structure"
   ],
   "properties": {
     "types": {
@@ -29,7 +29,7 @@
         }
       }
     },
-    "records": {
+    "structure": {
       "type": "object",
       "patternProperties": {
         ".*": {

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -178,7 +178,7 @@ export class ProtocolAuthorization {
     const protocolPathArray = protocolPath.split('/');
 
     // traverse rule sets using protocolPath
-    let currentRuleSet: ProtocolRuleSet = protocolDefinition;
+    let currentRuleSet: ProtocolRuleSet = { records: protocolDefinition.structure };
     let i = 0;
     while (i < protocolPathArray.length) {
       const currentTypeName = protocolPathArray[i];

--- a/src/interfaces/protocols/types.ts
+++ b/src/interfaces/protocols/types.ts
@@ -11,7 +11,7 @@ export type ProtocolsConfigureDescriptor = {
 
 export type ProtocolDefinition = {
   types: ProtocolTypes;
-  records: {
+  structure: {
     [key: string]: ProtocolRuleSet;
   }
 };

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1266,9 +1266,9 @@ describe('RecordsWriteHandler.handle()', () => {
         // create an invalid ancestor path that is longer than possible
         const invalidProtocolDefinition = { ...credentialIssuanceProtocolDefinition };
         const allowRuleIndex =
-          invalidProtocolDefinition.records.credentialApplication.records.credentialResponse.$actions
+          invalidProtocolDefinition.structure.credentialApplication.records.credentialResponse.$actions
             .findIndex((allowRule) => allowRule.who === ProtocolActor.Recipient);
-        invalidProtocolDefinition.records.credentialApplication.records.credentialResponse
+        invalidProtocolDefinition.structure.credentialApplication.records.credentialResponse
           .$actions[allowRuleIndex].of
             = 'credentialResponse';
         // this is invalid as the root ancestor can only be `credentialApplication` based on record structure

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -238,14 +238,14 @@ export class TestDataGenerator {
       const generatedLabel = 'record' + TestDataGenerator.randomString(10);
 
       definition = {
-        types   : {},
-        records : {}
+        types     : {},
+        structure : {}
       };
       definition.types[generatedLabel] = {
         schema      : `test-object`,
         dataFormats : ['text/plain']
       };
-      definition.records[generatedLabel] = {};
+      definition.structure[generatedLabel] = {};
     }
 
     // TODO: #139 - move protocol definition out of the descriptor - https://github.com/TBD54566975/dwn-sdk-js/issues/139

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -13,7 +13,7 @@ describe('ProtocolsConfigure schema definition', () => {
           dataFormats : ['text/plain']
         }
       },
-      records: {
+      structure: {
         email: {
           $actions: [
             {

--- a/tests/vectors/protocol-definitions/credential-issuance.json
+++ b/tests/vectors/protocol-definitions/credential-issuance.json
@@ -9,7 +9,7 @@
       "dataFormats": ["application/json"]
     }
   },
-  "records": {
+  "structure": {
     "credentialApplication": {
       "$actions": [
         {

--- a/tests/vectors/protocol-definitions/dex.json
+++ b/tests/vectors/protocol-definitions/dex.json
@@ -13,7 +13,7 @@
       "dataFormats": ["application/json"]
     }
   },
-  "records": {
+  "structure": {
     "ask": {
       "$actions": [
         {

--- a/tests/vectors/protocol-definitions/email.json
+++ b/tests/vectors/protocol-definitions/email.json
@@ -5,7 +5,7 @@
       "dataFormats": ["text/plain"]
     }
   },
-  "records": {
+  "structure": {
     "email": {
       "$actions": [
         {

--- a/tests/vectors/protocol-definitions/message.json
+++ b/tests/vectors/protocol-definitions/message.json
@@ -5,7 +5,7 @@
       "dataFormats": ["text/plain"]
     }
   },
-  "records": {
+  "structure": {
     "message": {
       "$actions": [
         {

--- a/tests/vectors/protocol-definitions/minimal.json
+++ b/tests/vectors/protocol-definitions/minimal.json
@@ -2,7 +2,7 @@
   "types": {
     "foo": {}
   },
-  "records": {
+  "structure": {
     "foo": {}
   }
 }

--- a/tests/vectors/protocol-definitions/private-protocol.json
+++ b/tests/vectors/protocol-definitions/private-protocol.json
@@ -1,11 +1,11 @@
 {
-    "types": {
-      "privateNote": {
-        "schema": "private-note",
-        "dataFormats": ["text/plain"]
-      }
-    },
-    "records": {
-      "privateNote": {}
+  "types": {
+    "privateNote": {
+      "schema": "private-note",
+      "dataFormats": ["text/plain"]
     }
+  },
+  "structure": {
+    "privateNote": {}
   }
+}

--- a/tests/vectors/protocol-definitions/social-media.json
+++ b/tests/vectors/protocol-definitions/social-media.json
@@ -17,7 +17,7 @@
       "dataFormats": ["text/plain"]
     }
   },
-  "records": {
+  "structure": {
     "message": {
       "$actions": [
         {


### PR DESCRIPTION
Keeping this one short. In the next PR, I'll remove `records` from the `ProtocolRuleSets` so we don't have to repeat it all over the place.