### PR TITLE
#284 - allowed `recipient` only if `protocol` exists in a RecordsWrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.7%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.15%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.15%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.7%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.7%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.16%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.15%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.7%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-94.69%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.15%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.15%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.69%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-94.7%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.15%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.15%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-94.7%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/json-schemas/records/records-write.json
+++ b/json-schemas/records/records-write.json
@@ -148,6 +148,11 @@
         "dateModified",
         "dataFormat"
       ],
+      "dependencies": {
+        "recipient": [
+          "protocol"
+        ]
+      },
       "allOf": [
         {
           "$comment": "rule defining `published` and `datePublished` relationship",
@@ -197,36 +202,6 @@
                     ]
                   }
                 }
-              ]
-            }
-          ]
-        },
-        {
-          "$comment": "rule: `recipient` can only exist if `protocol` exists`",
-          "anyOf": [
-            {
-              "$comment": "both `protocol` and `recipient` are not allowed",
-              "allOf": [
-                {
-                  "not": {
-                    "required": [
-                      "protocol"
-                    ]
-                  }
-                },
-                {
-                  "not": {
-                    "required": [
-                      "recipient"
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "$comment": "only `protocol` is required",
-              "required": [
-                "protocol"
               ]
             }
           ]

--- a/json-schemas/records/records-write.json
+++ b/json-schemas/records/records-write.json
@@ -200,6 +200,36 @@
               ]
             }
           ]
+        },
+        {
+          "$comment": "rule: `recipient` can only exist if `protocol` exists`",
+          "anyOf": [
+            {
+              "$comment": "both `protocol` and `recipient` are not allowed",
+              "allOf": [
+                {
+                  "not": {
+                    "required": [
+                      "protocol"
+                    ]
+                  }
+                },
+                {
+                  "not": {
+                    "required": [
+                      "recipient"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "$comment": "only `protocol` is required",
+              "required": [
+                "protocol"
+              ]
+            }
+          ]
         }
       ]
     }

--- a/src/interfaces/records/messages/records-query.ts
+++ b/src/interfaces/records/messages/records-query.ts
@@ -66,11 +66,11 @@ export class RecordsQuery extends Message<RecordsQueryMessage> {
     }
 
     // extra checks if a recipient filter is specified
-    const recipientDid = this.message.descriptor.filter.recipient;
-    if (recipientDid !== undefined) {
+    const recipient = this.message.descriptor.filter.recipient;
+    if (recipient !== undefined) {
       // make sure the recipient is the author
-      if (recipientDid !== this.author) {
-        throw new Error(`${this.author} is not allowed to query records intended for another recipient: ${recipientDid}`);
+      if (recipient !== this.author) {
+        throw new Error(`${this.author} is not allowed to query records intended for another recipient: ${recipient}`);
       }
     }
   }

--- a/src/interfaces/records/messages/records-write.ts
+++ b/src/interfaces/records/messages/records-write.ts
@@ -168,7 +168,7 @@ export class RecordsWrite extends Message<RecordsWriteMessage> {
       method        : DwnMethodName.Write,
       protocol      : options.protocol !== undefined ? normalizeProtocolUrl(options.protocol) : undefined,
       protocolPath  : options.protocolPath,
-      recipient     : options.recipient!,
+      recipient     : options.recipient,
       schema        : options.schema !== undefined ? normalizeSchemaUrl(options.schema) : undefined,
       parentId      : options.parentId,
       dataCid,

--- a/src/interfaces/records/types.ts
+++ b/src/interfaces/records/types.ts
@@ -13,7 +13,7 @@ export type RecordsWriteDescriptor = {
   method: DwnMethodName.Write;
   protocol?: string;
   protocolPath?: string;
-  recipient: string;
+  recipient?: string;
   schema?: string;
   parentId?: string;
   dataCid: string;

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -463,10 +463,10 @@ describe('RecordsQueryHandler.handle()', () => {
         { requester: alice, schema, data: Encoder.stringToBytes('1') }
       );
       const record2Data = await TestDataGenerator.generateRecordsWrite(
-        { requester: alice, schema, protocol: 'protocol', protocolPath: 'path', recipientDid: bob.did, data: Encoder.stringToBytes('2') }
+        { requester: alice, schema, protocol: 'protocol', protocolPath: 'path', recipient: bob.did, data: Encoder.stringToBytes('2') }
       );
       const record3Data = await TestDataGenerator.generateRecordsWrite(
-        { requester: bob, schema, protocol: 'protocol', protocolPath: 'path', recipientDid: alice.did, data: Encoder.stringToBytes('3') }
+        { requester: bob, schema, protocol: 'protocol', protocolPath: 'path', recipient: alice.did, data: Encoder.stringToBytes('3') }
       );
       const record4Data = await TestDataGenerator.generateRecordsWrite(
         { requester: alice, schema, data: Encoder.stringToBytes('4'), published: true }

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -463,10 +463,10 @@ describe('RecordsQueryHandler.handle()', () => {
         { requester: alice, schema, data: Encoder.stringToBytes('1') }
       );
       const record2Data = await TestDataGenerator.generateRecordsWrite(
-        { requester: alice, schema, data: Encoder.stringToBytes('2'), recipientDid: bob.did }
+        { requester: alice, schema, protocol: 'protocol', protocolPath: 'path', recipientDid: bob.did, data: Encoder.stringToBytes('2') }
       );
       const record3Data = await TestDataGenerator.generateRecordsWrite(
-        { requester: bob, recipientDid: alice.did, schema, data: Encoder.stringToBytes('3') }
+        { requester: bob, schema, protocol: 'protocol', protocolPath: 'path', recipientDid: alice.did, data: Encoder.stringToBytes('3') }
       );
       const record4Data = await TestDataGenerator.generateRecordsWrite(
         { requester: alice, schema, data: Encoder.stringToBytes('4'), published: true }

--- a/tests/interfaces/records/handlers/records-read.spec.ts
+++ b/tests/interfaces/records/handlers/records-read.spec.ts
@@ -179,7 +179,7 @@ describe('RecordsReadHandler.handle()', () => {
           schema       : protocolDefinition.types.image.schema,
           dataFormat   : 'image/jpeg',
           data         : encodedImage,
-          recipientDid : alice.did
+          recipient    : alice.did
         });
         const imageReply = await dwn.processMessage(alice.did, imageRecordsWrite.message, imageRecordsWrite.dataStream);
         expect(imageReply.status.code).to.equal(202);
@@ -220,7 +220,7 @@ describe('RecordsReadHandler.handle()', () => {
           schema       : protocolDefinition.types.email.schema,
           dataFormat   : protocolDefinition.types.email.dataFormats[0],
           data         : encodedEmail,
-          recipientDid : bob.did
+          recipient    : bob.did
         });
         const imageReply = await dwn.processMessage(alice.did, emailRecordsWrite.message, emailRecordsWrite.dataStream);
         expect(imageReply.status.code).to.equal(202);
@@ -269,7 +269,7 @@ describe('RecordsReadHandler.handle()', () => {
           schema       : protocolDefinition.types.email.schema,
           dataFormat   : protocolDefinition.types.email.dataFormats[0],
           data         : encodedEmail,
-          recipientDid : alice.did
+          recipient    : alice.did
         });
         const imageReply = await dwn.processMessage(alice.did, emailRecordsWrite.message, emailRecordsWrite.dataStream);
         expect(imageReply.status.code).to.equal(202);

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -348,7 +348,7 @@ describe('RecordsWriteHandler.handle()', () => {
       const write2Change = await TestDataGenerator.generateRecordsWrite({
         requester    : alice,
         // immutable properties just inherit from the message given
-        recipientDid : write2.message.descriptor.recipient,
+        recipient    : write2.message.descriptor.recipient,
         recordId     : write2.message.recordId,
         dateCreated  : write2.message.descriptor.dateCreated,
         contextId    : write2.message.contextId,
@@ -637,7 +637,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const encodedCredentialApplication = new TextEncoder().encode('credential application data');
         const credentialApplication = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
-          recipientDid : vcIssuer.did,
+          recipient    : vcIssuer.did,
           protocol     : protocolDefinition.protocol,
           protocolPath : 'credentialApplication', // this comes from `types` in protocol definition
           schema       : credentialApplicationSchema,
@@ -654,7 +654,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const credentialResponse = await TestDataGenerator.generateRecordsWrite(
           {
             requester    : vcIssuer,
-            recipientDid : alice.did,
+            recipient    : alice.did,
             protocol     : protocolDefinition.protocol,
             protocolPath : 'credentialApplication/credentialResponse', // this comes from `types` in protocol definition
             contextId    : credentialApplicationContextId,
@@ -888,8 +888,8 @@ describe('RecordsWriteHandler.handle()', () => {
         expect(carolWriteReply.status.detail).to.contain('must match to author of initial write');
       });
 
-      it('should not allow to change immutable recipientDid', async () => {
-        // scenario: Bob writes into Alice's DWN given Alice's "message" protocol allow-anyone rule, then tries to modify immutable recipientDid
+      it('should not allow to change immutable recipient', async () => {
+        // scenario: Bob writes into Alice's DWN given Alice's "message" protocol allow-anyone rule, then tries to modify immutable recipient
 
         // NOTE: no need to test the same for parent, protocol, and contextId
         // because changing them will result in other error conditions
@@ -937,7 +937,7 @@ describe('RecordsWriteHandler.handle()', () => {
         expect(bobRecordQueryReply.entries?.length).to.equal(1);
         expect(bobRecordQueryReply.entries![0].encodedData).to.equal(base64url.baseEncode(bobData));
 
-        // generate a new message from bob changing immutable recipientDid
+        // generate a new message from bob changing immutable recipient
         const updatedMessageFromBob = await TestDataGenerator.generateRecordsWrite(
           {
             requester    : bob,
@@ -948,7 +948,7 @@ describe('RecordsWriteHandler.handle()', () => {
             dataFormat   : protocolDefinition.types.message.dataFormats[0],
             data         : bobData,
             recordId     : messageFromBob.message.recordId,
-            recipientDid : bob.did // this immutable property was Alice's DID initially
+            recipient    : bob.did // this immutable property was Alice's DID initially
           }
         );
 
@@ -985,7 +985,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const encodedCredentialApplication = new TextEncoder().encode('credential application data');
         const credentialApplication = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
-          recipientDid : vcIssuer.did,
+          recipient    : vcIssuer.did,
           protocol,
           protocolPath : 'credentialApplication', // this comes from `types` in protocol definition
           schema       : credentialApplicationSchema,
@@ -1002,7 +1002,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const credentialResponse = await TestDataGenerator.generateRecordsWrite(
           {
             requester    : fakeVcIssuer,
-            recipientDid : alice.did,
+            recipient    : alice.did,
             protocol,
             protocolPath : 'credentialApplication/credentialResponse', // this comes from `types` in protocol definition
             contextId    : credentialApplicationContextId,
@@ -1024,7 +1024,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const data = Encoder.stringToBytes('any data');
         const credentialApplication = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
-          recipientDid : alice.did,
+          recipient    : alice.did,
           protocol,
           protocolPath : 'credentialApplication/credentialResponse', // this comes from `types` in protocol definition
           data
@@ -1051,7 +1051,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const data = Encoder.stringToBytes('any data');
         const credentialApplication = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
-          recipientDid : alice.did,
+          recipient    : alice.did,
           protocol,
           protocolPath : 'credentialApplication', // this comes from `types` in protocol definition
           schema       : 'unexpectedSchema',
@@ -1080,7 +1080,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const data = Encoder.stringToBytes('any data');
         const credentialApplication = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
-          recipientDid : alice.did,
+          recipient    : alice.did,
           protocol,
           protocolPath : 'invalidType',
           data
@@ -1107,7 +1107,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const data = Encoder.stringToBytes('any data');
         const credentialApplication = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
-          recipientDid : alice.did,
+          recipient    : alice.did,
           protocol,
           protocolPath : 'credentialApplication/credentialResponse', // incorrect path. correct path is `credentialResponse` because this record has no parent
           schema       : protocolDefinition.types.credentialApplication.schema,
@@ -1137,7 +1137,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const data = Encoder.stringToBytes('any data');
         const recordsWriteMatch = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
-          recipientDid : alice.did,
+          recipient    : alice.did,
           protocol,
           protocolPath : 'image',
           schema       : protocolDefinition.types.image.schema,
@@ -1150,7 +1150,7 @@ describe('RecordsWriteHandler.handle()', () => {
         // write record with mismatch dataFormat
         const recordsWriteMismatch = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
-          recipientDid : alice.did,
+          recipient    : alice.did,
           protocol,
           protocolPath : 'image',
           schema       : protocolDefinition.types.image.schema,
@@ -1183,7 +1183,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const data = Encoder.stringToBytes('any data');
         const failedCredentialResponse = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
-          recipientDid : alice.did,
+          recipient    : alice.did,
           protocol,
           protocolPath : 'credentialResponse',
           schema       : credentialResponseSchema, // this is a known schema type, but not allowed for a protocol root record
@@ -1197,7 +1197,7 @@ describe('RecordsWriteHandler.handle()', () => {
         // Successfully write a 'credentialApplication' at the top level of the of the record hierarchy
         const credentialApplication = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
-          recipientDid : alice.did,
+          recipient    : alice.did,
           protocol,
           protocolPath : 'credentialApplication', // allowed at root level
           schema       : credentialApplicationSchema,
@@ -1210,7 +1210,7 @@ describe('RecordsWriteHandler.handle()', () => {
         // Try and fail to write another 'credentialApplication' below the first 'credentialApplication'
         const failedCredentialApplication = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
-          recipientDid : alice.did,
+          recipient    : alice.did,
           protocol,
           protocolPath : 'credentialApplication/credentialApplication', // credentialApplications may not be nested below another credentialApplication
           schema       : credentialApplicationSchema,
@@ -1226,7 +1226,7 @@ describe('RecordsWriteHandler.handle()', () => {
         // Successfully write a 'credentialResponse' below the 'credentialApplication'
         const credentialResponse = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
-          recipientDid : alice.did,
+          recipient    : alice.did,
           protocol,
           protocolPath : 'credentialApplication/credentialResponse',
           schema       : credentialResponseSchema,
@@ -1241,7 +1241,7 @@ describe('RecordsWriteHandler.handle()', () => {
         // Testing case where there is no rule set for any record type at the given level in the hierarchy
         const nestedCredentialApplication = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
-          recipientDid : alice.did,
+          recipient    : alice.did,
           protocol,
           protocolPath : 'credentialApplication/credentialResponse/credentialApplication',
           schema       : credentialApplicationSchema,
@@ -1273,7 +1273,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const data = Encoder.stringToBytes('any data');
         const aliceWriteMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
-          recipientDid : alice.did,
+          recipient    : alice.did,
           protocol,
           protocolPath : 'privateNote', // this comes from `types`
           schema       : protocolDefinition.types.privateNote.schema,
@@ -1288,7 +1288,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const bob = await DidKeyResolver.generate();
         const bobWriteMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : bob,
-          recipientDid : alice.did,
+          recipient    : alice.did,
           protocol,
           protocolPath : 'privateNote', // this comes from `types`
           schema       : 'private-note',
@@ -1330,7 +1330,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const data = Encoder.stringToBytes('irrelevant');
         const messageDataWithIssuerA = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
-          recipientDid : issuer.did,
+          recipient    : issuer.did,
           schema       : invalidProtocolDefinition.types.credentialApplication.schema,
           protocol,
           protocolPath : 'credentialApplication', // this comes from `types` in protocol definition
@@ -1344,7 +1344,7 @@ describe('RecordsWriteHandler.handle()', () => {
         // simulate issuer attempting to respond to Alice's VC application
         const invalidResponseByIssuerA = await TestDataGenerator.generateRecordsWrite({
           requester    : issuer,
-          recipientDid : alice.did,
+          recipient    : alice.did,
           schema       : invalidProtocolDefinition.types.credentialResponse.schema,
           contextId,
           parentId     : messageDataWithIssuerA.message.recordId,
@@ -1382,7 +1382,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const data = Encoder.stringToBytes('irrelevant');
         const askMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
-          recipientDid : pfi.did,
+          recipient    : pfi.did,
           schema       : protocolDefinition.types.ask.schema,
           protocol,
           protocolPath : 'ask',
@@ -1395,7 +1395,7 @@ describe('RecordsWriteHandler.handle()', () => {
 
         const offerMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : pfi,
-          recipientDid : alice.did,
+          recipient    : alice.did,
           schema       : protocolDefinition.types.offer.schema,
           contextId,
           parentId     : askMessageData.message.recordId,
@@ -1410,7 +1410,7 @@ describe('RecordsWriteHandler.handle()', () => {
         // the actual test: making sure fulfillment message is accepted
         const fulfillmentMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
-          recipientDid : pfi.did,
+          recipient    : pfi.did,
           schema       : protocolDefinition.types.fulfillment.schema,
           contextId,
           parentId     : offerMessageData.message.recordId,
@@ -1461,7 +1461,7 @@ describe('RecordsWriteHandler.handle()', () => {
         const data = Encoder.stringToBytes('irrelevant');
         const askMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
-          recipientDid : pfi.did,
+          recipient    : pfi.did,
           schema       : protocolDefinition.types.ask.schema,
           protocol,
           protocolPath : 'ask',
@@ -1475,7 +1475,7 @@ describe('RecordsWriteHandler.handle()', () => {
         // the actual test: making sure fulfillment message fails
         const fulfillmentMessageData = await TestDataGenerator.generateRecordsWrite({
           requester    : alice,
-          recipientDid : pfi.did,
+          recipient    : pfi.did,
           schema       : protocolDefinition.types.fulfillment.schema,
           contextId,
           parentId     : 'non-existent-id',
@@ -1623,7 +1623,7 @@ describe('RecordsWriteHandler.handle()', () => {
           dataFormat   : 'image/jpeg',
           dataCid, // bob learns of, and references alice's secrete data's CID
           dataSize,
-          recipientDid : alice.did
+          recipient    : alice.did
         });
         const imageReply = await dwn.processMessage(alice.did, imageRecordsWrite.message, imageRecordsWrite.dataStream);
         expect(imageReply.status.code).to.equal(400); // should be disallowed

--- a/tests/interfaces/records/messages/records-write.spec.ts
+++ b/tests/interfaces/records/messages/records-write.spec.ts
@@ -22,7 +22,6 @@ describe('RecordsWrite', () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const options = {
-        recipient                   : alice.did,
         data                        : TestDataGenerator.randomBytes(10),
         dataFormat                  : 'application/json',
         dateCreated                 : '2022-10-14T10:20:30.405060Z',
@@ -47,7 +46,6 @@ describe('RecordsWrite', () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const options = {
-        recipient                   : alice.did,
         data                        : TestDataGenerator.randomBytes(10),
         dataFormat                  : 'application/json',
         recordId                    : await TestDataGenerator.randomCborSha256Cid(),

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -86,7 +86,7 @@ export type GenerateProtocolsQueryOutput = {
 export type GenerateRecordsWriteInput = {
   requester?: Persona;
   attesters?: Persona[];
-  recipientDid?: string;
+  recipient?: string;
   protocol?: string;
   protocolPath?: string;
   contextId?: string;
@@ -320,7 +320,7 @@ export class TestDataGenerator {
     }
 
     const options: RecordsWriteOptions = {
-      recipient       : input?.recipientDid,
+      recipient       : input?.recipient,
       protocol        : input?.protocol,
       protocolPath    : input?.protocolPath,
       contextId       : input?.contextId,

--- a/tests/validation/json-schemas/records/records-write.spec.ts
+++ b/tests/validation/json-schemas/records/records-write.spec.ts
@@ -205,7 +205,7 @@ describe('RecordsWrite schema definition', () => {
     Message.validateJsonSchema(invalidMessage);
   });
 
-  it('should throw if `contextId` is set but `protocol` is missing', () => {
+  it('should throw if `contextId` is defined but `protocol` is missing', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
       contextId  : 'invalid', // must have `protocol` to exist
@@ -232,7 +232,7 @@ describe('RecordsWrite schema definition', () => {
     }).throws('must have required property \'protocol\'');
   });
 
-  it('should throw if `protocol` is set but `contextId` is missing', () => {
+  it('should throw if `protocol` is defined but `contextId` is missing', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
       descriptor : {
@@ -259,7 +259,7 @@ describe('RecordsWrite schema definition', () => {
     }).throws('must have required property \'contextId\'');
   });
 
-  it('should throw if `protocol` is set but `protocolPath` is missing', () => {
+  it('should throw if `protocol` is defined but `protocolPath` is missing', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
       contextId  : 'anyContextId', // required by protocol-based message
@@ -288,7 +288,7 @@ describe('RecordsWrite schema definition', () => {
     }).throws('descriptor: must have required property \'protocolPath\'');
   });
 
-  it('should throw if `protocolPath` is set but `protocol` is missing', () => {
+  it('should throw if `protocolPath` is defined but `protocol` is missing', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
       contextId  : 'anyContextId',
@@ -317,7 +317,7 @@ describe('RecordsWrite schema definition', () => {
     }).throws('descriptor: must have required property \'protocol\'');
   });
 
-  it('should throw if `protocol` is set but `schema` is missing', () => {
+  it('should throw if `protocol` is defined but `schema` is missing', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
       contextId  : 'anyContextId', // required by protocol-based message
@@ -345,6 +345,95 @@ describe('RecordsWrite schema definition', () => {
     expect(() => {
       Message.validateJsonSchema(invalidMessage);
     }).throws('descriptor: must have required property \'schema\'');
+  });
+
+  it('should throw if `protocol` is undefined but `recipient` is defined', () => {
+    const invalidMessage = {
+      recordId   : 'anyRecordId',
+      contextId  : 'anyContextId',
+      descriptor : {
+        interface    : 'Records',
+        method       : 'Write',
+        // protocol     : 'http://foo.bar', // intentionally missing
+        recipient    : 'did:example:anyone',
+        // protocolPath : 'foo/bar', // intentionally missing
+        schema       : 'http://foo.bar/schema',
+        dataCid      : 'anyCid',
+        dataFormat   : 'application/json',
+        dataSize     : 123,
+        dateCreated  : '2022-12-19T10:20:30.123456Z',
+        dateModified : '2022-12-19T10:20:30.123456Z'
+      },
+      authorization: {
+        payload    : 'anyPayload',
+        signatures : [{
+          protected : 'anyProtectedHeader',
+          signature : 'anySignature'
+        }]
+      }
+    };
+
+    expect(() => {
+      Message.validateJsonSchema(invalidMessage);
+    }).throws('descriptor: must have required property \'protocol\'');
+  });
+
+  it('should pass if `protocol` is defined but `recipient` undefined', () => {
+    const invalidMessage = {
+      recordId   : 'anyRecordId',
+      contextId  : 'anyContextId',
+      descriptor : {
+        interface    : 'Records',
+        method       : 'Write',
+        protocol     : 'http://foo.bar',
+        // recipient    : 'did:example:anyone', // intentionally missing
+        protocolPath : 'foo/bar',
+        schema       : 'http://foo.bar/schema',
+        dataCid      : 'anyCid',
+        dataFormat   : 'application/json',
+        dataSize     : 123,
+        dateCreated  : '2022-12-19T10:20:30.123456Z',
+        dateModified : '2022-12-19T10:20:30.123456Z'
+      },
+      authorization: {
+        payload    : 'anyPayload',
+        signatures : [{
+          protected : 'anyProtectedHeader',
+          signature : 'anySignature'
+        }]
+      }
+    };
+
+    Message.validateJsonSchema(invalidMessage);
+  });
+
+  it('should pass if `protocol` and `recipient` are both defined', () => {
+    const invalidMessage = {
+      recordId   : 'anyRecordId',
+      contextId  : 'anyContextId',
+      descriptor : {
+        interface    : 'Records',
+        method       : 'Write',
+        protocol     : 'http://foo.bar',
+        recipient    : 'did:example:anyone',
+        protocolPath : 'foo/bar',
+        schema       : 'http://foo.bar/schema',
+        dataCid      : 'anyCid',
+        dataFormat   : 'application/json',
+        dataSize     : 123,
+        dateCreated  : '2022-12-19T10:20:30.123456Z',
+        dateModified : '2022-12-19T10:20:30.123456Z'
+      },
+      authorization: {
+        payload    : 'anyPayload',
+        signatures : [{
+          protected : 'anyProtectedHeader',
+          signature : 'anySignature'
+        }]
+      }
+    };
+
+    Message.validateJsonSchema(invalidMessage);
   });
 
   it('should throw if published is false but datePublished is present', () => {


### PR DESCRIPTION
* allowed `recipient` only if `protocol` exists in a RecordsWrite
* made `recipient` an optional parameter
* opportunistic rename `recipientDid` to `recipient` for consistency