### PR TITLE
Remove records keyword from protocol definitions

### DIFF
--- a/json-schemas/protocol-rule-set.json
+++ b/json-schemas/protocol-rule-set.json
@@ -61,14 +61,11 @@
           }
         ]
       }
-    },
-    "records": {
-      "type": "object",
-      "patternProperties": {
-        ".*": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/protocol-rule-set.json"
-        }
-      }
+    }
+  },
+  "patternProperties": {
+    "^[^$].*": {
+      "$ref": "https://identity.foundation/dwn/json-schemas/protocol-rule-set.json"
     }
   }
 }

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -178,11 +178,11 @@ export class ProtocolAuthorization {
     const protocolPathArray = protocolPath.split('/');
 
     // traverse rule sets using protocolPath
-    let currentRuleSet: ProtocolRuleSet = { records: protocolDefinition.structure };
+    let currentRuleSet: ProtocolRuleSet = protocolDefinition.structure;
     let i = 0;
     while (i < protocolPathArray.length) {
       const currentTypeName = protocolPathArray[i];
-      const nextRuleSet = currentRuleSet.records?.[currentTypeName];
+      const nextRuleSet: ProtocolRuleSet | undefined = currentRuleSet[currentTypeName];
 
       if (nextRuleSet === undefined) {
         const partialProtocolPath = protocolPathArray.slice(0, i + 1).join('/');

--- a/src/interfaces/protocols/types.ts
+++ b/src/interfaces/protocols/types.ts
@@ -36,15 +36,16 @@ export enum ProtocolAction {
   Write = 'write'
 }
 
+export type ProtocolActionRule = {
+  who: string,
+  of?: string,
+  can: string
+};
+
 export type ProtocolRuleSet = {
-  $actions?: {
-    who: string,
-    of?: string,
-    can: string
-  }[];
-  records?: {
-    [key: string]: ProtocolRuleSet;
-  }
+  $actions?: ProtocolActionRule[];
+  // JSON Schema verifies that properties other than `$actions` will actually have type ProtocolRuleSet
+  [key: string]: any;
 };
 
 export type ProtocolsConfigureMessage = BaseMessage & {

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -1266,9 +1266,9 @@ describe('RecordsWriteHandler.handle()', () => {
         // create an invalid ancestor path that is longer than possible
         const invalidProtocolDefinition = { ...credentialIssuanceProtocolDefinition };
         const actionRuleIndex =
-          invalidProtocolDefinition.structure.credentialApplication.records.credentialResponse.$actions
+          invalidProtocolDefinition.structure.credentialApplication.credentialResponse.$actions
             .findIndex((actionRule) => actionRule.who === ProtocolActor.Recipient);
-        invalidProtocolDefinition.structure.credentialApplication.records.credentialResponse
+        invalidProtocolDefinition.structure.credentialApplication.credentialResponse
           .$actions[actionRuleIndex].of
             = 'credentialResponse';
         // this is invalid as the root ancestor can only be `credentialApplication` based on record structure

--- a/tests/vectors/protocol-definitions/credential-issuance.json
+++ b/tests/vectors/protocol-definitions/credential-issuance.json
@@ -17,16 +17,14 @@
           "can": "write"
         }
       ],
-      "records": {
-        "credentialResponse": {
-          "$actions": [
-            {
-              "who": "recipient",
-              "of": "credentialApplication",
-              "can": "write"
-            }
-          ]
-        }
+      "credentialResponse": {
+        "$actions": [
+          {
+            "who": "recipient",
+            "of": "credentialApplication",
+            "can": "write"
+          }
+        ]
       }
     }
   }

--- a/tests/vectors/protocol-definitions/dex.json
+++ b/tests/vectors/protocol-definitions/dex.json
@@ -21,26 +21,22 @@
           "can": "write"
         }
       ],
-      "records": {
-        "offer": {
+      "offer": {
+        "$actions": [
+          {
+            "who": "recipient",
+            "of": "ask",
+            "can": "write"
+          }
+        ],
+        "fulfillment": {
           "$actions": [
             {
               "who": "recipient",
-              "of": "ask",
+              "of": "ask/offer",
               "can": "write"
             }
-          ],
-          "records": {
-            "fulfillment": {
-              "$actions": [
-                {
-                  "who": "recipient",
-                  "of": "ask/offer",
-                  "can": "write"
-                }
-              ]
-            }
-          }
+          ]
         }
       }
     }

--- a/tests/vectors/protocol-definitions/email.json
+++ b/tests/vectors/protocol-definitions/email.json
@@ -23,25 +23,23 @@
           "can": "read"
         }
       ],
-      "records": {
-        "email": {
-          "$actions": [
-            {
-              "who": "anyone",
-              "can": "write"
-            },
-            {
-              "who": "author",
-              "of": "email/email",
-              "can": "read"
-            },
-            {
-              "who": "recipient",
-              "of": "email/email",
-              "can": "read"
-            }
-          ]
-        }
+      "email": {
+        "$actions": [
+          {
+            "who": "anyone",
+            "can": "write"
+          },
+          {
+            "who": "author",
+            "of": "email/email",
+            "can": "read"
+          },
+          {
+            "who": "recipient",
+            "of": "email/email",
+            "can": "read"
+          }
+        ]
       }
     }
   }

