### PR TITLE
#345 - Require `of` in protocol action rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.21%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.93%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.21%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.63%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.02%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-92.3%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.63%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/json-schemas/protocol-rule-set.json
+++ b/json-schemas/protocol-rule-set.json
@@ -9,31 +9,57 @@
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": [
-          "who",
-          "can"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "who": {
-            "type": "string",
-            "enum": [
-              "anyone",
-              "author",
-              "recipient"
-            ]
+        "anyOf": [
+          {
+            "required": [
+              "who",
+              "can"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "who": {
+                "type": "string",
+                "enum": [
+                  "anyone"
+                ]
+              },
+              "can": {
+                "type": "string",
+                "enum": [
+                  "read",
+                  "write"
+                ]
+              }
+            }
           },
-          "of": {
-            "type": "string"
-          },
-          "can": {
-            "type": "string",
-            "enum": [
-              "read",
-              "write"
-            ]
+          {
+            "required": [
+              "who",
+              "of",
+              "can"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "who": {
+                "type": "string",
+                "enum": [
+                  "author",
+                  "recipient"
+                ]
+              },
+              "of": {
+                "type": "string"
+              },
+              "can": {
+                "type": "string",
+                "enum": [
+                  "read",
+                  "write"
+                ]
+              }
+            }
           }
-        }
+        ]
       }
     },
     "records": {

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -291,44 +291,44 @@ export class ProtocolAuthorization {
     const actionRules = inboundMessageRuleSet.$actions;
 
     if (actionRules === undefined) {
-      // if no allow rule is defined, owner of DWN can do everything
+      // if no action rule is defined, owner of DWN can do everything
       if (requesterDid === tenant) {
         return;
       } else {
-        throw new Error(`no allow rule defined for ${incomingMessageMethod}, ${requesterDid} is unauthorized`);
+        throw new Error(`no action rule defined for ${incomingMessageMethod}, ${requesterDid} is unauthorized`);
       }
     }
 
     const allowedActions = new Set<string>();
-    for (const allowRule of actionRules) {
-      switch (allowRule.who) {
+    for (const actionRule of actionRules) {
+      switch (actionRule.who) {
       case ProtocolActor.Anyone:
-        allowedActions.add(allowRule.can);
+        allowedActions.add(actionRule.can);
         break;
       case ProtocolActor.Author:
         const messageForAuthorCheck = ProtocolAuthorization.getMessage(
           ancestorMessageChain,
-          allowRule.of!,
+          actionRule.of!,
         );
 
         if (messageForAuthorCheck !== undefined) {
           const expectedRequesterDid = Message.getAuthor(messageForAuthorCheck);
 
           if (requesterDid === expectedRequesterDid) {
-            allowedActions.add(allowRule.can);
+            allowedActions.add(actionRule.can);
           }
         }
         break;
       case ProtocolActor.Recipient:
         const messageForRecipientCheck = ProtocolAuthorization.getMessage(
           ancestorMessageChain,
-            allowRule.of!,
+            actionRule.of!,
         );
         if (messageForRecipientCheck !== undefined) {
           const expectedRequesterDid = messageForRecipientCheck.descriptor.recipient;
 
           if (requesterDid === expectedRequesterDid) {
-            allowedActions.add(allowRule.can);
+            allowedActions.add(actionRule.can);
           }
         }
         break;

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1212,10 +1212,10 @@ describe('RecordsWriteHandler.handle()', () => {
         expect(nestedCredentialApplicationReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationMissingRuleSet);
       });
 
-      it('should only allow DWN owner to write if record does not have an allow rule defined', async () => {
+      it('should only allow DWN owner to write if record does not have an action rule defined', async () => {
         const alice = await DidKeyResolver.generate();
 
-        // write a protocol definition without an explicit allow rule
+        // write a protocol definition without an explicit action rule
         const protocol = 'private-protocol';
         const protocolDefinition = privateProtocol;
         const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
@@ -1256,7 +1256,7 @@ describe('RecordsWriteHandler.handle()', () => {
 
         reply = await dwn.processMessage(alice.did, bobWriteMessageData.message, bobWriteMessageData.dataStream);
         expect(reply.status.code).to.equal(401);
-        expect(reply.status.detail).to.contain(`no allow rule defined for Write`);
+        expect(reply.status.detail).to.contain(`no action rule defined for Write`);
       });
 
       it('should fail authorization if path to expected recipient in definition has incorrect label', async () => {
@@ -1265,11 +1265,11 @@ describe('RecordsWriteHandler.handle()', () => {
 
         // create an invalid ancestor path that is longer than possible
         const invalidProtocolDefinition = { ...credentialIssuanceProtocolDefinition };
-        const allowRuleIndex =
+        const actionRuleIndex =
           invalidProtocolDefinition.records.credentialApplication.records.credentialResponse.$actions
-            .findIndex((allowRule) => allowRule.who === ProtocolActor.Recipient);
+            .findIndex((actionRule) => actionRule.who === ProtocolActor.Recipient);
         invalidProtocolDefinition.records.credentialApplication.records.credentialResponse
-          .$actions[allowRuleIndex].of
+          .$actions[actionRuleIndex].of
             = 'credentialResponse';
         // this is invalid as the root ancestor can only be `credentialApplication` based on record structure
 
@@ -1317,7 +1317,7 @@ describe('RecordsWriteHandler.handle()', () => {
         expect(reply.status.detail).to.contain('mismatching record schema');
       });
 
-      it('should look up recipient path with ancestor depth of 2+ (excluding self) in allow rule correctly', async () => {
+      it('should look up recipient path with ancestor depth of 2+ (excluding self) in action rule correctly', async () => {
         // simulate a DEX protocol with at least 3 layers of message exchange: ask -> offer -> fulfillment
         // make sure recipient of offer can send fulfillment
 

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -44,7 +44,7 @@ describe('ProtocolsConfigure schema definition', () => {
 
     expect(() => {
       Message.validateJsonSchema(message);
-    }).throws('/$actions/0'); //
+    }).throws('/$actions/0');
   });
 
   describe('rule-set tests', () => {

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -85,5 +85,19 @@ describe('ProtocolsConfigure schema definition', () => {
         validateJsonSchema('ProtocolRuleSet', invalidRuleSet);
       }).throws('/$actions/0');
     });
+
+    it('#183 - should throw if `of` is present in `anyone` rule-set', async () => {
+      const invalidRuleSet = {
+        $actions: [{
+          who : 'anyone',
+          of: 'thread', // intentionally present
+          can : 'read'
+        }]
+      };
+
+      expect(() => {
+        validateJsonSchema('ProtocolRuleSet', invalidRuleSet);
+      }).throws('/$actions/0');
+    });
   });
 });

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -5,7 +5,7 @@ import { DwnInterfaceName, DwnMethodName, Message } from '../../../../src/core/m
 import type { ProtocolDefinition, ProtocolsConfigureMessage } from '../../../../src/interfaces/protocols/types.js';
 
 describe('ProtocolsConfigure schema definition', () => {
-  it('should throw if unknown actor is encountered in allow rule', async () => {
+  it('should throw if unknown actor is encountered in action rule', async () => {
     const protocolDefinition: ProtocolDefinition = {
       types: {
         email: {
@@ -44,48 +44,46 @@ describe('ProtocolsConfigure schema definition', () => {
 
     expect(() => {
       Message.validateJsonSchema(message);
-    }).throws('who: must be equal to one of the allowed values');
+    }).throws('/$actions/0'); //
   });
 
   describe('rule-set tests', () => {
-    it('#183 - should throw if required `to` is missing in rule-set', async () => {
+    it('#183 - should throw if required `can` is missing in rule-set', async () => {
       const invalidRuleSet1 = {
-        allow: {
-          anyone: {
-          // to: ['write'] // intentionally missing
-          }
-        }
+        $actions: [{
+          who : 'author',
+          of  : 'thread',
+          // can: 'read'  // intentionally missing
+        }]
       };
 
       const invalidRuleSet2 = {
-        allow: {
-          recipient: {
-            of: 'thread'
-          // to: ['write'] // intentionally missing
-          }
-        }
+        $actions: [{
+          who : 'recipient',
+          of  : 'thread',
+          // can: 'read'  // intentionally missing
+        }]
       };
 
       for (const ruleSet of [invalidRuleSet1, invalidRuleSet2]) {
         expect(() => {
           validateJsonSchema('ProtocolRuleSet', ruleSet);
-        }).throws(); // error message is misleading thus not checking explicitly
+        }).throws('/$actions/0');
       }
     });
 
     it('#183 - should throw if required `of` is missing in rule-set', async () => {
       const invalidRuleSet = {
-        allow: {
-          recipient: {
-          // of : 'thread', // intentionally missing
-            to: ['write']
-          }
-        }
+        $actions: [{
+          who : 'author',
+          // of: 'thread', // intentionally missing
+          can : 'read'
+        }]
       };
 
       expect(() => {
         validateJsonSchema('ProtocolRuleSet', invalidRuleSet);
-      }).throws(); // error message is misleading thus not checking explicitly
+      }).throws('/$actions/0');
     });
   });
 });

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -90,7 +90,7 @@ describe('ProtocolsConfigure schema definition', () => {
       const invalidRuleSet = {
         $actions: [{
           who : 'anyone',
-          of: 'thread', // intentionally present
+          of  : 'thread', // intentionally present
           can : 'read'
         }]
       };


### PR DESCRIPTION
#345

Tweaking JSON schema and making tests hopefully a little more robust in order to enforce presence of `of` when `who` === `author` or `recipient`.