### PR TITLE
index-level refactoring

### DIFF
--- a/Q_AND_A.md
+++ b/Q_AND_A.md
@@ -48,3 +48,11 @@
   This is because:
   1. `kid` is an optional property of a JWK, there is no guarantee that the public JWK will contain it.
   2. In the future public key may not always be given in JWK format. A key in raw bytes does not contain metadata such as key ID.
+
+
+## Protocol
+- Can a record that is not protocol-authorized have `protocol` property in its `descriptor`?
+
+  (Last updated: 2023/05/23)
+
+  No.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.14%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.24%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.97%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.14%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.15%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.25%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.95%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.15%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.15%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.25%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.95%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.15%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.15%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.24%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.95%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.15%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-96.96%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.31%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.28%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-96.96%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-96.99%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.41%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.28%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-96.99%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.15%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.24%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.95%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.15%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-96.96%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.31%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.28%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-96.96%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.17%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.32%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-94%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.17%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.14%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.24%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.97%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.14%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.15%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.33%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-94%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.15%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.17%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.32%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-94%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.17%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/src/store/index-level.ts
+++ b/src/store/index-level.ts
@@ -35,10 +35,10 @@ export class IndexLevel {
 
   /**
    * Adds indexes for a specific data/object/content.
-   * @param id ID of the data/object/content being indexed.
+   * @param dataId ID of the data/object/content being indexed.
    */
   async put(
-    id: string,
+    dataId: string,
     indexes: { [property: string]: unknown },
     options?: IndexLevelOptions
   ): Promise<void> {
@@ -49,7 +49,7 @@ export class IndexLevel {
 
     // create an index entry for each property in the `indexes`
     for (const propertyName in indexes) {
-      const value = indexes[propertyName];
+      const propertyValue = indexes[propertyName];
 
       // NOTE: appending data ID after (property + value) serves two purposes:
       // 1. creates a unique entry of the property-value pair per data/object
@@ -61,16 +61,16 @@ export class IndexLevel {
       // 'schema\u0000"http://ud4kyzon6ugxn64boz7v"\u0000bafyreigs3em7lrclhntzhgvkrf75j2muk6e7ypq3lrw3ffgcpyazyw6pry'
       // 'dataCid\u0000"bafkreic3ie3cxsblp46vn3ofumdnwiqqk4d5ah7uqgpcn6xps4skfvagze"\u0000bafyreigs3em7lrclhntzhgvkrf75j2muk6e7ypq3lrw3ffgcpyazyw6pry'
       // 'dateCreated\u0000"2023-05-25T18:23:29.425008Z"\u0000bafyreigs3em7lrclhntzhgvkrf75j2muk6e7ypq3lrw3ffgcpyazyw6pry'
-      const key = this.join(propertyName, this.encodeValue(value), id);
-      operations.push({ type: 'put', key, value: id });
+      const key = this.join(propertyName, this.encodeValue(propertyValue), dataId);
+      operations.push({ type: 'put', key, value: dataId });
     }
 
     // create a reverse lookup entry for data ID -> its indexes
     // this is for indexes deletion (`delete()`): so that given the data ID, we are able to delete all its indexes
     // we can consider putting this info in a different data partition if this ever becomes more complex/confusing
-    operations.push({ type: 'put', key: `__${id}__indexes`, value: JSON.stringify(indexes) });
+    operations.push({ type: 'put', key: `__${dataId}__indexes`, value: JSON.stringify(indexes) });
 
-    return this.db.batch(operations, options);
+    await this.db.batch(operations, options);
   }
 
   async query(filter: Filter, options?: IndexLevelOptions): Promise<Array<string>> {
@@ -81,10 +81,6 @@ export class IndexLevel {
     // We will find the union of these many individual queries later.
     for (const propertyName in filter) {
       const propertyFilter = filter[propertyName];
-
-      if (propertyFilter === null) {
-        continue;
-      }
 
       if (typeof propertyFilter === 'object') {
         if (Array.isArray(propertyFilter)) {
@@ -111,21 +107,21 @@ export class IndexLevel {
 
     // map of ID of all data/object -> list of missing property matches
     // if list of missing property matches is 0, then it data/object is fully matches the filter
-    const missingPropertyMatchesForId: { [id: string]: Set<string> } = { };
+    const missingPropertyMatchesForId: { [dataId: string]: Set<string> } = { };
 
     // Resolve promises and find the union of results for each individual propertyName DB query
     const matchedIDs: string[] = [ ];
     for (const [propertyName, promises] of Object.entries(propertyNameToPromises)) {
       // acting as an OR match for the property, any of the promises returning a match will be treated as a property match
       for (const promise of promises) {
-        for (const id of await promise) {
+        for (const dataId of await promise) {
           // if first time seeing a property matching for the data/object, record all properties needing a match to track progress
-          missingPropertyMatchesForId[id] ??= new Set<string>([ ...Object.keys(filter) ]);
+          missingPropertyMatchesForId[dataId] ??= new Set<string>([ ...Object.keys(filter) ]);
 
-          missingPropertyMatchesForId[id].delete(propertyName);
-          if (missingPropertyMatchesForId[id].size === 0) {
+          missingPropertyMatchesForId[dataId].delete(propertyName);
+          if (missingPropertyMatchesForId[dataId].size === 0) {
             // full filter match, add it to return list
-            matchedIDs.push(id);
+            matchedIDs.push(dataId);
           }
         }
       }
@@ -134,8 +130,8 @@ export class IndexLevel {
     return matchedIDs;
   }
 
-  async delete(id: string, options?: IndexLevelOptions): Promise<void> {
-    const serializedIndexes = await this.db.get(`__${id}__indexes`, options);
+  async delete(dataId: string, options?: IndexLevelOptions): Promise<void> {
+    const serializedIndexes = await this.db.get(`__${dataId}__indexes`, options);
     if (!serializedIndexes) {
       return;
     }
@@ -145,14 +141,14 @@ export class IndexLevel {
     // delete all indexes associated with the data of the given ID
     const ops: LevelWrapperBatchOperation<string>[] = [ ];
     for (const propertyName in indexes) {
-      const value = indexes[propertyName];
-      const key = this.join(propertyName, this.encodeValue(value), id);
+      const propertyValue = indexes[propertyName];
+      const key = this.join(propertyName, this.encodeValue(propertyValue), dataId);
       ops.push({ type: 'del', key });
     }
 
-    ops.push({ type: 'del', key: `__${id}__indexes` });
+    ops.push({ type: 'del', key: `__${dataId}__indexes` });
 
-    return this.db.batch(ops, options);
+    await this.db.batch(ops, options);
   }
 
   async clear(): Promise<void> {
@@ -160,7 +156,7 @@ export class IndexLevel {
   }
 
   /**
-   * @returns IDs that matches the exact property and value.
+   * @returns IDs of data that matches the exact property and value.
    */
   private async findExactMatches(propertyName: string, propertyValue: unknown, options?: IndexLevelOptions): Promise<string[]> {
     const propertyValuePrefix = this.join(propertyName, this.encodeValue(propertyValue));
@@ -170,18 +166,18 @@ export class IndexLevel {
     };
 
     const matches: string[] = [];
-    for await (const [ key, id ] of this.db.iterator(iteratorOptions, options)) {
+    for await (const [ key, dataId ] of this.db.iterator(iteratorOptions, options)) {
       if (!key.startsWith(propertyValuePrefix)) {
         break;
       }
 
-      matches.push(id);
+      matches.push(dataId);
     }
     return matches;
   }
 
   /**
-   * @returns IDs that matches the range filter.
+   * @returns IDs of data that matches the range filter.
    */
   private async findRangeMatches(propertyName: string, range: RangeFilter, options?: IndexLevelOptions): Promise<string[]> {
     const iteratorOptions: LevelWrapperIteratorOptions<string> = { };
@@ -196,23 +192,23 @@ export class IndexLevel {
     }
 
     const matches: string[] = [];
-    for await (const [ key, id ] of this.db.iterator(iteratorOptions, options)) {
+    for await (const [ key, dataId ] of this.db.iterator(iteratorOptions, options)) {
       // immediately stop if we arrive at an index entry for a different property
       if (!key.startsWith(propertyName)) {
         break;
       }
 
-      matches.push(id);
+      matches.push(dataId);
     }
 
     if ('lte' in range) {
       // When `lte` is used, we must also query the exact match explicitly because the exact match will not be included in the iterator above.
       // This is due to the extra data (CID) appended to the (property + value) key prefix, e.g.
       // key = 'dateCreated\u0000"2023-05-25T11:22:33.000000Z"\u0000bafyreigs3em7lrclhntzhgvkrf75j2muk6e7ypq3lrw3ffgcpyazyw6pry'
-      // the value would be considered greater than { lte: `dateCreated\u0000"2023-05-25T11:22:33.000000Z"` } in the iterator options,
-      // thus would not included in such iterator even though we'd like it to be.
-      for (const id of await this.findExactMatches(propertyName, range.lte, options)) {
-        matches.push(id);
+      // the value would be considered greater than { lte: `dateCreated\u0000"2023-05-25T11:22:33.000000Z"` } used in the iterator options,
+      // thus would not be included in the iterator even though we'd like it to be.
+      for (const dataId of await this.findExactMatches(propertyName, range.lte, options)) {
+        matches.push(dataId);
       }
     }
 

--- a/src/store/level-wrapper.ts
+++ b/src/store/level-wrapper.ts
@@ -191,14 +191,21 @@ export class LevelWrapper<V> {
     }
   }
 
+  /**
+   * Gets the min and max key value of this partition.
+   */
   private get sublevelRange(): [ string, string ] | undefined {
-    const prefix = (this.db as any).prefix;
+    const prefix = (this.db as any).prefix as string;
     if (!prefix) {
       return undefined;
     }
 
-    // use the separator to derive an exclusive `end` that will never match to a key (which matches how `abstract-level` creates a `boundary`)
-    return [ prefix, prefix.slice(0, -1) + String.fromCharCode(prefix.charCodeAt(prefix.length - 1) + 1) ];
+    // derive an exclusive `maxKey` by changing the last prefix character to the immediate succeeding character in unicode
+    // (which matches how `abstract-level` creates a `boundary`)
+    const maxKey = prefix.slice(0, -1) + String.fromCharCode(prefix.charCodeAt(prefix.length - 1) + 1);
+    const minKey = prefix;
+
+    return [minKey, maxKey];
   }
 
   private get root(): LevelWrapper<V> {

--- a/src/utils/abort.ts
+++ b/src/utils/abort.ts
@@ -1,8 +1,10 @@
 /**
- * Wraps the given `AbortSignal` in a `Promise` that rejects if it is triggered (and will therefore never resolve).
+ * Wraps the given `AbortSignal` in a `Promise` that rejects if it is programmatically triggered,
+ * otherwise the promise will remain in await state (will never resolve).
  */
-function promisifySignal<Type>(signal: AbortSignal): Promise<Type> {
+function promisifySignal<T>(signal: AbortSignal): Promise<T> {
   return new Promise((resolve, reject) => {
+    // immediately reject if the given is signal is already aborted
     if (signal.aborted) {
       reject(signal.reason);
       return;
@@ -17,13 +19,13 @@ function promisifySignal<Type>(signal: AbortSignal): Promise<Type> {
 /**
  * Wraps the given `Promise` such that it will reject if the `AbortSignal` is triggered.
  */
-export async function abortOr<Type>(signal: AbortSignal | undefined, promise: Promise<Type>): Promise<Type> {
+export async function executeUnlessAborted<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
   if (!signal) {
     return promise;
   }
 
   return Promise.race([
     promise,
-    promisifySignal<Type>(signal),
+    promisifySignal<T>(signal),
   ]);
 }

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -4,7 +4,7 @@ import flat from 'flat';
  * Flattens the given object.
  * e.g. `{ a: { b: { c: 42 } } }` becomes `{ 'a.b.c': 42 }`
  */
-export function flatten(obj: unknown): object {
+export function flatten(obj: unknown): Record<string, unknown> {
   const flattened = flat.flatten<unknown, Record<string, unknown>>(obj);
   removeEmptyObjects(flattened);
   return flattened;


### PR DESCRIPTION
Refactored the Level implementation of data indexing in preparation for inevitable Protocol participant requirements:

1.  Refactored `put()` by simplifying how indexes are stored for deletion purposes
1. Refactored `query()` (thanks @diehuxx !!)
1. Refactored `findExactMatches()` and `findRangeMatches()` by removing `findMatches()`
1. Refactored `delete()`
1. Removed `Match`
1. Added a lot of comments/documentation
1. A lot of renames