--- a/tests/vectors/protocol-definitions/social-media.json
+++ b/tests/vectors/protocol-definitions/social-media.json
@@ -25,16 +25,14 @@
           "can": "write"
         }
       ],
-      "records": {
-        "reply": {
-          "$actions": [
-            {
-              "who": "recipient",
-              "of": "message",
-              "can": "write"
-            }
-          ]
-        }
+      "reply": {
+        "$actions": [
+          {
+            "who": "recipient",
+            "of": "message",
+            "can": "write"
+          }
+        ]
       }
     },
     "image": {
@@ -48,34 +46,32 @@
           "can": "write"
         }
       ],
-      "records": {
-        "caption": {
-          "$actions": [
-            {
-              "who": "anyone",
-              "can": "read"
-            },
-            {
-              "who": "author",
-              "of": "image",
-              "can": "write"
-            }
-          ]
-        },
-        "reply": {
-          "$actions": [
-            {
-              "who": "author",
-              "of": "image",
-              "can": "read"
-            },
-            {
-              "who": "recipient",
-              "of": "image",
-              "can": "write"
-            }
-          ]
-        }
+      "caption": {
+        "$actions": [
+          {
+            "who": "anyone",
+            "can": "read"
+          },
+          {
+            "who": "author",
+            "of": "image",
+            "can": "write"
+          }
+        ]
+      },
+      "reply": {
+        "$actions": [
+          {
+            "who": "author",
+            "of": "image",
+            "can": "read"
+          },
+          {
+            "who": "recipient",
+            "of": "image",
+            "can": "write"
+          }
+        ]
       }
     }
   }


### PR DESCRIPTION
Last change we have planned for the protocol definition DSL. Remove `records` from `ProtocolRuleSets`.

There are some tradeoffs about different ways to structure `type ProtocolRuleSet` so it is ergonomic for consumers of `dwn-sdk-js`. The requirements are:
1. The `$actions` field must be optional and will have type `ProtocolActionRule` when it is present.
2. Any other string property will have type `ProtocolRuleSet`.

### Option 1: `any`
In my opinion, this is the least gross option. All other options entail writing unsightly typescript.

Benefit: Doesn't require lots of `(...as ProtocolActionRule)` or `(...as ProtocolRuleSet), and doesn't involve weird `Symbol` conversion logic.
Drawback: Least strict typing. Not very different from vanilla JS experience.

```typescript
export type ProtocolRuleSet = {
  $actions?: ProtocolActionRule[];
  // JSON Schema verifies that properties other than `$actions` will actually have type ProtocolRuleSet
  [key: string]: any;
}

// The following all transpile, but results may have type `any`
const ruleSet: ProtocolRuleSet = {
  $actions: [{ who: 'anyone', can: 'read' }],
  ask: {
    $actions: [{ who: 'anyone', can: 'read' }],
    offer: {
      $actions: [{ who: 'anyone', can: 'read' }],
      fulfillment: {}
    }
  }
};

ruleSet.$actions;
ruleSet.$actions![0].who;
ruleSet.ask.foo.fulfillment; // still transpiles because `ask` is `any`
(ruleSet.ask as ProtocolRuleSet).$actions?.[0].who;
```

### Option 2: Symbols
Benefit: Allows good typing of each nested `ProtocolRuleSet`
Drawback: Every time we ingest or send a protocol definition, we need to parse through it and replace string `$actions` with the symbol. I find this kinda gross and error prone to need to call `toSymbol(protocol)` and `stringToSymbol(protocol)` throughout the code and in tests. More importantly app developers would need to make this conversion all over the place too.

```typescript
const $ACTIONS = Symbol('$actions');

export type ProtocolRuleSet = {
  [$ACTIONS]?: ProtocolActionRule[];
  [key: string]: ProtocolRuleSet;
}

const ruleSet: ProtocolRuleSet = {
  [$ACTIONS]: [{ who: 'anyone', can: 'read' }],
  ask: {
    [$ACTIONS]: [{ who: 'anyone', can: 'read' }],
    offer: {
      [$ACTIONS]: [{ who: 'anyone', can: 'read' }],
      fulfillment: {}
    }
  }
};

ruleSet[$ACTIONS];
ruleSet[$ACTIONS]?.[0].who;
ruleSet.ask.offer.fulfillment;
ruleSet.ask[$ACTIONS]?.[0].who;
```

### Option 3: Too many `as`
```typescript
export type ProtocolRuleSet = {
  $actions?: ProtocolActionRule[];
  [key: string]: ProtocolRuleSet | ProtocolActionRule[] | undefined;
}

const ruleSet: ProtocolRuleSet = {
  $actions: [{ who: 'anyone', can: 'read' }],
  ask: {
    $actions: [{ who: 'anyone', can: 'read' }],
    offer: {
      actions: [{ who: 'anyone', can: 'read' }],
      fulfillment: {}
    }
  }
};

ruleSet.$actions;
ruleSet.$actions?.[0].who;
// ruleSet.ask.offer.fulfillment; // Does not transpile
((ruleSet.ask as ProtocolRuleSet)?.offer as ProtocolRuleSet)?.fulfillment;
((ruleSet.ask as ProtocolRuleSet).$actions as (ProtocolActionRule | undefined))?.[0].who;
```