### PR TITLE
Renamed requester to author

### DIFF
--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -94,7 +94,7 @@ export async function authenticate(jws: GeneralJws | undefined, didResolver: Did
  * @throws {Error} if fails authentication
  */
 export async function authorize(tenant: string, incomingMessage: Message<BaseMessage>): Promise<void> {
-  // if author/requester is the same as the target tenant, we can directly grant access
+  // if author is the same as the target tenant, we can directly grant access
   if (incomingMessage.author === tenant) {
     return;
   } else {

--- a/src/did/did-resolver.ts
+++ b/src/did/did-resolver.ts
@@ -41,7 +41,7 @@ export class DidResolver {
    * @returns {DidResolutionResult}
    */
   public async resolve(did: string): Promise<DidResolutionResult> {
-    // naively validate requester DID
+    // naively validate the given DID
     Did.validate(did);
     const splitDID = did.split(':', 3);
 

--- a/src/interfaces/permissions/types.ts
+++ b/src/interfaces/permissions/types.ts
@@ -25,8 +25,8 @@ export type PermissionConditions = {
   // defaults to false.
   publication?: boolean
 
-  // sharedAccess indicates whether the requester has access to records authored
-  // by others. False indicates that the requester only has access to records
+  // sharedAccess indicates whether the author has access to records authored
+  // by others. False indicates that the author only has access to records
   // they authored.
   // defaults to `false`
   sharedAccess?: boolean

--- a/src/interfaces/records/handlers/records-query.ts
+++ b/src/interfaces/records/handlers/records-query.ts
@@ -76,13 +76,13 @@ export class RecordsQueryHandler implements MethodHandler {
   /**
    * Fetches the records as a non-owner, return only:
    * 1. published records; and
-   * 2. unpublished records intended for the requester (where `recipient` is the requester)
+   * 2. unpublished records intended for the query author (where `recipient` is the query author)
    */
   private async fetchRecordsAsNonOwner(tenant: string, recordsQuery: RecordsQuery)
     : Promise<RecordsWriteMessageWithOptionalEncodedData[]> {
     const publishedRecords = await this.fetchPublishedRecords(tenant, recordsQuery);
-    const unpublishedRecordsForRequester = await this.fetchUnpublishedRecordsForRequester(tenant, recordsQuery);
-    const unpublishedRecordsByRequester = await this.fetchUnpublishedRecordsByRequester(tenant, recordsQuery);
+    const unpublishedRecordsForRequester = await this.fetchUnpublishedRecordsForQueryAuthor(tenant, recordsQuery);
+    const unpublishedRecordsByRequester = await this.fetchUnpublishedRecordsByAuthor(tenant, recordsQuery);
     const records = [...publishedRecords, ...unpublishedRecordsForRequester, ...unpublishedRecordsByRequester];
     return records;
   }
@@ -104,12 +104,12 @@ export class RecordsQueryHandler implements MethodHandler {
   }
 
   /**
-   * Fetches only unpublished records that are intended for the requester (where `recipient` is the requester).
+   * Fetches only unpublished records that are intended for the query author (where `recipient` is the author).
    */
-  private async fetchUnpublishedRecordsForRequester(tenant: string, recordsQuery: RecordsQuery)
+  private async fetchUnpublishedRecordsForQueryAuthor(tenant: string, recordsQuery: RecordsQuery)
     : Promise<RecordsWriteMessageWithOptionalEncodedData[]> {
 
-    // include records where recipient is requester
+    // include records where recipient is query author
     const filter = {
       ...RecordsQuery.convertFilter(recordsQuery.message.descriptor.filter),
       interface         : DwnInterfaceName.Records,
@@ -124,12 +124,12 @@ export class RecordsQueryHandler implements MethodHandler {
   }
 
   /**
-   * Fetches only unpublished records that are authored by the requester.
+   * Fetches only unpublished records where the author is the same as the query author.
    */
-  private async fetchUnpublishedRecordsByRequester(tenant: string, recordsQuery: RecordsQuery)
+  private async fetchUnpublishedRecordsByAuthor(tenant: string, recordsQuery: RecordsQuery)
     : Promise<RecordsWriteMessageWithOptionalEncodedData[]> {
 
-    // include records where recipient is requester
+    // include records where author is the same as the query author
     const filter = {
       ...RecordsQuery.convertFilter(recordsQuery.message.descriptor.filter),
       // TODO: `recordsQuery.author` cannot be undefined until #299 is implemented (https://github.com/TBD54566975/dwn-sdk-js/issues/299)

--- a/src/interfaces/records/messages/records-read.ts
+++ b/src/interfaces/records/messages/records-read.ts
@@ -54,7 +54,7 @@ export class RecordsRead extends Message<RecordsReadMessage> {
 
   public async authorize(tenant: string, newestRecordsWrite: RecordsWrite, messageStore: MessageStore): Promise<void> {
     const { descriptor } = newestRecordsWrite.message;
-    // if author/requester is the same as the target tenant, we can directly grant access
+    // if author is the same as the target tenant, we can directly grant access
     if (this.author === tenant) {
       return;
     } else if (descriptor.published === true) {

--- a/tests/dwn.spec.ts
+++ b/tests/dwn.spec.ts
@@ -55,9 +55,9 @@ describe('DWN', () => {
     it('#224 - should be able to initialize a DWN with undefined config', async () => {
       const dwnWithoutConfig = await Dwn.create(); // without passing in a config
       const alice = await DidKeyResolver.generate();
-      const { requester, message } = await TestDataGenerator.generateRecordsQuery({ requester: alice });
+      const { author, message } = await TestDataGenerator.generateRecordsQuery({ author: alice });
 
-      const tenant = requester.did;
+      const tenant = author.did;
       const reply = await dwnWithoutConfig.processMessage(tenant, message);
 
       expect(reply.status.code).to.equal(200);
@@ -71,7 +71,7 @@ describe('DWN', () => {
       const alice = await DidKeyResolver.generate();
 
       const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({
-        requester: alice,
+        author: alice,
       });
 
       const reply = await dwn.processMessage(alice.did, message, dataStream);
@@ -81,9 +81,9 @@ describe('DWN', () => {
 
     it('should process RecordsQuery message', async () => {
       const alice = await DidKeyResolver.generate();
-      const { requester, message } = await TestDataGenerator.generateRecordsQuery({ requester: alice });
+      const { author, message } = await TestDataGenerator.generateRecordsQuery({ author: alice });
 
-      const tenant = requester.did;
+      const tenant = author.did;
       const reply = await dwn.processMessage(tenant, message);
 
       expect(reply.status.code).to.equal(200);
@@ -92,7 +92,7 @@ describe('DWN', () => {
 
     it('should process an EventsGet message', async () => {
       const alice = await DidKeyResolver.generate();
-      const { message } = await TestDataGenerator.generateEventsGet({ requester: alice });
+      const { message } = await TestDataGenerator.generateEventsGet({ author: alice });
 
       const reply: EventsGetReply = await dwn.processMessage(alice.did, message);
 
@@ -156,9 +156,9 @@ describe('DWN', () => {
       });
 
       const alice = await DidKeyResolver.generate();
-      const { requester, message } = await TestDataGenerator.generateRecordsQuery({ requester: alice });
+      const { author, message } = await TestDataGenerator.generateRecordsQuery({ author: alice });
 
-      const tenant = requester.did;
+      const tenant = author.did;
       const reply = await dwnWithConfig.processMessage(tenant, message);
 
       expect(reply.status.code).to.equal(401);
@@ -189,7 +189,7 @@ describe('DWN', () => {
       const messageCids: string[] = [];
 
       const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({
-        requester: alice
+        author: alice
       });
 
       const messageCid = await Message.getCid(recordsWrite.message);
@@ -199,7 +199,7 @@ describe('DWN', () => {
       expect(reply.status.code).to.equal(202);
 
       const { messagesGet } = await TestDataGenerator.generateMessagesGet({
-        requester: alice,
+        author: alice,
         messageCids
       });
 
@@ -221,12 +221,12 @@ describe('DWN', () => {
       const alice = await DidKeyResolver.generate();
 
       const { recordsWrite } = await TestDataGenerator.generateRecordsWrite({
-        requester: alice
+        author: alice
       });
 
       const messageCids = [await Message.getCid(recordsWrite.message)];
       const { messagesGet } = await TestDataGenerator.generateMessagesGet({
-        requester: alice,
+        author: alice,
         messageCids
       });
       (messagesGet.message as any).descriptor.interface = 'Protocols'; // Will cause interface and method check to fail
@@ -240,7 +240,7 @@ describe('DWN', () => {
     it('should allow an initial `RecordsWrite` to be written without supplying data', async () => {
       const alice = await DidKeyResolver.generate();
 
-      const { recordsWrite } = await TestDataGenerator.generateRecordsWrite({ requester: alice });
+      const { recordsWrite } = await TestDataGenerator.generateRecordsWrite({ author: alice });
 
       // simulate synchronize of pruned initial `RecordsWrite`
       const reply = await dwn.synchronizePrunedInitialRecordsWrite(alice.did, recordsWrite.message);
@@ -248,8 +248,8 @@ describe('DWN', () => {
 
       // verify `RecordsWrite` inserted can be queried but without the data returned
       const recordsQueryMessageData = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { recordId: recordsWrite.message.recordId }
+        author : alice,
+        filter : { recordId: recordsWrite.message.recordId }
       });
       const recordsQueryReply = await dwn.processMessage(alice.did, recordsQueryMessageData.message);
 
@@ -261,7 +261,7 @@ describe('DWN', () => {
       const newDataBytes = Encoder.stringToBytes('new data');
       const newDataEncoded = Encoder.bytesToBase64Url(newDataBytes);
       const newRecordsWrite = await TestDataGenerator.generateFromRecordsWrite({
-        requester     : alice,
+        author        : alice,
         existingWrite : recordsWrite,
         data          : newDataBytes
       });
@@ -297,7 +297,7 @@ describe('DWN', () => {
       });
 
       const alice = await DidKeyResolver.generate();
-      const { message } = await TestDataGenerator.generateRecordsWrite({ requester: alice });
+      const { message } = await TestDataGenerator.generateRecordsWrite({ author: alice });
 
       const reply = await dwnWithConfig.synchronizePrunedInitialRecordsWrite(alice.did, message);
 

--- a/tests/event-log/event-log-level.spec.ts
+++ b/tests/event-log/event-log-level.spec.ts
@@ -25,15 +25,15 @@ describe('EventLogLevel Tests', () => {
   });
 
   it('separates events by tenant', async () => {
-    const { requester, message } = await TestDataGenerator.generateRecordsWrite();
+    const { author, message } = await TestDataGenerator.generateRecordsWrite();
     const messageCid = await Message.getCid(message);
-    const watermark = await eventLog.append(requester.did, messageCid);
+    const watermark = await eventLog.append(author.did, messageCid);
 
-    const { requester: requester2, message: message2 } = await TestDataGenerator.generateRecordsWrite();
+    const { author: requester2, message: message2 } = await TestDataGenerator.generateRecordsWrite();
     const messageCid2 = await Message.getCid(message2);
     const watermark2 = await eventLog.append(requester2.did, messageCid2);
 
-    let events = await eventLog.getEvents(requester.did);
+    let events = await eventLog.getEvents(author.did);
     expect(events.length).to.equal(1);
     expect(events[0].watermark).to.equal(watermark);
     expect(events[0].messageCid).to.equal(messageCid);
@@ -49,21 +49,21 @@ describe('EventLogLevel Tests', () => {
   it('returns events in the order that they were appended', async () => {
     const expectedEvents: Array<Event> = [];
 
-    const { requester, message } = await TestDataGenerator.generateRecordsWrite();
+    const { author, message } = await TestDataGenerator.generateRecordsWrite();
     const messageCid = await Message.getCid(message);
-    const watermark = await eventLog.append(requester.did, messageCid);
+    const watermark = await eventLog.append(author.did, messageCid);
 
     expectedEvents.push({ watermark, messageCid });
 
     for (let i = 0; i < 9; i += 1) {
-      const { message } = await TestDataGenerator.generateRecordsWrite({ requester });
+      const { message } = await TestDataGenerator.generateRecordsWrite({ author });
       const messageCid = await Message.getCid(message);
-      const watermark = await eventLog.append(requester.did, messageCid);
+      const watermark = await eventLog.append(author.did, messageCid);
 
       expectedEvents.push({ watermark, messageCid });
     }
 
-    const events = await eventLog.getEvents(requester.did);
+    const events = await eventLog.getEvents(author.did);
     expect(events.length).to.equal(expectedEvents.length);
 
     for (let i = 0; i < 10; i += 1) {
@@ -76,21 +76,21 @@ describe('EventLogLevel Tests', () => {
     it('gets all events for a tenant if watermark is not provided', async () => {
       const expectedEvents: Event[] = [];
 
-      const { requester, message } = await TestDataGenerator.generateRecordsWrite();
+      const { author, message } = await TestDataGenerator.generateRecordsWrite();
       const messageCid = await Message.getCid(message);
 
-      const watermark = await eventLog.append(requester.did, messageCid);
+      const watermark = await eventLog.append(author.did, messageCid);
       expectedEvents.push({ messageCid, watermark });
 
       for (let i = 0; i < 9; i += 1) {
-        const { message } = await TestDataGenerator.generateRecordsWrite({ requester });
+        const { message } = await TestDataGenerator.generateRecordsWrite({ author });
         const messageCid = await Message.getCid(message);
 
-        const watermark = await eventLog.append(requester.did, messageCid);
+        const watermark = await eventLog.append(author.did, messageCid);
         expectedEvents.push({ messageCid, watermark });
       }
 
-      const events = await eventLog.getEvents(requester.did);
+      const events = await eventLog.getEvents(author.did);
       expect(events.length).to.equal(10);
 
       for (let i = 0; i < events.length; i += 1) {
@@ -100,19 +100,19 @@ describe('EventLogLevel Tests', () => {
     });
 
     it('gets all events that occured after the watermark provided', async () => {
-      const { requester, message } = await TestDataGenerator.generateRecordsWrite();
+      const { author, message } = await TestDataGenerator.generateRecordsWrite();
       const messageCid = await Message.getCid(message);
 
-      await eventLog.append(requester.did, messageCid);
+      await eventLog.append(author.did, messageCid);
 
       const messageCids: string[] = [];
       let testWatermark;
 
       for (let i = 0; i < 9; i += 1) {
-        const { message } = await TestDataGenerator.generateRecordsWrite({ requester });
+        const { message } = await TestDataGenerator.generateRecordsWrite({ author });
         const messageCid = await Message.getCid(message);
 
-        const watermark = await eventLog.append(requester.did, messageCid);
+        const watermark = await eventLog.append(author.did, messageCid);
 
         if (i === 4) {
           testWatermark = watermark;
@@ -123,7 +123,7 @@ describe('EventLogLevel Tests', () => {
         }
       }
 
-      const events = await eventLog.getEvents(requester.did, { gt: testWatermark });
+      const events = await eventLog.getEvents(author.did, { gt: testWatermark });
       expect(events.length).to.equal(4);
 
       for (let i = 0; i < events.length; i += 1) {
@@ -135,25 +135,25 @@ describe('EventLogLevel Tests', () => {
   describe('deleteEventsByCid', () => {
     it('finds and deletes events that whose values match the cids provided', async () => {
       const cids: string[] = [];
-      const { requester, message } = await TestDataGenerator.generateRecordsWrite();
+      const { author, message } = await TestDataGenerator.generateRecordsWrite();
       const messageCid = await Message.getCid(message);
 
-      await eventLog.append(requester.did, messageCid);
+      await eventLog.append(author.did, messageCid);
 
       for (let i = 0; i < 9; i += 1) {
-        const { message } = await TestDataGenerator.generateRecordsWrite({ requester });
+        const { message } = await TestDataGenerator.generateRecordsWrite({ author });
         const messageCid = await Message.getCid(message);
 
-        await eventLog.append(requester.did, messageCid);
+        await eventLog.append(author.did, messageCid);
         if (i % 2 === 0) {
           cids.push(messageCid);
         }
       }
 
-      const numEventsDeleted = await eventLog.deleteEventsByCid(requester.did, cids);
+      const numEventsDeleted = await eventLog.deleteEventsByCid(author.did, cids);
       expect(numEventsDeleted).to.equal(cids.length);
 
-      const remainingEvents = await eventLog.getEvents(requester.did);
+      const remainingEvents = await eventLog.getEvents(author.did);
       expect(remainingEvents.length).to.equal(10 - cids.length);
 
       const cidSet = new Set(cids);

--- a/tests/interfaces/events/handlers/events-get.spec.ts
+++ b/tests/interfaces/events/handlers/events-get.spec.ts
@@ -56,7 +56,7 @@ describe('EventsGetHandler.handle()', () => {
     const alice = await DidKeyResolver.generate();
     const bob = await DidKeyResolver.generate();
 
-    const { message } = await TestDataGenerator.generateEventsGet({ requester: alice });
+    const { message } = await TestDataGenerator.generateEventsGet({ author: alice });
     const reply = await dwn.processMessage(bob.did, message);
 
     expect(reply.status.code).to.equal(401);
@@ -67,7 +67,7 @@ describe('EventsGetHandler.handle()', () => {
   it('returns a 400 if message is invalid', async () => {
     const alice = await DidKeyResolver.generate();
 
-    const { message } = await TestDataGenerator.generateEventsGet({ requester: alice });
+    const { message } = await TestDataGenerator.generateEventsGet({ author: alice });
     message['descriptor']['troll'] = 'hehe';
 
     const reply = await dwn.processMessage(alice.did, message);
@@ -82,7 +82,7 @@ describe('EventsGetHandler.handle()', () => {
     const expectedCids: string[] = [];
 
     for (let i = 0; i < 5; i += 1) {
-      const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ requester: alice });
+      const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice });
       const reply = await dwn.processMessage(alice.did, message, dataStream);
 
       expect(reply.status.code).to.equal(202);
@@ -91,7 +91,7 @@ describe('EventsGetHandler.handle()', () => {
 
     }
 
-    const { message } = await TestDataGenerator.generateEventsGet({ requester: alice });
+    const { message } = await TestDataGenerator.generateEventsGet({ author: alice });
     const reply: EventsGetReply = await dwn.processMessage(alice.did, message);
 
     expect(reply.status.code).to.equal(200);
@@ -107,13 +107,13 @@ describe('EventsGetHandler.handle()', () => {
     const alice = await DidKeyResolver.generate();
 
     for (let i = 0; i < 5; i += 1) {
-      const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ requester: alice });
+      const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice });
       const reply = await dwn.processMessage(alice.did, message, dataStream);
 
       expect(reply.status.code).to.equal(202);
     }
 
-    const { message } = await TestDataGenerator.generateEventsGet({ requester: alice });
+    const { message } = await TestDataGenerator.generateEventsGet({ author: alice });
     let reply: EventsGetReply = await dwn.processMessage(alice.did, message);
 
     expect(reply.status.code).to.equal(200);
@@ -122,7 +122,7 @@ describe('EventsGetHandler.handle()', () => {
     const expectedCids: string[] = [];
 
     for (let i = 0; i < 3; i += 1) {
-      const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ requester: alice });
+      const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice });
       const reply = await dwn.processMessage(alice.did, message, dataStream);
 
       expect(reply.status.code).to.equal(202);
@@ -130,7 +130,7 @@ describe('EventsGetHandler.handle()', () => {
       expectedCids.push(messageCid);
     }
 
-    const { message: m } = await TestDataGenerator.generateEventsGet({ requester: alice, watermark });
+    const { message: m } = await TestDataGenerator.generateEventsGet({ author: alice, watermark });
     reply = await dwn.processMessage(alice.did, m);
 
     expect(reply.status.code).to.equal(200);

--- a/tests/interfaces/messages/handlers/messages-get.spec.ts
+++ b/tests/interfaces/messages/handlers/messages-get.spec.ts
@@ -59,10 +59,10 @@ describe('MessagesGetHandler.handle()', () => {
   it('returns a 401 if tenant is not author', async () => {
     const alice = await DidKeyResolver.generate();
     const bob = await DidKeyResolver.generate();
-    const { recordsWrite } = await TestDataGenerator.generateRecordsWrite({ requester: alice });
+    const { recordsWrite } = await TestDataGenerator.generateRecordsWrite({ author: alice });
 
     const { message } = await TestDataGenerator.generateMessagesGet({
-      requester   : alice,
+      author      : alice,
       messageCids : [await Message.getCid(recordsWrite.message)]
     });
 
@@ -75,10 +75,10 @@ describe('MessagesGetHandler.handle()', () => {
 
   it('returns a 400 if message is invalid', async () => {
     const alice = await DidKeyResolver.generate();
-    const { recordsWrite } = await TestDataGenerator.generateRecordsWrite({ requester: alice });
+    const { recordsWrite } = await TestDataGenerator.generateRecordsWrite({ author: alice });
 
     const { message } = await TestDataGenerator.generateMessagesGet({
-      requester   : alice,
+      author      : alice,
       messageCids : [await Message.getCid(recordsWrite.message)]
     });
 
@@ -93,10 +93,10 @@ describe('MessagesGetHandler.handle()', () => {
 
   it('returns a 400 if message contains an invalid message cid', async () => {
     const alice = await DidKeyResolver.generate();
-    const { recordsWrite } = await TestDataGenerator.generateRecordsWrite({ requester: alice });
+    const { recordsWrite } = await TestDataGenerator.generateRecordsWrite({ author: alice });
 
     const { message } = await TestDataGenerator.generateMessagesGet({
-      requester   : alice,
+      author      : alice,
       messageCids : [await Message.getCid(recordsWrite.message)]
     });
 
@@ -115,7 +115,7 @@ describe('MessagesGetHandler.handle()', () => {
     const messageCids: string[] = [];
 
     const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({
-      requester: alice
+      author: alice
     });
 
     let messageCid = await Message.getCid(recordsWrite.message);
@@ -125,8 +125,8 @@ describe('MessagesGetHandler.handle()', () => {
     expect(reply.status.code).to.equal(202);
 
     const { recordsDelete } = await TestDataGenerator.generateRecordsDelete({
-      requester : alice,
-      recordId  : recordsWrite.message.recordId
+      author   : alice,
+      recordId : recordsWrite.message.recordId
     });
 
     messageCid = await Message.getCid(recordsDelete.message);
@@ -136,7 +136,7 @@ describe('MessagesGetHandler.handle()', () => {
     expect(reply.status.code).to.equal(202);
 
     const { protocolsConfigure } = await TestDataGenerator.generateProtocolsConfigure({
-      requester: alice
+      author: alice
     });
 
     messageCid = await Message.getCid(protocolsConfigure.message);
@@ -146,7 +146,7 @@ describe('MessagesGetHandler.handle()', () => {
     expect(reply.status.code).to.equal(202);
 
     const { messagesGet } = await TestDataGenerator.generateMessagesGet({
-      requester: alice,
+      author: alice,
       messageCids
     });
 
@@ -166,11 +166,11 @@ describe('MessagesGetHandler.handle()', () => {
 
   it('returns message as undefined in reply entry when a messageCid is not found', async () => {
     const alice = await DidKeyResolver.generate();
-    const { recordsWrite } = await TestDataGenerator.generateRecordsWrite({ requester: alice });
+    const { recordsWrite } = await TestDataGenerator.generateRecordsWrite({ author: alice });
     const recordsWriteMessageCid = await Message.getCid(recordsWrite.message);
 
     const { message } = await TestDataGenerator.generateMessagesGet({
-      requester   : alice,
+      author      : alice,
       messageCids : [recordsWriteMessageCid]
     });
 
@@ -195,11 +195,11 @@ describe('MessagesGetHandler.handle()', () => {
     const messagesGetHandler = new MessagesGetHandler(didResolver, messageStore, dataStore);
 
     const alice = await DidKeyResolver.generate();
-    const { recordsWrite } = await TestDataGenerator.generateRecordsWrite({ requester: alice });
+    const { recordsWrite } = await TestDataGenerator.generateRecordsWrite({ author: alice });
     const recordsWriteMessageCid = await Message.getCid(recordsWrite.message);
 
     const { message } = await TestDataGenerator.generateMessagesGet({
-      requester   : alice,
+      author      : alice,
       messageCids : [recordsWriteMessageCid]
     });
 
@@ -218,7 +218,7 @@ describe('MessagesGetHandler.handle()', () => {
     const alice = await DidKeyResolver.generate();
 
     const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({
-      requester: alice
+      author: alice
     });
 
     const reply = await dwn.processMessage(alice.did, recordsWrite.toJSON(), dataStream);
@@ -226,7 +226,7 @@ describe('MessagesGetHandler.handle()', () => {
 
     const recordsWriteMessageCid = await Message.getCid(recordsWrite.message);
     const { message } = await TestDataGenerator.generateMessagesGet({
-      requester   : alice,
+      author      : alice,
       messageCids : [recordsWriteMessageCid]
     });
 
@@ -248,7 +248,7 @@ describe('MessagesGetHandler.handle()', () => {
     const bob = await DidKeyResolver.generate();
 
     const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({
-      requester: alice
+      author: alice
     });
 
     const reply = await dwn.processMessage(alice.did, recordsWrite.toJSON(), dataStream);
@@ -256,7 +256,7 @@ describe('MessagesGetHandler.handle()', () => {
 
     const recordsWriteMessageCid = await Message.getCid(recordsWrite.message);
     const { message } = await TestDataGenerator.generateMessagesGet({
-      requester   : bob,
+      author      : bob,
       messageCids : [await Message.getCid(recordsWrite.message)]
     });
 

--- a/tests/interfaces/messages/messages/messages-get.spec.ts
+++ b/tests/interfaces/messages/messages/messages-get.spec.ts
@@ -9,11 +9,11 @@ import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 describe('MessagesGet Message', () => {
   describe('create', () => {
     it('creates a MessagesGet message', async () => {
-      const { requester, message } = await TestDataGenerator.generateRecordsWrite();
+      const { author, message } = await TestDataGenerator.generateRecordsWrite();
       const messageCid = await Message.getCid(message);
 
       const messagesGet = await MessagesGet.create({
-        authorizationSignatureInput : await Jws.createSignatureInput(requester),
+        authorizationSignatureInput : await Jws.createSignatureInput(author),
         messageCids                 : [messageCid]
       });
 
@@ -58,11 +58,11 @@ describe('MessagesGet Message', () => {
 
   describe('parse', () => {
     it('parses a message into a MessagesGet instance', async () => {
-      const { requester, message } = await TestDataGenerator.generateRecordsWrite();
+      const { author, message } = await TestDataGenerator.generateRecordsWrite();
       let messageCid = await Message.getCid(message);
 
       const messagesGet = await MessagesGet.create({
-        authorizationSignatureInput : await Jws.createSignatureInput(requester),
+        authorizationSignatureInput : await Jws.createSignatureInput(author),
         messageCids                 : [messageCid]
       });
 
@@ -76,11 +76,11 @@ describe('MessagesGet Message', () => {
     });
 
     it('throws an exception if messageCids contains an invalid cid', async () => {
-      const { requester, message: recordsWriteMessage } = await TestDataGenerator.generateRecordsWrite();
+      const { author, message: recordsWriteMessage } = await TestDataGenerator.generateRecordsWrite();
       const messageCid = await Message.getCid(recordsWriteMessage);
 
       const messagesGet = await MessagesGet.create({
-        authorizationSignatureInput : await Jws.createSignatureInput(requester),
+        authorizationSignatureInput : await Jws.createSignatureInput(author),
         messageCids                 : [messageCid]
       });
 

--- a/tests/interfaces/records/handlers/records-delete.spec.ts
+++ b/tests/interfaces/records/handlers/records-delete.spec.ts
@@ -62,14 +62,14 @@ describe('RecordsDeleteHandler.handle()', () => {
       const alice = await DidKeyResolver.generate();
 
       // insert data
-      const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ requester: alice });
+      const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice });
       const writeReply = await dwn.processMessage(alice.did, message, dataStream);
       expect(writeReply.status.code).to.equal(202);
 
       // ensure data is inserted
       const queryData = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { recordId: message.recordId }
+        author : alice,
+        filter : { recordId: message.recordId }
       });
 
       const reply = await dwn.processMessage(alice.did, queryData.message);
@@ -117,7 +117,7 @@ describe('RecordsDeleteHandler.handle()', () => {
       const alice = await DidKeyResolver.generate();
 
       // initial write
-      const initialWriteData = await TestDataGenerator.generateRecordsWrite({ requester: alice });
+      const initialWriteData = await TestDataGenerator.generateRecordsWrite({ author: alice });
       const initialWriteReply = await dwn.processMessage(alice.did, initialWriteData.message, initialWriteData.dataStream);
       expect(initialWriteReply.status.code).to.equal(202);
 
@@ -129,7 +129,7 @@ describe('RecordsDeleteHandler.handle()', () => {
       });
       const subsequentWriteData = await TestDataGenerator.generateFromRecordsWrite({
         existingWrite : initialWriteData.recordsWrite,
-        requester     : alice
+        author        : alice
       });
 
       // subsequent write
@@ -142,8 +142,8 @@ describe('RecordsDeleteHandler.handle()', () => {
 
       // ensure data still exists
       const queryData = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { recordId: initialWriteData.message.recordId }
+        author : alice,
+        filter : { recordId: initialWriteData.message.recordId }
       });
       const expectedEncodedData = Encoder.bytesToBase64Url(subsequentWriteData.dataBytes);
       const reply = await dwn.processMessage(alice.did, queryData.message);
@@ -164,15 +164,15 @@ describe('RecordsDeleteHandler.handle()', () => {
 
       // alice writes a record
       const aliceWriteData = await TestDataGenerator.generateRecordsWrite({
-        requester: alice,
+        author: alice,
         data
       });
       const aliceWriteReply = await dwn.processMessage(alice.did, aliceWriteData.message, aliceWriteData.dataStream);
       expect(aliceWriteReply.status.code).to.equal(202);
 
       const aliceQueryWriteAfterAliceWriteData = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { recordId: aliceWriteData.message.recordId }
+        author : alice,
+        filter : { recordId: aliceWriteData.message.recordId }
       });
       const aliceQueryWriteAfterAliceWriteReply = await dwn.processMessage(alice.did, aliceQueryWriteAfterAliceWriteData.message);
       expect(aliceQueryWriteAfterAliceWriteReply.status.code).to.equal(200);
@@ -183,15 +183,15 @@ describe('RecordsDeleteHandler.handle()', () => {
 
       // alice deleting the record
       const aliceDeleteWriteData = await TestDataGenerator.generateRecordsDelete({
-        requester : alice,
-        recordId  : aliceWriteData.message.recordId
+        author   : alice,
+        recordId : aliceWriteData.message.recordId
       });
       const aliceDeleteWriteReply = await dwn.processMessage(alice.did, aliceDeleteWriteData.message);
       expect(aliceDeleteWriteReply.status.code).to.equal(202);
 
       const aliceQueryWriteAfterAliceDeleteData = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { recordId: aliceWriteData.message.recordId }
+        author : alice,
+        filter : { recordId: aliceWriteData.message.recordId }
       });
       const aliceQueryWriteAfterAliceDeleteReply = await dwn.processMessage(alice.did, aliceQueryWriteAfterAliceDeleteData.message);
       expect(aliceQueryWriteAfterAliceDeleteReply.status.code).to.equal(200);
@@ -201,15 +201,15 @@ describe('RecordsDeleteHandler.handle()', () => {
 
       // alice writes a new record with the same data
       const aliceRewriteData = await TestDataGenerator.generateRecordsWrite({
-        requester: alice,
+        author: alice,
         data
       });
       const aliceRewriteReply = await dwn.processMessage(alice.did, aliceRewriteData.message, aliceRewriteData.dataStream);
       expect(aliceRewriteReply.status.code).to.equal(202);
 
       const aliceQueryWriteAfterAliceRewriteData = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { recordId: aliceRewriteData.message.recordId }
+        author : alice,
+        filter : { recordId: aliceRewriteData.message.recordId }
       });
       const aliceQueryWriteAfterAliceRewriteReply = await dwn.processMessage(alice.did, aliceQueryWriteAfterAliceRewriteData.message);
       expect(aliceQueryWriteAfterAliceRewriteReply.status.code).to.equal(200);
@@ -233,28 +233,28 @@ describe('RecordsDeleteHandler.handle()', () => {
       const blockstoreOfBobOfDataCid = await blockstoreOfBob.partition(dataCid);
 
       // alice writes a records with data
-      const aliceWriteData = await TestDataGenerator.generateRecordsWrite({ requester: alice, data });
+      const aliceWriteData = await TestDataGenerator.generateRecordsWrite({ author: alice, data });
       const aliceWriteReply = await dwn.processMessage(alice.did, aliceWriteData.message, aliceWriteData.dataStream);
       expect(aliceWriteReply.status.code).to.equal(202);
 
       await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfAliceOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
 
       // alice writes another record with the same data
-      const aliceAssociateData = await TestDataGenerator.generateRecordsWrite({ requester: alice, data });
+      const aliceAssociateData = await TestDataGenerator.generateRecordsWrite({ author: alice, data });
       const aliceAssociateReply = await dwn.processMessage(alice.did, aliceAssociateData.message, aliceAssociateData.dataStream);
       expect(aliceAssociateReply.status.code).to.equal(202);
 
       await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfAliceOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
 
       // bob writes a records with same data
-      const bobWriteData = await TestDataGenerator.generateRecordsWrite({ requester: bob, data });
+      const bobWriteData = await TestDataGenerator.generateRecordsWrite({ author: bob, data });
       const bobWriteReply = await dwn.processMessage(bob.did, bobWriteData.message, bobWriteData.dataStream);
       expect(bobWriteReply.status.code).to.equal(202);
 
       await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfBobOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
 
       // bob writes another record with the same data
-      const bobAssociateData = await TestDataGenerator.generateRecordsWrite({ requester: bob, data });
+      const bobAssociateData = await TestDataGenerator.generateRecordsWrite({ author: bob, data });
       const bobAssociateReply = await dwn.processMessage(bob.did, bobAssociateData.message, bobAssociateData.dataStream);
       expect(bobAssociateReply.status.code).to.equal(202);
 
@@ -262,8 +262,8 @@ describe('RecordsDeleteHandler.handle()', () => {
 
       // alice deletes one of the two records
       const aliceDeleteWriteData = await TestDataGenerator.generateRecordsDelete({
-        requester : alice,
-        recordId  : aliceWriteData.message.recordId
+        author   : alice,
+        recordId : aliceWriteData.message.recordId
       });
       const aliceDeleteWriteReply = await dwn.processMessage(alice.did, aliceDeleteWriteData.message);
       expect(aliceDeleteWriteReply.status.code).to.equal(202);
@@ -272,8 +272,8 @@ describe('RecordsDeleteHandler.handle()', () => {
 
       // alice deletes the other record
       const aliceDeleteAssociateData = await TestDataGenerator.generateRecordsDelete({
-        requester : alice,
-        recordId  : aliceAssociateData.message.recordId
+        author   : alice,
+        recordId : aliceAssociateData.message.recordId
       });
       const aliceDeleteAssociateReply = await dwn.processMessage(alice.did, aliceDeleteAssociateData.message);
       expect(aliceDeleteAssociateReply.status.code).to.equal(202);
@@ -287,7 +287,7 @@ describe('RecordsDeleteHandler.handle()', () => {
       it('should include RecordsDelete event and keep initial RecordsWrite event', async () => {
         const alice = await DidKeyResolver.generate();
 
-        const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ requester: alice });
+        const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice });
         const writeReply = await dwn.processMessage(alice.did, message, dataStream);
         expect(writeReply.status.code).to.equal(202);
 
@@ -314,30 +314,30 @@ describe('RecordsDeleteHandler.handle()', () => {
       });
 
       it('should only keep first write and delete when subsequent writes happen', async () => {
-        const { message, requester, dataStream, recordsWrite } = await TestDataGenerator.generateRecordsWrite();
-        TestStubGenerator.stubDidResolver(didResolver, [requester]);
+        const { message, author, dataStream, recordsWrite } = await TestDataGenerator.generateRecordsWrite();
+        TestStubGenerator.stubDidResolver(didResolver, [author]);
 
-        const reply = await dwn.processMessage(requester.did, message, dataStream);
+        const reply = await dwn.processMessage(author.did, message, dataStream);
         expect(reply.status.code).to.equal(202);
 
         const newWrite = await RecordsWrite.createFrom({
           unsignedRecordsWriteMessage : recordsWrite.message,
           published                   : true,
-          authorizationSignatureInput : Jws.createSignatureInput(requester)
+          authorizationSignatureInput : Jws.createSignatureInput(author)
         });
 
-        const newWriteReply = await dwn.processMessage(requester.did, newWrite.message);
+        const newWriteReply = await dwn.processMessage(author.did, newWrite.message);
         expect(newWriteReply.status.code).to.equal(202);
 
         const recordsDelete = await RecordsDelete.create({
           recordId                    : message.recordId,
-          authorizationSignatureInput : Jws.createSignatureInput(requester)
+          authorizationSignatureInput : Jws.createSignatureInput(author)
         });
 
-        const deleteReply = await dwn.processMessage(requester.did, recordsDelete.message);
+        const deleteReply = await dwn.processMessage(author.did, recordsDelete.message);
         expect(deleteReply.status.code).to.equal(202);
 
-        const events = await eventLog.getEvents(requester.did);
+        const events = await eventLog.getEvents(author.did);
         expect(events.length).to.equal(2);
 
         const deletedMessageCid = await Message.getCid(newWrite.message);
@@ -352,12 +352,12 @@ describe('RecordsDeleteHandler.handle()', () => {
   });
 
   it('should return 401 if signature check fails', async () => {
-    const { requester, message } = await TestDataGenerator.generateRecordsDelete();
-    const tenant = requester.did;
+    const { author, message } = await TestDataGenerator.generateRecordsDelete();
+    const tenant = author.did;
 
     // setting up a stub did resolver & message store
     // intentionally not supplying the public key so a different public key is generated to simulate invalid signature
-    const mismatchingPersona = await TestDataGenerator.generatePersona({ did: requester.did, keyId: requester.keyId });
+    const mismatchingPersona = await TestDataGenerator.generatePersona({ did: author.did, keyId: author.keyId });
     const didResolver = TestStubGenerator.createDidResolverStub(mismatchingPersona);
     const messageStore = sinon.createStubInstance(MessageStoreLevel);
     const dataStore = sinon.createStubInstance(DataStoreLevel);
@@ -368,8 +368,8 @@ describe('RecordsDeleteHandler.handle()', () => {
   });
 
   it('should return 400 if fail parsing the message', async () => {
-    const { requester, message } = await TestDataGenerator.generateRecordsDelete();
-    const tenant = requester.did;
+    const { author, message } = await TestDataGenerator.generateRecordsDelete();
+    const tenant = author.did;
 
     // setting up a stub method resolver & message store
     const messageStore = sinon.createStubInstance(MessageStoreLevel);

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -79,9 +79,9 @@ describe('RecordsQueryHandler.handle()', () => {
       // insert three messages into DB, two with matching protocol
       const alice = await TestDataGenerator.generatePersona();
       const dataFormat = 'myAwesomeDataFormat';
-      const write1 = await TestDataGenerator.generateRecordsWrite({ requester: alice });
-      const write2 = await TestDataGenerator.generateRecordsWrite({ requester: alice, dataFormat, schema: 'schema1' });
-      const write3 = await TestDataGenerator.generateRecordsWrite({ requester: alice, dataFormat, schema: 'schema2' });
+      const write1 = await TestDataGenerator.generateRecordsWrite({ author: alice });
+      const write2 = await TestDataGenerator.generateRecordsWrite({ author: alice, dataFormat, schema: 'schema1' });
+      const write3 = await TestDataGenerator.generateRecordsWrite({ author: alice, dataFormat, schema: 'schema2' });
 
       // setting up a stub resolver
       const mockResolution = TestDataGenerator.createDidResolutionResult(alice);;
@@ -96,7 +96,7 @@ describe('RecordsQueryHandler.handle()', () => {
       expect(writeReply3.status.code).to.equal(202);
 
       // testing singular conditional query
-      const messageData = await TestDataGenerator.generateRecordsQuery({ requester: alice, filter: { dataFormat } });
+      const messageData = await TestDataGenerator.generateRecordsQuery({ author: alice, filter: { dataFormat } });
 
       const reply = await dwn.processMessage(alice.did, messageData.message);
 
@@ -105,8 +105,8 @@ describe('RecordsQueryHandler.handle()', () => {
 
       // testing multi-conditional query, reuse data generated above for bob
       const messageData2 = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : {
+        author : alice,
+        filter : {
           dataFormat,
           schema: 'schema1'
         }
@@ -121,12 +121,12 @@ describe('RecordsQueryHandler.handle()', () => {
     it('should return `encodedData` if data size is within the spec threshold', async () => {
       const data = TestDataGenerator.randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded); // within/on threshold
       const alice = await DidKeyResolver.generate();
-      const write= await TestDataGenerator.generateRecordsWrite({ requester: alice, data });
+      const write= await TestDataGenerator.generateRecordsWrite({ author: alice, data });
 
       const writeReply = await dwn.processMessage(alice.did, write.message, write.dataStream);
       expect(writeReply.status.code).to.equal(202);
 
-      const messageData = await TestDataGenerator.generateRecordsQuery({ requester: alice, filter: { recordId: write.message.recordId } });
+      const messageData = await TestDataGenerator.generateRecordsQuery({ author: alice, filter: { recordId: write.message.recordId } });
       const reply = await dwn.processMessage(alice.did, messageData.message);
 
       expect(reply.status.code).to.equal(200);
@@ -137,12 +137,12 @@ describe('RecordsQueryHandler.handle()', () => {
     it('should not return `encodedData` if data size is greater then spec threshold', async () => {
       const data = TestDataGenerator.randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded + 1); // exceeding threshold
       const alice = await DidKeyResolver.generate();
-      const write= await TestDataGenerator.generateRecordsWrite({ requester: alice, data });
+      const write= await TestDataGenerator.generateRecordsWrite({ author: alice, data });
 
       const writeReply = await dwn.processMessage(alice.did, write.message, write.dataStream);
       expect(writeReply.status.code).to.equal(202);
 
-      const messageData = await TestDataGenerator.generateRecordsQuery({ requester: alice, filter: { recordId: write.message.recordId } });
+      const messageData = await TestDataGenerator.generateRecordsQuery({ author: alice, filter: { recordId: write.message.recordId } });
       const reply = await dwn.processMessage(alice.did, messageData.message);
 
       expect(reply.status.code).to.equal(200);
@@ -154,8 +154,8 @@ describe('RecordsQueryHandler.handle()', () => {
       // scenario: 2 records authored by alice, 1st attested by alice, 2nd attested by bob
       const alice = await DidKeyResolver.generate();
       const bob = await DidKeyResolver.generate();
-      const recordsWrite1 = await TestDataGenerator.generateRecordsWrite({ requester: alice, attesters: [alice] });
-      const recordsWrite2 = await TestDataGenerator.generateRecordsWrite({ requester: alice, attesters: [bob] });
+      const recordsWrite1 = await TestDataGenerator.generateRecordsWrite({ author: alice, attesters: [alice] });
+      const recordsWrite2 = await TestDataGenerator.generateRecordsWrite({ author: alice, attesters: [bob] });
 
       // insert data
       const writeReply1 = await dwn.processMessage(alice.did, recordsWrite1.message, recordsWrite1.dataStream);
@@ -164,7 +164,7 @@ describe('RecordsQueryHandler.handle()', () => {
       expect(writeReply2.status.code).to.equal(202);
 
       // testing attester filter
-      const recordsQuery1 = await TestDataGenerator.generateRecordsQuery({ requester: alice, filter: { attester: alice.did } });
+      const recordsQuery1 = await TestDataGenerator.generateRecordsQuery({ author: alice, filter: { attester: alice.did } });
       const reply1 = await dwn.processMessage(alice.did, recordsQuery1.message);
       expect(reply1.entries?.length).to.equal(1);
       const reply1Attester = Jws.getSignerDid((reply1.entries![0] as RecordsWriteMessage).attestation!.signatures[0]);
@@ -172,8 +172,8 @@ describe('RecordsQueryHandler.handle()', () => {
 
       // testing attester + another filter
       const recordsQuery2 = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { attester: bob.did, schema: recordsWrite2.message.descriptor.schema }
+        author : alice,
+        filter : { attester: bob.did, schema: recordsWrite2.message.descriptor.schema }
       });
       const reply2 = await dwn.processMessage(alice.did, recordsQuery2.message);
       expect(reply2.entries?.length).to.equal(1);
@@ -182,7 +182,7 @@ describe('RecordsQueryHandler.handle()', () => {
 
       // testing attester filter that yields no results
       const carol = await DidKeyResolver.generate();
-      const recordsQuery3 = await TestDataGenerator.generateRecordsQuery({ requester: alice, filter: { attester: carol.did } });
+      const recordsQuery3 = await TestDataGenerator.generateRecordsQuery({ author: alice, filter: { attester: carol.did } });
       const reply3 = await dwn.processMessage(alice.did, recordsQuery3.message);
       expect(reply3.entries?.length).to.equal(0);
     });
@@ -193,9 +193,9 @@ describe('RecordsQueryHandler.handle()', () => {
       const firstDayOf2022 = createDateString(new Date(2022, 1, 1));
       const firstDayOf2023 = createDateString(new Date(2023, 1, 1));
       const alice = await DidKeyResolver.generate();
-      const write1 = await TestDataGenerator.generateRecordsWrite({ requester: alice, dateCreated: firstDayOf2021, dateModified: firstDayOf2021 });
-      const write2 = await TestDataGenerator.generateRecordsWrite({ requester: alice, dateCreated: firstDayOf2022, dateModified: firstDayOf2022 });
-      const write3 = await TestDataGenerator.generateRecordsWrite({ requester: alice, dateCreated: firstDayOf2023, dateModified: firstDayOf2023 });
+      const write1 = await TestDataGenerator.generateRecordsWrite({ author: alice, dateCreated: firstDayOf2021, dateModified: firstDayOf2021 });
+      const write2 = await TestDataGenerator.generateRecordsWrite({ author: alice, dateCreated: firstDayOf2022, dateModified: firstDayOf2022 });
+      const write3 = await TestDataGenerator.generateRecordsWrite({ author: alice, dateCreated: firstDayOf2023, dateModified: firstDayOf2023 });
 
       // insert data
       const writeReply1 = await dwn.processMessage(alice.did, write1.message, write1.dataStream);
@@ -208,9 +208,9 @@ describe('RecordsQueryHandler.handle()', () => {
       // testing `from` range
       const lastDayOf2021 = createDateString(new Date(2021, 12, 31));
       const recordsQuery1 = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { dateCreated: { from: lastDayOf2021 } },
-        dateSort  : DateSort.CreatedAscending
+        author   : alice,
+        filter   : { dateCreated: { from: lastDayOf2021 } },
+        dateSort : DateSort.CreatedAscending
       });
       const reply1 = await dwn.processMessage(alice.did, recordsQuery1.message);
       expect(reply1.entries?.length).to.equal(2);
@@ -220,9 +220,9 @@ describe('RecordsQueryHandler.handle()', () => {
       // testing `to` range
       const lastDayOf2022 = createDateString(new Date(2022, 12, 31));
       const recordsQuery2 = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { dateCreated: { to: lastDayOf2022 } },
-        dateSort  : DateSort.CreatedAscending
+        author   : alice,
+        filter   : { dateCreated: { to: lastDayOf2022 } },
+        dateSort : DateSort.CreatedAscending
       });
       const reply2 = await dwn.processMessage(alice.did, recordsQuery2.message);
       expect(reply2.entries?.length).to.equal(2);
@@ -232,9 +232,9 @@ describe('RecordsQueryHandler.handle()', () => {
       // testing `from` and `to` range
       const lastDayOf2023 = createDateString(new Date(2023, 12, 31));
       const recordsQuery3 = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { dateCreated: { from: lastDayOf2022, to: lastDayOf2023 } },
-        dateSort  : DateSort.CreatedAscending
+        author   : alice,
+        filter   : { dateCreated: { from: lastDayOf2022, to: lastDayOf2023 } },
+        dateSort : DateSort.CreatedAscending
       });
       const reply3 = await dwn.processMessage(alice.did, recordsQuery3.message);
       expect(reply3.entries?.length).to.equal(1);
@@ -242,9 +242,9 @@ describe('RecordsQueryHandler.handle()', () => {
 
       // testing edge case where value equals `from` and `to`
       const recordsQuery4 = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { dateCreated: { from: firstDayOf2022, to: firstDayOf2023 } },
-        dateSort  : DateSort.CreatedAscending
+        author   : alice,
+        filter   : { dateCreated: { from: firstDayOf2022, to: firstDayOf2023 } },
+        dateSort : DateSort.CreatedAscending
       });
       const reply4 = await dwn.processMessage(alice.did, recordsQuery4.message);
       expect(reply4.entries?.length).to.equal(1);
@@ -259,13 +259,13 @@ describe('RecordsQueryHandler.handle()', () => {
       const alice = await DidKeyResolver.generate();
       const schema = '2021And2022Schema';
       const write1 = await TestDataGenerator.generateRecordsWrite({
-        requester: alice, dateCreated: firstDayOf2021, dateModified: firstDayOf2021, schema
+        author: alice, dateCreated: firstDayOf2021, dateModified: firstDayOf2021, schema
       });
       const write2 = await TestDataGenerator.generateRecordsWrite({
-        requester: alice, dateCreated: firstDayOf2022, dateModified: firstDayOf2022, schema
+        author: alice, dateCreated: firstDayOf2022, dateModified: firstDayOf2022, schema
       });
       const write3 = await TestDataGenerator.generateRecordsWrite({
-        requester: alice, dateCreated: firstDayOf2023, dateModified: firstDayOf2023
+        author: alice, dateCreated: firstDayOf2023, dateModified: firstDayOf2023
       });
 
       // insert data
@@ -280,8 +280,8 @@ describe('RecordsQueryHandler.handle()', () => {
       const lastDayOf2021 = createDateString(new Date(2021, 12, 31));
       const lastDayOf2023 = createDateString(new Date(2023, 12, 31));
       const recordsQuery5 = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : {
+        author : alice,
+        filter : {
           schema, // by itself selects the first 2 records
           dateCreated: { from: lastDayOf2021, to: lastDayOf2023 } // by itself selects the last 2 records
         },
@@ -294,7 +294,7 @@ describe('RecordsQueryHandler.handle()', () => {
 
     it('should not include `authorization` in returned records', async () => {
       const alice = await TestDataGenerator.generatePersona();
-      const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ requester: alice });
+      const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice });
 
       // setting up a stub method resolver
       const mockResolution = TestDataGenerator.createDidResolutionResult(alice);;
@@ -304,8 +304,8 @@ describe('RecordsQueryHandler.handle()', () => {
       expect(writeReply.status.code).to.equal(202);
 
       const queryData = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { schema: message.descriptor.schema }
+        author : alice,
+        filter : { schema: message.descriptor.schema }
       });
 
       const queryReply = await dwn.processMessage(alice.did, queryData.message);
@@ -318,14 +318,14 @@ describe('RecordsQueryHandler.handle()', () => {
       // scenario: alice and bob attest to a message alice authored
 
       const alice = await DidKeyResolver.generate();
-      const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ requester: alice, attesters: [alice] });
+      const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice, attesters: [alice] });
 
       const writeReply = await dwn.processMessage(alice.did, message, dataStream);
       expect(writeReply.status.code).to.equal(202);
 
       const queryData = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { schema: message.descriptor.schema }
+        author : alice,
+        filter : { schema: message.descriptor.schema }
       });
 
       const queryReply = await dwn.processMessage(alice.did, queryData.message);
@@ -341,10 +341,10 @@ describe('RecordsQueryHandler.handle()', () => {
       const alice = await TestDataGenerator.generatePersona();
       const schema = 'aSchema';
       const publishedWriteData = await TestDataGenerator.generateRecordsWrite({
-        requester: alice, schema, published: true
+        author: alice, schema, published: true
       });
       const unpublishedWriteData = await TestDataGenerator.generateRecordsWrite({
-        requester: alice, schema
+        author: alice, schema
       });
 
       // setting up a stub method resolver
@@ -359,9 +359,9 @@ describe('RecordsQueryHandler.handle()', () => {
 
       // test published date ascending sort does not include any records that is not published
       const publishedAscendingQueryData = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        dateSort  : DateSort.PublishedAscending,
-        filter    : { schema }
+        author   : alice,
+        dateSort : DateSort.PublishedAscending,
+        filter   : { schema }
       });
       const publishedAscendingQueryReply = await dwn.processMessage(alice.did, publishedAscendingQueryData.message);
 
@@ -370,9 +370,9 @@ describe('RecordsQueryHandler.handle()', () => {
 
       // test published date scending sort does not include any records that is not published
       const publishedDescendingQueryData = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        dateSort  : DateSort.PublishedDescending,
-        filter    : { schema }
+        author   : alice,
+        dateSort : DateSort.PublishedDescending,
+        filter   : { schema }
       });
       const publishedDescendingQueryReply = await dwn.processMessage(alice.did, publishedDescendingQueryData.message);
 
@@ -385,9 +385,9 @@ describe('RecordsQueryHandler.handle()', () => {
       const alice = await TestDataGenerator.generatePersona();
       const schema = 'aSchema';
       const published = true;
-      const write1Data = await TestDataGenerator.generateRecordsWrite({ requester: alice, schema, published });
-      const write2Data = await TestDataGenerator.generateRecordsWrite({ requester: alice, schema, published });
-      const write3Data = await TestDataGenerator.generateRecordsWrite({ requester: alice, schema, published });
+      const write1Data = await TestDataGenerator.generateRecordsWrite({ author: alice, schema, published });
+      const write2Data = await TestDataGenerator.generateRecordsWrite({ author: alice, schema, published });
+      const write3Data = await TestDataGenerator.generateRecordsWrite({ author: alice, schema, published });
 
       // setting up a stub method resolver
       const mockResolution = TestDataGenerator.createDidResolutionResult(alice);;
@@ -403,9 +403,9 @@ describe('RecordsQueryHandler.handle()', () => {
 
       // createdAscending test
       const createdAscendingQueryData = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        dateSort  : DateSort.CreatedAscending,
-        filter    : { schema }
+        author   : alice,
+        dateSort : DateSort.CreatedAscending,
+        filter   : { schema }
       });
       const createdAscendingQueryReply = await dwn.processMessage(alice.did, createdAscendingQueryData.message);
 
@@ -415,9 +415,9 @@ describe('RecordsQueryHandler.handle()', () => {
 
       // createdDescending test
       const createdDescendingQueryData = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        dateSort  : DateSort.CreatedDescending,
-        filter    : { schema }
+        author   : alice,
+        dateSort : DateSort.CreatedDescending,
+        filter   : { schema }
       });
       const createdDescendingQueryReply = await dwn.processMessage(alice.did, createdDescendingQueryData.message);
 
@@ -427,9 +427,9 @@ describe('RecordsQueryHandler.handle()', () => {
 
       // publishedAscending test
       const publishedAscendingQueryData = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        dateSort  : DateSort.PublishedAscending,
-        filter    : { schema }
+        author   : alice,
+        dateSort : DateSort.PublishedAscending,
+        filter   : { schema }
       });
       const publishedAscendingQueryReply = await dwn.processMessage(alice.did, publishedAscendingQueryData.message);
 
@@ -439,9 +439,9 @@ describe('RecordsQueryHandler.handle()', () => {
 
       // publishedDescending test
       const publishedDescendingQueryData = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        dateSort  : DateSort.PublishedDescending,
-        filter    : { schema }
+        author   : alice,
+        dateSort : DateSort.PublishedDescending,
+        filter   : { schema }
       });
       const publishedDescendingQueryReply = await dwn.processMessage(alice.did, publishedDescendingQueryData.message);
 
@@ -450,7 +450,7 @@ describe('RecordsQueryHandler.handle()', () => {
       expect(publishedDescendingQueryReply.entries?.[2].descriptor['datePublished']).to.equal(write1Data.message.descriptor.datePublished);
     });
 
-    it('should only return published records and unpublished records that is meant for requester', async () => {
+    it('should only return published records and unpublished records that is meant for author', async () => {
       // write three records into Alice's DB:
       // 1st is unpublished
       // 2nd is also unpublished but is meant for (has recipient as) Bob
@@ -460,16 +460,16 @@ describe('RecordsQueryHandler.handle()', () => {
       const bob = await DidKeyResolver.generate();
       const schema = 'schema1';
       const record1Data = await TestDataGenerator.generateRecordsWrite(
-        { requester: alice, schema, data: Encoder.stringToBytes('1') }
+        { author: alice, schema, data: Encoder.stringToBytes('1') }
       );
       const record2Data = await TestDataGenerator.generateRecordsWrite(
-        { requester: alice, schema, protocol: 'protocol', protocolPath: 'path', recipient: bob.did, data: Encoder.stringToBytes('2') }
+        { author: alice, schema, protocol: 'protocol', protocolPath: 'path', recipient: bob.did, data: Encoder.stringToBytes('2') }
       );
       const record3Data = await TestDataGenerator.generateRecordsWrite(
-        { requester: bob, schema, protocol: 'protocol', protocolPath: 'path', recipient: alice.did, data: Encoder.stringToBytes('3') }
+        { author: bob, schema, protocol: 'protocol', protocolPath: 'path', recipient: alice.did, data: Encoder.stringToBytes('3') }
       );
       const record4Data = await TestDataGenerator.generateRecordsWrite(
-        { requester: alice, schema, data: Encoder.stringToBytes('4'), published: true }
+        { author: alice, schema, data: Encoder.stringToBytes('4'), published: true }
       );
 
       // directly inserting data to datastore so that we don't have to setup to grant Bob permission to write to Alice's DWN
@@ -484,8 +484,8 @@ describe('RecordsQueryHandler.handle()', () => {
 
       // test correctness for Bob's query
       const bobQueryMessageData = await TestDataGenerator.generateRecordsQuery({
-        requester : bob,
-        filter    : { schema }
+        author : bob,
+        filter : { schema }
       });
 
       const replyToBob = await dwn.processMessage(alice.did, bobQueryMessageData.message);
@@ -502,8 +502,8 @@ describe('RecordsQueryHandler.handle()', () => {
 
       // test correctness for Alice's query
       const aliceQueryMessageData = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { schema }
+        author : alice,
+        filter : { schema }
       });
 
       const replyToAliceQuery = await dwn.processMessage(alice.did, aliceQueryMessageData.message);
@@ -518,7 +518,7 @@ describe('RecordsQueryHandler.handle()', () => {
       const bob = await DidKeyResolver.generate();
       const schema = 'schema1';
       const unpublishedRecordsWrite = await TestDataGenerator.generateRecordsWrite(
-        { requester: alice, schema, data: Encoder.stringToBytes('1'), published: false } // explicitly setting `published` to `false`
+        { author: alice, schema, data: Encoder.stringToBytes('1'), published: false } // explicitly setting `published` to `false`
       );
 
       const result1 = await dwn.processMessage(alice.did, unpublishedRecordsWrite.message, unpublishedRecordsWrite.dataStream);
@@ -526,8 +526,8 @@ describe('RecordsQueryHandler.handle()', () => {
 
       // alice should be able to see the unpublished record
       const queryByAlice = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { schema }
+        author : alice,
+        filter : { schema }
       });
       const replyToAliceQuery = await dwn.processMessage(alice.did, queryByAlice.message);
       expect(replyToAliceQuery.status.code).to.equal(200);
@@ -535,22 +535,22 @@ describe('RecordsQueryHandler.handle()', () => {
 
       // actual test: bob should not be able to see unpublished record
       const queryByBob = await TestDataGenerator.generateRecordsQuery({
-        requester : bob,
-        filter    : { schema }
+        author : bob,
+        filter : { schema }
       });
       const replyToBobQuery = await dwn.processMessage(alice.did, queryByBob.message);
       expect(replyToBobQuery.status.code).to.equal(200);
       expect(replyToBobQuery.entries?.length).to.equal(0);
     });
 
-    it('should throw if a non-owner requester querying for records not intended for the requester (as recipient)', async () => {
+    it('should throw if a non-owner author querying for records not intended for the author (as recipient)', async () => {
       const alice = await DidKeyResolver.generate();
       const bob = await DidKeyResolver.generate();
       const carol = await DidKeyResolver.generate();
 
       const bobQueryMessageData = await TestDataGenerator.generateRecordsQuery({
-        requester : bob,
-        filter    : { recipient: carol.did } // bob querying carol's records
+        author : bob,
+        filter : { recipient: carol.did } // bob querying carol's records
       });
 
       const replyToBobQuery = await dwn.processMessage(alice.did, bobQueryMessageData.message);
@@ -564,8 +564,8 @@ describe('RecordsQueryHandler.handle()', () => {
       const bob = await DidKeyResolver.generate();
 
       const bobQueryMessageData = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { recipient: bob.did } // alice as the DWN owner querying bob's records
+        author : alice,
+        filter : { recipient: bob.did } // alice as the DWN owner querying bob's records
       });
 
       const replyToBobQuery = await dwn.processMessage(alice.did, bobQueryMessageData.message);
@@ -578,12 +578,12 @@ describe('RecordsQueryHandler.handle()', () => {
       const alice = await DidKeyResolver.generate();
       const bob = await DidKeyResolver.generate();
       const schema = 'myAwesomeSchema';
-      const recordsWriteMessage1Data = await TestDataGenerator.generateRecordsWrite({ requester: alice, schema });
-      const recordsWriteMessage2Data = await TestDataGenerator.generateRecordsWrite({ requester: bob, schema });
+      const recordsWriteMessage1Data = await TestDataGenerator.generateRecordsWrite({ author: alice, schema });
+      const recordsWriteMessage2Data = await TestDataGenerator.generateRecordsWrite({ author: bob, schema });
 
       const aliceQueryMessageData = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { schema }
+        author : alice,
+        filter : { schema }
       });
 
       // insert data into 2 different tenants
@@ -601,8 +601,8 @@ describe('RecordsQueryHandler.handle()', () => {
 
       // query for non-normalized protocol
       const recordsQuery = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { protocol: 'example.com/' },
+        author : alice,
+        filter : { protocol: 'example.com/' },
       });
 
       // overwrite protocol because #create auto-normalizes protocol
@@ -625,8 +625,8 @@ describe('RecordsQueryHandler.handle()', () => {
 
       // query for non-normalized schema
       const recordsQuery = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { schema: 'example.com/' },
+        author : alice,
+        filter : { schema: 'example.com/' },
       });
 
       // overwrite schema because #create auto-normalizes schema
@@ -657,7 +657,7 @@ describe('RecordsQueryHandler.handle()', () => {
         const protocolDefinition = emailProtocolDefinition;
         const protocol = protocolDefinition.protocol;
         const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
-          requester: alice,
+          author: alice,
           protocolDefinition
         });
 
@@ -686,7 +686,7 @@ describe('RecordsQueryHandler.handle()', () => {
         const schema = protocolDefinition.types.email.schema;
         const { message, dataStream } = await TestDataGenerator.generateRecordsWrite(
           {
-            requester    : bob,
+            author       : bob,
             protocol,
             protocolPath : 'email', // this comes from `types` in protocol definition
             schema,
@@ -777,8 +777,8 @@ describe('RecordsQueryHandler.handle()', () => {
         };
 
         const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({
-          requester : alice,
-          data      : encryptedDataBytes,
+          author : alice,
+          data   : encryptedDataBytes,
           encryptionInput
         });
 
@@ -841,12 +841,12 @@ describe('RecordsQueryHandler.handle()', () => {
   });
 
   it('should return 401 if signature check fails', async () => {
-    const { requester, message } = await TestDataGenerator.generateRecordsQuery();
-    const tenant = requester.did;
+    const { author, message } = await TestDataGenerator.generateRecordsQuery();
+    const tenant = author.did;
 
     // setting up a stub did resolver & message store
     // intentionally not supplying the public key so a different public key is generated to simulate invalid signature
-    const mismatchingPersona = await TestDataGenerator.generatePersona({ did: requester.did, keyId: requester.keyId });
+    const mismatchingPersona = await TestDataGenerator.generatePersona({ did: author.did, keyId: author.keyId });
     const didResolver = TestStubGenerator.createDidResolverStub(mismatchingPersona);
     const messageStore = sinon.createStubInstance(MessageStoreLevel);
     const dataStore = sinon.createStubInstance(DataStoreLevel);
@@ -858,11 +858,11 @@ describe('RecordsQueryHandler.handle()', () => {
   });
 
   it('should return 400 if fail parsing the message', async () => {
-    const { requester, message } = await TestDataGenerator.generateRecordsQuery();
-    const tenant = requester.did;
+    const { author, message } = await TestDataGenerator.generateRecordsQuery();
+    const tenant = author.did;
 
     // setting up a stub method resolver & message store
-    const didResolver = TestStubGenerator.createDidResolverStub(requester);
+    const didResolver = TestStubGenerator.createDidResolverStub(author);
     const messageStore = sinon.createStubInstance(MessageStoreLevel);
     const dataStore = sinon.createStubInstance(DataStoreLevel);
     const recordsQueryHandler = new RecordsQueryHandler(didResolver, messageStore, dataStore);

--- a/tests/interfaces/records/handlers/records-read.spec.ts
+++ b/tests/interfaces/records/handlers/records-read.spec.ts
@@ -70,7 +70,7 @@ describe('RecordsReadHandler.handle()', () => {
       const alice = await DidKeyResolver.generate();
 
       // insert data
-      const { message, dataStream, dataBytes } = await TestDataGenerator.generateRecordsWrite({ requester: alice });
+      const { message, dataStream, dataBytes } = await TestDataGenerator.generateRecordsWrite({ author: alice });
       const writeReply = await dwn.processMessage(alice.did, message, dataStream);
       expect(writeReply.status.code).to.equal(202);
 
@@ -93,7 +93,7 @@ describe('RecordsReadHandler.handle()', () => {
       const alice = await DidKeyResolver.generate();
 
       // insert data
-      const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ requester: alice });
+      const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice });
       const writeReply = await dwn.processMessage(alice.did, message, dataStream);
       expect(writeReply.status.code).to.equal(202);
 
@@ -113,7 +113,7 @@ describe('RecordsReadHandler.handle()', () => {
       const alice = await DidKeyResolver.generate();
 
       // insert public data
-      const { message, dataStream, dataBytes } = await TestDataGenerator.generateRecordsWrite({ requester: alice, published: true });
+      const { message, dataStream, dataBytes } = await TestDataGenerator.generateRecordsWrite({ author: alice, published: true });
       const writeReply = await dwn.processMessage(alice.did, message, dataStream);
       expect(writeReply.status.code).to.equal(202);
 
@@ -134,7 +134,7 @@ describe('RecordsReadHandler.handle()', () => {
       const alice = await DidKeyResolver.generate();
 
       // insert public data
-      const { message, dataStream, dataBytes } = await TestDataGenerator.generateRecordsWrite({ requester: alice, published: true });
+      const { message, dataStream, dataBytes } = await TestDataGenerator.generateRecordsWrite({ author: alice, published: true });
       const writeReply = await dwn.processMessage(alice.did, message, dataStream);
       expect(writeReply.status.code).to.equal(202);
 
@@ -164,7 +164,7 @@ describe('RecordsReadHandler.handle()', () => {
 
         // Install social-media protocol on Alice's DWN
         const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
-          requester: alice,
+          author: alice,
           protocolDefinition
         });
         const protocolWriteReply = await dwn.processMessage(alice.did, protocolsConfig.message, protocolsConfig.dataStream);
@@ -173,7 +173,7 @@ describe('RecordsReadHandler.handle()', () => {
         // Alice writes image to her DWN
         const encodedImage = new TextEncoder().encode('cafe-aesthetic.jpg');
         const imageRecordsWrite = await TestDataGenerator.generateRecordsWrite({
-          requester    : alice,
+          author       : alice,
           protocol     : protocolDefinition.protocol,
           protocolPath : 'image', // this comes from `types` in protocol definition
           schema       : protocolDefinition.types.image.schema,
@@ -205,7 +205,7 @@ describe('RecordsReadHandler.handle()', () => {
 
         // Install email protocol on Alice's DWN
         const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
-          requester: alice,
+          author: alice,
           protocolDefinition
         });
         const protocolWriteReply = await dwn.processMessage(alice.did, protocolsConfig.message, protocolsConfig.dataStream);
@@ -214,7 +214,7 @@ describe('RecordsReadHandler.handle()', () => {
         // Alice writes an email with Bob as recipient
         const encodedEmail = new TextEncoder().encode('Dear Bob, hello!');
         const emailRecordsWrite = await TestDataGenerator.generateRecordsWrite({
-          requester    : alice,
+          author       : alice,
           protocol     : protocolDefinition.protocol,
           protocolPath : 'email', // this comes from `types` in protocol definition
           schema       : protocolDefinition.types.email.schema,
@@ -254,7 +254,7 @@ describe('RecordsReadHandler.handle()', () => {
 
         // Install email protocol on Alice's DWN
         const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
-          requester: alice,
+          author: alice,
           protocolDefinition
         });
         const protocolWriteReply = await dwn.processMessage(alice.did, protocolsConfig.message, protocolsConfig.dataStream);
@@ -263,7 +263,7 @@ describe('RecordsReadHandler.handle()', () => {
         // Alice writes an email with Bob as recipient
         const encodedEmail = new TextEncoder().encode('Dear Alice, hello!');
         const emailRecordsWrite = await TestDataGenerator.generateRecordsWrite({
-          requester    : bob,
+          author       : bob,
           protocol     : protocolDefinition.protocol,
           protocolPath : 'email', // this comes from `types` in protocol definition
           schema       : protocolDefinition.types.email.schema,
@@ -309,14 +309,14 @@ describe('RecordsReadHandler.handle()', () => {
       const alice = await DidKeyResolver.generate();
 
       // insert public data
-      const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ requester: alice, published: true });
+      const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice, published: true });
       const writeReply = await dwn.processMessage(alice.did, message, dataStream);
       expect(writeReply.status.code).to.equal(202);
 
       // ensure data is inserted
       const queryData = await TestDataGenerator.generateRecordsQuery({
-        requester : alice,
-        filter    : { recordId: message.recordId }
+        author : alice,
+        filter : { recordId: message.recordId }
       });
 
       const reply = await dwn.processMessage(alice.did, queryData.message);
@@ -348,7 +348,7 @@ describe('RecordsReadHandler.handle()', () => {
       sinon.stub(dataStore, 'get').resolves(undefined);
 
       // insert data
-      const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ requester: alice });
+      const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice });
       const writeReply = await dwn.processMessage(alice.did, message, dataStream);
       expect(writeReply.status.code).to.equal(202);
 
@@ -388,8 +388,8 @@ describe('RecordsReadHandler.handle()', () => {
         };
 
         const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({
-          requester : alice,
-          data      : encryptedDataBytes,
+          author : alice,
+          data   : encryptedDataBytes,
           encryptionInput
         });
 
@@ -455,7 +455,7 @@ describe('RecordsReadHandler.handle()', () => {
         // configure protocol
         const protocolDefinition = emailProtocolDefinition;
         const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
-          requester: alice,
+          author: alice,
           protocolDefinition
         });
 
@@ -483,7 +483,7 @@ describe('RecordsReadHandler.handle()', () => {
 
         const { message, dataStream } = await TestDataGenerator.generateRecordsWrite(
           {
-            requester    : bob,
+            author       : bob,
             protocol     : protocolDefinition.protocol,
             protocolPath : 'email', // this comes from `types` in protocol definition
             schema       : protocolDefinition.types.email.schema,

--- a/tests/interfaces/records/messages/records-write.spec.ts
+++ b/tests/interfaces/records/messages/records-write.spec.ts
@@ -230,14 +230,14 @@ describe('RecordsWrite', () => {
 
   describe('createFrom()', () => {
     it('should create a RecordsWrite with `published` set to `true` with just `publishedDate` given', async () => {
-      const { requester, recordsWrite } = await TestDataGenerator.generateRecordsWrite({
+      const { author, recordsWrite } = await TestDataGenerator.generateRecordsWrite({
         published: false
       });
 
       const write = await RecordsWrite.createFrom({
         unsignedRecordsWriteMessage : recordsWrite.message,
         datePublished               : getCurrentTimeInHighPrecision(),
-        authorizationSignatureInput : Jws.createSignatureInput(requester)
+        authorizationSignatureInput : Jws.createSignatureInput(author)
       });
 
       expect(write.message.descriptor.published).to.be.true;

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -57,20 +57,20 @@ export type Persona = {
 };
 
 export type GenerateProtocolsConfigureInput = {
-  requester?: Persona;
+  author?: Persona;
   dateCreated?: string;
   protocolDefinition?: ProtocolDefinition;
 };
 
 export type GenerateProtocolsConfigureOutput = {
-  requester: Persona;
+  author: Persona;
   message: ProtocolsConfigureMessage;
   dataStream?: Readable;
   protocolsConfigure: ProtocolsConfigure;
 };
 
 export type GenerateProtocolsQueryInput = {
-  requester?: Persona;
+  author?: Persona;
   dateCreated?: string;
   filter?: {
     protocol: string;
@@ -78,13 +78,13 @@ export type GenerateProtocolsQueryInput = {
 };
 
 export type GenerateProtocolsQueryOutput = {
-  requester: Persona;
+  author: Persona;
   message: ProtocolsQueryMessage;
   protocolsQuery: ProtocolsQuery;
 };
 
 export type GenerateRecordsWriteInput = {
-  requester?: Persona;
+  author?: Persona;
   attesters?: Persona[];
   recipient?: string;
   protocol?: string;
@@ -105,7 +105,7 @@ export type GenerateRecordsWriteInput = {
 };
 
 export type GenerateFromRecordsWriteInput = {
-  requester: Persona,
+  author: Persona,
   existingWrite: RecordsWrite,
   data?: Uint8Array;
   published?: boolean;
@@ -121,7 +121,7 @@ export type GenerateFromRecordsWriteOut = {
 };
 
 export type GenerateRecordsWriteOutput = {
-  requester: Persona;
+  author: Persona;
   message: RecordsWriteMessage;
   dataCid?: string;
   dataSize?: number;
@@ -131,30 +131,30 @@ export type GenerateRecordsWriteOutput = {
 };
 
 export type GenerateRecordsQueryInput = {
-  requester?: Persona;
+  author?: Persona;
   dateCreated?: string;
   filter?: RecordsQueryFilter;
   dateSort?: DateSort;
 };
 
 export type GenerateRecordsQueryOutput = {
-  requester: Persona;
+  author: Persona;
   message: RecordsQueryMessage;
 };
 
 export type GenerateRecordsDeleteInput = {
-  requester?: Persona;
+  author?: Persona;
   recordId?: string;
 };
 
 export type GenerateRecordsDeleteOutput = {
-  requester: Persona;
+  author: Persona;
   recordsDelete: RecordsDelete;
   message: RecordsDeleteMessage;
 };
 
 export type GenerateHooksWriteInput = {
-  requester?: Persona;
+  author?: Persona;
   dateCreated?: string;
   filter?: {
     method: string;
@@ -163,28 +163,28 @@ export type GenerateHooksWriteInput = {
 };
 
 export type GenerateHooksWriteOutput = {
-  requester: Persona;
+  author: Persona;
   message: HooksWriteMessage;
 };
 
 export type GenerateEventsGetInput = {
-  requester?: Persona;
+  author?: Persona;
   watermark?: string;
 };
 
 export type GenerateEventsGetOutput = {
-  requester: Persona;
+  author: Persona;
   eventsGet: EventsGet;
   message: EventsGetMessage;
 };
 
 export type GenerateMessagesGetInput = {
-  requester?: Persona;
+  author?: Persona;
   messageCids: string[]
 };
 
 export type GenerateMessagesGetOutput = {
-  requester: Persona;
+  author: Persona;
   message: MessagesGetMessage;
   messagesGet: MessagesGet;
 };
@@ -204,11 +204,11 @@ export class TestDataGenerator {
       did = `did:example:${didSuffix}`;
     }
 
-    // generate requester key ID if not given
+    // generate persona key ID if not given
     const keyIdSuffix = TestDataGenerator.randomString(10);
     const keyId = input?.keyId ?? `${did}#${keyIdSuffix}`;
 
-    // generate requester key pair if not given
+    // generate persona key pair if not given
     const keyPair = input?.keyPair ?? await Secp256k1.generateKeyPair();
 
     const persona: Persona = {
@@ -229,7 +229,7 @@ export class TestDataGenerator {
     input?: GenerateProtocolsConfigureInput
   ): Promise<GenerateProtocolsConfigureOutput> {
 
-    const requester = input?.requester ?? await TestDataGenerator.generatePersona();
+    const author = input?.author ?? await TestDataGenerator.generatePersona();
 
     // generate protocol types and  definition if not given
     let definition = input?.protocolDefinition;
@@ -252,7 +252,7 @@ export class TestDataGenerator {
     // const dataStream = DataStream.fromObject(definition); // intentionally left here to demonstrate the pattern to use when #139 is implemented
     const dataStream = undefined;
 
-    const authorizationSignatureInput = Jws.createSignatureInput(requester);
+    const authorizationSignatureInput = Jws.createSignatureInput(author);
 
     const options: ProtocolsConfigureOptions = {
       dateCreated: input?.dateCreated,
@@ -263,7 +263,7 @@ export class TestDataGenerator {
     const protocolsConfigure = await ProtocolsConfigure.create(options);
 
     return {
-      requester,
+      author,
       message: protocolsConfigure.message,
       dataStream,
       protocolsConfigure
@@ -274,10 +274,10 @@ export class TestDataGenerator {
    * Generates a ProtocolsQuery message for testing.
    */
   public static async generateProtocolsQuery(input?: GenerateProtocolsQueryInput): Promise<GenerateProtocolsQueryOutput> {
-    // generate requester persona if not given
-    const requester = input?.requester ?? await TestDataGenerator.generatePersona();
+    // generate author persona if not given
+    const author = input?.author ?? await TestDataGenerator.generatePersona();
 
-    const authorizationSignatureInput = Jws.createSignatureInput(requester);
+    const authorizationSignatureInput = Jws.createSignatureInput(author);
 
     const options: ProtocolsQueryOptions = {
       dateCreated : input?.dateCreated,
@@ -289,7 +289,7 @@ export class TestDataGenerator {
     const protocolsQuery = await ProtocolsQuery.create(options);
 
     return {
-      requester,
+      author,
       message: protocolsQuery.message,
       protocolsQuery
     };
@@ -301,13 +301,13 @@ export class TestDataGenerator {
    * @param input.attesters Attesters of the message. Will NOT be generated if not given.
    * @param input.data Data that belongs to the record. Generated when not given only if `dataCid` and `dataSize` are also not given.
    * @param input.dataFormat Format of the data. Defaults to 'application/json' if not given.
-   * @param input.requester Author of the message. Generated if not given.
+   * @param input.author Author of the message. Generated if not given.
    * @param input.schema Schema of the message. Randomly generated if not given.
    */
   public static async generateRecordsWrite(input?: GenerateRecordsWriteInput): Promise<GenerateRecordsWriteOutput> {
-    const requester = input?.requester ?? await TestDataGenerator.generatePersona();
+    const author = input?.author ?? await TestDataGenerator.generatePersona();
 
-    const authorizationSignatureInput = Jws.createSignatureInput(requester);
+    const authorizationSignatureInput = Jws.createSignatureInput(author);
     const attestationSignatureInputs = Jws.createSignatureInputs(input?.attesters ?? []);
 
     const dataCid = input?.dataCid;
@@ -344,7 +344,7 @@ export class TestDataGenerator {
     const message = recordsWrite.message as RecordsWriteMessage;
 
     return {
-      requester,
+      author,
       message,
       dataCid,
       dataSize,
@@ -375,7 +375,7 @@ export class TestDataGenerator {
       published,
       datePublished,
       dateModified                : input.dateModified,
-      authorizationSignatureInput : Jws.createSignatureInput(input.requester)
+      authorizationSignatureInput : Jws.createSignatureInput(input.author)
     };
 
     const recordsWrite = await RecordsWrite.createFrom(options);
@@ -391,9 +391,9 @@ export class TestDataGenerator {
    * Generates a RecordsQuery message for testing.
    */
   public static async generateRecordsQuery(input?: GenerateRecordsQueryInput): Promise<GenerateRecordsQueryOutput> {
-    const requester = input?.requester ?? await TestDataGenerator.generatePersona();
+    const author = input?.author ?? await TestDataGenerator.generatePersona();
 
-    const authorizationSignatureInput = Jws.createSignatureInput(requester);
+    const authorizationSignatureInput = Jws.createSignatureInput(author);
 
     const options: RecordsQueryOptions = {
       dateCreated : input?.dateCreated,
@@ -407,7 +407,7 @@ export class TestDataGenerator {
     const message = recordsQuery.message as RecordsQueryMessage;
 
     return {
-      requester,
+      author,
       message
     };
   };
@@ -416,15 +416,15 @@ export class TestDataGenerator {
    * Generates a RecordsDelete for testing.
    */
   public static async generateRecordsDelete(input?: GenerateRecordsDeleteInput): Promise<GenerateRecordsDeleteOutput> {
-    const requester = input?.requester ?? await DidKeyResolver.generate();
+    const author = input?.author ?? await DidKeyResolver.generate();
 
     const recordsDelete = await RecordsDelete.create({
       recordId                    : input?.recordId ?? await TestDataGenerator.randomCborSha256Cid(),
-      authorizationSignatureInput : Jws.createSignatureInput(requester)
+      authorizationSignatureInput : Jws.createSignatureInput(author)
     });
 
     return {
-      requester,
+      author,
       recordsDelete,
       message: recordsDelete.message
     };
@@ -434,9 +434,9 @@ export class TestDataGenerator {
    * Generates a HooksWrite message for testing.
    */
   public static async generateHooksWrite(input?: GenerateHooksWriteInput): Promise<GenerateHooksWriteOutput> {
-    const requester = input?.requester ?? await TestDataGenerator.generatePersona();
+    const author = input?.author ?? await TestDataGenerator.generatePersona();
 
-    const authorizationSignatureInput = Jws.createSignatureInput(requester);
+    const authorizationSignatureInput = Jws.createSignatureInput(author);
 
     const options: HooksWriteOptions = {
       dateCreated : input?.dateCreated,
@@ -448,7 +448,7 @@ export class TestDataGenerator {
     const hooksWrite = await HooksWrite.create(options);
 
     return {
-      requester,
+      author,
       message: hooksWrite.message
     };
   };
@@ -471,8 +471,8 @@ export class TestDataGenerator {
   }
 
   public static async generateEventsGet(input?: GenerateEventsGetInput): Promise<GenerateEventsGetOutput> {
-    const requester = input?.requester ?? await TestDataGenerator.generatePersona();
-    const authorizationSignatureInput = Jws.createSignatureInput(requester);
+    const author = input?.author ?? await TestDataGenerator.generatePersona();
+    const authorizationSignatureInput = Jws.createSignatureInput(author);
 
     const options: EventsGetOptions = { authorizationSignatureInput };
     if (input?.watermark) {
@@ -482,15 +482,15 @@ export class TestDataGenerator {
     const eventsGet = await EventsGet.create(options);
 
     return {
-      requester,
+      author,
       eventsGet,
       message: eventsGet.message
     };
   }
 
   public static async generateMessagesGet(input: GenerateMessagesGetInput): Promise<GenerateMessagesGetOutput> {
-    const requester = input?.requester ?? await TestDataGenerator.generatePersona();
-    const authorizationSignatureInput = Jws.createSignatureInput(requester);
+    const author = input?.author ?? await TestDataGenerator.generatePersona();
+    const authorizationSignatureInput = Jws.createSignatureInput(author);
 
     const options: MessagesGetOptions = {
       authorizationSignatureInput,
@@ -500,7 +500,7 @@ export class TestDataGenerator {
     const messagesGet = await MessagesGet.create(options);
 
     return {
-      requester,
+      author,
       messagesGet,
       message: messagesGet.message,
     };


### PR DESCRIPTION
I have been meaning to rename "requester" to "author" for a long time and never found the bandwidth and gap to do so without introducing annoying conflicts due to the constant streams of PRs flowing in.

We initially used the two terms interchangeably months ago, and overtime we have converged on "author" being objectively the better term (especially in tests) except for some specific contexts, thus using this gap to quickly switch over.