### PR TITLE
Add smarter return typing to Dwn.processMessage()

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-96.98%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.92%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.31%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-96.98%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-96.98%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.93%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.31%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-96.98%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.16%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.77%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-94.01%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.16%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.15%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.76%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.97%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.15%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.15%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.33%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-94%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.15%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.16%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-93.77%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-94.01%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.16%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/src/core/message-reply.ts
+++ b/src/core/message-reply.ts
@@ -1,15 +1,6 @@
-import type { QueryResultEntry } from '../types/message-types.js';
-import type { Readable } from 'readable-stream';
-
 type Status = {
   code: number
   detail: string
-};
-
-type MessageReplyOptions = {
-  status: Status,
-  entries?: QueryResultEntry[];
-  data? : Readable;
 };
 
 export type BaseMessageReply = {

--- a/src/core/message-reply.ts
+++ b/src/core/message-reply.ts
@@ -12,11 +12,22 @@ type MessageReplyOptions = {
   data? : Readable;
 };
 
-export type BaseMessageReply = {
+export class BaseMessageReply {
   status: Status;
+
+  constructor(opts: MessageReplyOptions) {
+    this.status = opts.status;
+  }
+
+  static fromError(e: unknown, code: number): CommonMessageReply {
+
+    const detail = e instanceof Error ? e.message : 'Error';
+
+    return new CommonMessageReply({ status: { code, detail } });
+  }
 };
 
-export class MessageReply {
+export class CommonMessageReply {
   status: Status;
 
   /**
@@ -40,10 +51,5 @@ export class MessageReply {
     this.data = data;
   }
 
-  static fromError(e: unknown, code: number): MessageReply {
 
-    const detail = e instanceof Error ? e.message : 'Error';
-
-    return new MessageReply({ status: { code, detail } });
-  }
 }

--- a/src/core/message-reply.ts
+++ b/src/core/message-reply.ts
@@ -12,44 +12,13 @@ type MessageReplyOptions = {
   data? : Readable;
 };
 
-export class BaseMessageReply {
+export type BaseMessageReply = {
   status: Status;
-
-  constructor(opts: MessageReplyOptions) {
-    this.status = opts.status;
-  }
-
-  static fromError(e: unknown, code: number): CommonMessageReply {
-
-    const detail = e instanceof Error ? e.message : 'Error';
-
-    return new CommonMessageReply({ status: { code, detail } });
-  }
 };
 
-export class CommonMessageReply {
-  status: Status;
+export function messageReplyFromError(e: unknown, code: number): BaseMessageReply {
 
-  /**
-   * Resulting message entries or events returned from the invocation of the corresponding message.
-   * e.g. the resulting messages from a RecordsQuery
-   * Mutually exclusive with `data`.
-   */
-  entries?: QueryResultEntry[];
+  const detail = e instanceof Error ? e.message : 'Error';
 
-  /**
-   * Data corresponding to the message received if applicable (e.g. RecordsRead).
-   * Mutually exclusive with `entries`.
-   */
-  data?: Readable;
-
-  constructor(opts: MessageReplyOptions) {
-    const { status, entries, data } = opts;
-
-    this.status = status;
-    this.entries = entries;
-    this.data = data;
-  }
-
-
+  return { status: { code, detail } };
 }

--- a/src/core/message.ts
+++ b/src/core/message.ts
@@ -28,6 +28,17 @@ export enum DwnMethodName {
   Delete = 'Delete'
 }
 
+export enum DwnMessageName {
+  EventsGet = 'EventsGet',
+  MessagesGet = 'MessagesGet',
+  ProtocolsConfigure = 'ProtocolsConfigure',
+  ProtocolsQuery = 'ProtocolsQuery',
+  RecordsDelete = 'RecordsDelete',
+  RecordsQuery = 'RecordsQuery',
+  RecordsRead = 'RecordsRead',
+  RecordsWrite = 'RecordsWrite',
+}
+
 export abstract class Message<M extends BaseMessage> {
   readonly message: M;
   readonly authorizationPayload: any;

--- a/src/dwn.ts
+++ b/src/dwn.ts
@@ -175,13 +175,12 @@ export class Dwn {
     const actualMessageType = dwnInterface + dwnMethod;
     if (expectedMessageType !== actualMessageType) {
       return new BaseMessageReply({
-        status: { code: 400, detail: `Expected DWN message type ${expectedMessageType}, receieve ${actualMessageType}` }
+        status: { code: 400, detail: `Expected DWN message type ${expectedMessageType}, received ${actualMessageType}` }
       });
     }
 
     // validate message structure
     try {
-      // consider to push this down to individual handlers
       Message.validateJsonSchema(rawMessage);
     } catch (error) {
       return BaseMessageReply.fromError(error, 400);

--- a/src/dwn.ts
+++ b/src/dwn.ts
@@ -6,9 +6,9 @@ import type { MethodHandler } from './types/method-handler.js';
 import type { Readable } from 'readable-stream';
 import type { RecordsWriteHandlerOptions } from './interfaces/records/handlers/records-write.js';
 import type { TenantGate } from './core/tenant-gate.js';
+import type { DwnMessage, DwnMessageMap, DwnMessageReply } from './types/dwn-types.js';
 import type { MessagesGetMessage, MessagesGetReply } from './types/messages-types.js';
 import type { RecordsReadMessage, RecordsReadReply, RecordsWriteMessage } from './types/records-types.js';
-import type { DwnMessage, DwnMessageMap, DwnMessageReply } from './types/dwn-types.js';
 
 import { AllowAllTenantGate } from './core/tenant-gate.js';
 import { DataStoreLevel } from './store/data-store-level.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export { Jws } from './utils/jws.js';
 export { KeyMaterial, PrivateJwk, PublicJwk } from './types/jose-types.js';
 export { Message } from './core/message.js';
 export { MessagesGet, MessagesGetOptions } from './interfaces/messages/messages/messages-get.js';
-export { CommonMessageReply as MessageReply } from './core/message-reply.js';
+export { BaseMessageReply as MessageReply } from './core/message-reply.js';
 export { MessageStore } from './types/message-store.js';
 export { MessageStoreLevel } from './store/message-store-level.js';
 export { ProtocolsConfigure, ProtocolsConfigureOptions } from './interfaces/protocols/messages/protocols-configure.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export { Jws } from './utils/jws.js';
 export { KeyMaterial, PrivateJwk, PublicJwk } from './types/jose-types.js';
 export { Message } from './core/message.js';
 export { MessagesGet, MessagesGetOptions } from './interfaces/messages/messages/messages-get.js';
-export { MessageReply } from './core/message-reply.js';
+export { CommonMessageReply as MessageReply } from './core/message-reply.js';
 export { MessageStore } from './types/message-store.js';
 export { MessageStoreLevel } from './store/message-store-level.js';
 export { ProtocolsConfigure, ProtocolsConfigureOptions } from './interfaces/protocols/messages/protocols-configure.js';

--- a/src/interfaces/events/handlers/events-get.ts
+++ b/src/interfaces/events/handlers/events-get.ts
@@ -5,7 +5,7 @@ import type { MethodHandler } from '../../../types/method-handler.js';
 import type { EventsGetMessage, EventsGetReply } from '../../../types/event-types.js';
 
 import { EventsGet } from '../messages/events-get.js';
-import { MessageReply } from '../../../core/message-reply.js';
+import { BaseMessageReply } from '../../../core/message-reply.js';
 import { authenticate, authorize } from '../../../core/auth.js';
 
 type HandleArgs = {tenant: string, message: EventsGetMessage};
@@ -19,14 +19,14 @@ export class EventsGetHandler implements MethodHandler {
     try {
       eventsGet = await EventsGet.parse(message);
     } catch (e) {
-      return MessageReply.fromError(e, 400);
+      return BaseMessageReply.fromError(e, 400);
     }
 
     try {
       await authenticate(message.authorization, this.didResolver);
       await authorize(tenant, eventsGet);
     } catch (e) {
-      return MessageReply.fromError(e, 401);
+      return BaseMessageReply.fromError(e, 401);
     }
 
     // if watermark was provided in message, get all events _after_ the watermark.

--- a/src/interfaces/events/handlers/events-get.ts
+++ b/src/interfaces/events/handlers/events-get.ts
@@ -5,12 +5,12 @@ import type { MethodHandler } from '../../../types/method-handler.js';
 import type { EventsGetMessage, EventsGetReply } from '../../../types/event-types.js';
 
 import { EventsGet } from '../messages/events-get.js';
-import { BaseMessageReply } from '../../../core/message-reply.js';
 import { authenticate, authorize } from '../../../core/auth.js';
+import { messageReplyFromError } from '../../../core/message-reply.js';
 
 type HandleArgs = {tenant: string, message: EventsGetMessage};
 
-export class EventsGetHandler implements MethodHandler {
+export class EventsGetHandler implements MethodHandler<'EventsGet'> {
   constructor(private didResolver: DidResolver, private eventLog: EventLog) {}
 
   public async handle({ tenant, message }: HandleArgs): Promise<EventsGetReply> {
@@ -19,14 +19,14 @@ export class EventsGetHandler implements MethodHandler {
     try {
       eventsGet = await EventsGet.parse(message);
     } catch (e) {
-      return BaseMessageReply.fromError(e, 400);
+      return messageReplyFromError(e, 400);
     }
 
     try {
       await authenticate(message.authorization, this.didResolver);
       await authorize(tenant, eventsGet);
     } catch (e) {
-      return BaseMessageReply.fromError(e, 401);
+      return messageReplyFromError(e, 401);
     }
 
     // if watermark was provided in message, get all events _after_ the watermark.

--- a/src/interfaces/events/handlers/events-get.ts
+++ b/src/interfaces/events/handlers/events-get.ts
@@ -5,8 +5,8 @@ import type { MethodHandler } from '../../../types/method-handler.js';
 import type { EventsGetMessage, EventsGetReply } from '../../../types/event-types.js';
 
 import { EventsGet } from '../messages/events-get.js';
-import { authenticate, authorize } from '../../../core/auth.js';
 import { messageReplyFromError } from '../../../core/message-reply.js';
+import { authenticate, authorize } from '../../../core/auth.js';
 
 type HandleArgs = {tenant: string, message: EventsGetMessage};
 

--- a/src/interfaces/messages/handlers/messages-get.ts
+++ b/src/interfaces/messages/handlers/messages-get.ts
@@ -7,7 +7,7 @@ import type { MessagesGetMessage, MessagesGetReply, MessagesGetReplyEntry } from
 import { DataStream } from '../../../utils/data-stream.js';
 import { DwnConstant } from '../../../core/dwn-constant.js';
 import { Encoder } from '../../../utils/encoder.js';
-import { MessageReply } from '../../../core/message-reply.js';
+import { BaseMessageReply, CommonMessageReply } from '../../../core/message-reply.js';
 import { MessagesGet } from '../messages/messages-get.js';
 import { authenticate, authorize } from '../../../core/auth.js';
 import { DwnInterfaceName, DwnMethodName, Message } from '../../../core/message.js';
@@ -23,14 +23,14 @@ export class MessagesGetHandler implements MethodHandler {
     try {
       messagesGet = await MessagesGet.parse(message);
     } catch (e) {
-      return MessageReply.fromError(e, 400);
+      return BaseMessageReply.fromError(e, 400);
     }
 
     try {
       await authenticate(message.authorization, this.didResolver);
       await authorize(tenant, messagesGet);
     } catch (e) {
-      return MessageReply.fromError(e, 401);
+      return BaseMessageReply.fromError(e, 401);
     }
 
     const promises: Promise<MessagesGetReplyEntry>[] = [];

--- a/src/interfaces/messages/handlers/messages-get.ts
+++ b/src/interfaces/messages/handlers/messages-get.ts
@@ -1,3 +1,4 @@
+import type { BaseMessageReply } from '../../../core/message-reply.js';
 import type { DataStore } from '../../../types/data-store.js';
 import type { DidResolver } from '../../../did/did-resolver.js';
 import type { MessageStore } from '../../../types/message-store.js';
@@ -7,14 +8,14 @@ import type { MessagesGetMessage, MessagesGetReply, MessagesGetReplyEntry } from
 import { DataStream } from '../../../utils/data-stream.js';
 import { DwnConstant } from '../../../core/dwn-constant.js';
 import { Encoder } from '../../../utils/encoder.js';
-import { BaseMessageReply, CommonMessageReply } from '../../../core/message-reply.js';
+import { messageReplyFromError } from '../../../core/message-reply.js';
 import { MessagesGet } from '../messages/messages-get.js';
 import { authenticate, authorize } from '../../../core/auth.js';
 import { DwnInterfaceName, DwnMethodName, Message } from '../../../core/message.js';
 
 type HandleArgs = { tenant: string, message: MessagesGetMessage };
 
-export class MessagesGetHandler implements MethodHandler {
+export class MessagesGetHandler implements MethodHandler<'MessagesGet'> {
   constructor(private didResolver: DidResolver, private messageStore: MessageStore, private dataStore: DataStore) {}
 
   public async handle({ tenant, message }: HandleArgs): Promise<MessagesGetReply> {
@@ -23,14 +24,14 @@ export class MessagesGetHandler implements MethodHandler {
     try {
       messagesGet = await MessagesGet.parse(message);
     } catch (e) {
-      return BaseMessageReply.fromError(e, 400);
+      return messageReplyFromError(e, 400);
     }
 
     try {
       await authenticate(message.authorization, this.didResolver);
       await authorize(tenant, messagesGet);
     } catch (e) {
-      return BaseMessageReply.fromError(e, 401);
+      return messageReplyFromError(e, 401);
     }
 
     const promises: Promise<MessagesGetReplyEntry>[] = [];

--- a/src/interfaces/messages/handlers/messages-get.ts
+++ b/src/interfaces/messages/handlers/messages-get.ts
@@ -1,4 +1,3 @@
-import type { BaseMessageReply } from '../../../core/message-reply.js';
 import type { DataStore } from '../../../types/data-store.js';
 import type { DidResolver } from '../../../did/did-resolver.js';
 import type { MessageStore } from '../../../types/message-store.js';

--- a/src/interfaces/protocols/handlers/protocols-configure.ts
+++ b/src/interfaces/protocols/handlers/protocols-configure.ts
@@ -1,10 +1,11 @@
-import { BaseMessageReply, messageReplyFromError } from '../../../core/message-reply.js';
+import type { BaseMessageReply } from '../../../core/message-reply.js';
 import type { EventLog } from '../../../types/event-log.js';
 import type { MethodHandler } from '../../../types/method-handler.js';
 import type { ProtocolsConfigureMessage } from '../../../types/protocols-types.js';
 import type { DataStore, DidResolver, MessageStore } from '../../../index.js';
 
 import { canonicalAuth } from '../../../core/auth.js';
+import { messageReplyFromError } from '../../../core/message-reply.js';
 import { ProtocolsConfigure } from '../messages/protocols-configure.js';
 import { StorageController } from '../../../store/storage-controller.js';
 

--- a/src/interfaces/protocols/handlers/protocols-query.ts
+++ b/src/interfaces/protocols/handlers/protocols-query.ts
@@ -4,7 +4,7 @@ import type { QueryResultEntry } from '../../../types/message-types.js';
 import type { DataStore, DidResolver, MessageStore } from '../../../index.js';
 
 import { canonicalAuth } from '../../../core/auth.js';
-import { MessageReply } from '../../../core/message-reply.js';
+import { BaseMessageReply, CommonMessageReply } from '../../../core/message-reply.js';
 import { ProtocolsQuery } from '../messages/protocols-query.js';
 import { removeUndefinedProperties } from '../../../utils/object.js';
 
@@ -17,19 +17,19 @@ export class ProtocolsQueryHandler implements MethodHandler {
   public async handle({
     tenant,
     message
-  }: { tenant: string, message: ProtocolsQueryMessage}): Promise<MessageReply> {
+  }: { tenant: string, message: ProtocolsQueryMessage}): Promise<CommonMessageReply> {
 
     let protocolsQuery: ProtocolsQuery;
     try {
       protocolsQuery = await ProtocolsQuery.parse(message);
     } catch (e) {
-      return MessageReply.fromError(e, 400);
+      return BaseMessageReply.fromError(e, 400);
     }
 
     try {
       await canonicalAuth(tenant, protocolsQuery, this.didResolver);
     } catch (e) {
-      return MessageReply.fromError(e, 401);
+      return BaseMessageReply.fromError(e, 401);
     }
 
     const query = {
@@ -48,7 +48,7 @@ export class ProtocolsQueryHandler implements MethodHandler {
       entries.push(objectWithRemainingProperties);
     }
 
-    return new MessageReply({
+    return new CommonMessageReply({
       status: { code: 200, detail: 'OK' },
       entries
     });

--- a/src/interfaces/protocols/handlers/protocols-query.ts
+++ b/src/interfaces/protocols/handlers/protocols-query.ts
@@ -1,15 +1,13 @@
-import type { DwnMessageMap } from '../../../types/dwn-types.js';
 import type { MethodHandler } from '../../../types/method-handler.js';
-import type { ProtocolsQueryMessage, ProtocolsQueryReply } from '../../../types/protocols-types.js';
 import type { QueryResultEntry } from '../../../types/message-types.js';
 import type { DataStore, DidResolver, MessageStore } from '../../../index.js';
+import type { ProtocolsQueryMessage, ProtocolsQueryReply } from '../../../types/protocols-types.js';
 
 import { canonicalAuth } from '../../../core/auth.js';
+import { messageReplyFromError } from '../../../core/message-reply.js';
 import { ProtocolsQuery } from '../messages/protocols-query.js';
 import { removeUndefinedProperties } from '../../../utils/object.js';
-
 import { DwnInterfaceName, DwnMethodName } from '../../../core/message.js';
-import { messageReplyFromError } from '../../../core/message-reply.js';
 
 export class ProtocolsQueryHandler implements MethodHandler<'ProtocolsQuery'> {
 

--- a/src/interfaces/records/handlers/records-query.ts
+++ b/src/interfaces/records/handlers/records-query.ts
@@ -4,7 +4,7 @@ import type { RecordsQueryMessage, RecordsQueryReplyEntry, RecordsWriteMessage }
 
 import { authenticate } from '../../../core/auth.js';
 import { lexicographicalCompare } from '../../../utils/string.js';
-import { MessageReply } from '../../../core/message-reply.js';
+import { BaseMessageReply, CommonMessageReply } from '../../../core/message-reply.js';
 import type { RecordsWriteMessageWithOptionalEncodedData } from '../../../store/storage-controller.js';
 import { StorageController } from '../../../store/storage-controller.js';
 
@@ -18,19 +18,19 @@ export class RecordsQueryHandler implements MethodHandler {
   public async handle({
     tenant,
     message
-  }: {tenant: string, message: RecordsQueryMessage}): Promise<MessageReply> {
+  }: {tenant: string, message: RecordsQueryMessage}): Promise<CommonMessageReply> {
     let recordsQuery: RecordsQuery;
     try {
       recordsQuery = await RecordsQuery.parse(message);
     } catch (e) {
-      return MessageReply.fromError(e, 400);
+      return BaseMessageReply.fromError(e, 400);
     }
 
     try {
       await authenticate(message.authorization, this.didResolver);
       await recordsQuery.authorize(tenant);
     } catch (e) {
-      return MessageReply.fromError(e, 401);
+      return BaseMessageReply.fromError(e, 401);
     }
 
     let records: RecordsWriteMessageWithOptionalEncodedData[];
@@ -52,7 +52,7 @@ export class RecordsQueryHandler implements MethodHandler {
       entries.push(objectWithRemainingProperties);
     }
 
-    return new MessageReply({
+    return new CommonMessageReply({
       status: { code: 200, detail: 'OK' },
       entries
     });

--- a/src/interfaces/records/handlers/records-query.ts
+++ b/src/interfaces/records/handlers/records-query.ts
@@ -1,15 +1,15 @@
 import type { MethodHandler } from '../../../types/method-handler.js';
+import type { RecordsWriteMessageWithOptionalEncodedData } from '../../../store/storage-controller.js';
 import type { DataStore, DidResolver, MessageStore } from '../../../index.js';
 import type { RecordsQueryMessage, RecordsQueryReply, RecordsQueryReplyEntry, RecordsWriteMessage } from '../../../types/records-types.js';
 
 import { authenticate } from '../../../core/auth.js';
 import { lexicographicalCompare } from '../../../utils/string.js';
-import type { RecordsWriteMessageWithOptionalEncodedData } from '../../../store/storage-controller.js';
+import { messageReplyFromError } from '../../../core/message-reply.js';
 import { StorageController } from '../../../store/storage-controller.js';
 
 import { DateSort, RecordsQuery } from '../messages/records-query.js';
 import { DwnInterfaceName, DwnMethodName } from '../../../core/message.js';
-import { messageReplyFromError } from '../../../core/message-reply.js';
 
 export class RecordsQueryHandler implements MethodHandler<'RecordsQuery'> {
 

--- a/src/interfaces/records/handlers/records-read.ts
+++ b/src/interfaces/records/handlers/records-read.ts
@@ -4,8 +4,8 @@ import type { DataStore, DidResolver, MessageStore } from '../../../index.js';
 import type { RecordsReadMessage, RecordsReadReply, RecordsWriteMessage } from '../../../types/records-types.js';
 
 import { authenticate } from '../../../core/auth.js';
-import { messageReplyFromError } from '../../../core/message-reply.js';
 import { Message } from '../../../core/message.js';
+import { messageReplyFromError } from '../../../core/message-reply.js';
 import { RecordsRead } from '../messages/records-read.js';
 import { RecordsWrite } from '../messages/records-write.js';
 import { DwnInterfaceName, DwnMethodName } from '../../../core/message.js';

--- a/src/interfaces/records/handlers/records-write.ts
+++ b/src/interfaces/records/handlers/records-write.ts
@@ -16,6 +16,8 @@ export type RecordsWriteHandlerOptions = {
   skipDataStorage?: boolean; // used for DWN sync
 };
 
+type HandlerArgs = { tenant: string, message: RecordsWriteMessage, options?: RecordsWriteHandlerOptions, dataStream?: _Readable.Readable};
+
 export class RecordsWriteHandler implements MethodHandler<'RecordsWrite'> {
 
   constructor(private didResolver: DidResolver, private messageStore: MessageStore, private dataStore: DataStore, private eventLog: EventLog) { }
@@ -25,7 +27,7 @@ export class RecordsWriteHandler implements MethodHandler<'RecordsWrite'> {
     message,
     options,
     dataStream
-  }: { tenant: string, message: RecordsWriteMessage, options?: RecordsWriteHandlerOptions, dataStream?: _Readable.Readable}): Promise<BaseMessageReply> {
+  }: HandlerArgs): Promise<BaseMessageReply> {
     let recordsWrite: RecordsWrite;
     try {
       recordsWrite = await RecordsWrite.parse(message);

--- a/src/types/dwn-types.ts
+++ b/src/types/dwn-types.ts
@@ -1,9 +1,8 @@
 import type { EventsGetMessage, EventsGetReply } from './event-types.js';
 import type { MessagesGetMessage, MessagesGetReply } from './messages-types.js';
-import type { ProtocolsConfigureMessage, ProtocolsQueryMessage } from './protocols-types.js';
-import type { RecordsDeleteMessage, RecordsQueryMessage, RecordsReadMessage, RecordsReadReply, RecordsWriteMessage } from './records-types.js';
-
-import type { CommonMessageReply } from '../core/message-reply.js';
+import type { ProtocolsConfigureMessage, ProtocolsQueryMessage, ProtocolsQueryReply } from './protocols-types.js';
+import type { RecordsDeleteMessage, RecordsQueryMessage, RecordsQueryReply, RecordsReadMessage, RecordsReadReply, RecordsWriteMessage } from './records-types.js';
+import type { BaseMessageReply } from '../core/message-reply.js';
 
 export type DwnMessageMap = {
     EventsGet : EventsGetMessage;
@@ -19,12 +18,12 @@ export type DwnMessageMap = {
 export type DwnMessageReplyMap = {
     EventsGet : EventsGetReply,
     MessagesGet : MessagesGetReply,
-    ProtocolsConfigure : CommonMessageReply,
-    ProtocolsQuery : CommonMessageReply,
-    RecordsDelete : CommonMessageReply,
-    RecordsQuery : CommonMessageReply,
+    ProtocolsConfigure : BaseMessageReply,
+    ProtocolsQuery : ProtocolsQueryReply,
+    RecordsDelete : BaseMessageReply,
+    RecordsQuery : RecordsQueryReply,
     RecordsRead : RecordsReadReply,
-    RecordsWrite : CommonMessageReply,
+    RecordsWrite : BaseMessageReply,
 };
 
 export type DwnMessage<T extends keyof DwnMessageMap> = DwnMessageMap[T];

--- a/src/types/dwn-types.ts
+++ b/src/types/dwn-types.ts
@@ -1,0 +1,31 @@
+import type { EventsGetMessage, EventsGetReply } from './event-types.js';
+import type { MessagesGetMessage, MessagesGetReply } from './messages-types.js';
+import type { ProtocolsConfigureMessage, ProtocolsQueryMessage } from './protocols-types.js';
+import type { RecordsDeleteMessage, RecordsQueryMessage, RecordsReadMessage, RecordsReadReply, RecordsWriteMessage } from './records-types.js';
+
+import type { CommonMessageReply } from '../core/message-reply.js';
+
+export type DwnMessageMap = {
+    EventsGet : EventsGetMessage;
+    MessagesGet : MessagesGetMessage;
+    ProtocolsConfigure : ProtocolsConfigureMessage;
+    ProtocolsQuery : ProtocolsQueryMessage;
+    RecordsDelete : RecordsDeleteMessage;
+    RecordsQuery : RecordsQueryMessage;
+    RecordsRead : RecordsReadMessage;
+    RecordsWrite : RecordsWriteMessage;
+};
+
+export type DwnMessageReplyMap = {
+    EventsGet : EventsGetReply,
+    MessagesGet : MessagesGetReply,
+    ProtocolsConfigure : CommonMessageReply,
+    ProtocolsQuery : CommonMessageReply,
+    RecordsDelete : CommonMessageReply,
+    RecordsQuery : CommonMessageReply,
+    RecordsRead : RecordsReadReply,
+    RecordsWrite : CommonMessageReply,
+};
+
+export type DwnMessage<T extends keyof DwnMessageMap> = DwnMessageMap[T];
+export type DwnMessageReply<T extends keyof DwnMessageReplyMap> = DwnMessageReplyMap[T];

--- a/src/types/dwn-types.ts
+++ b/src/types/dwn-types.ts
@@ -1,8 +1,8 @@
+import type { BaseMessageReply } from '../core/message-reply.js';
 import type { EventsGetMessage, EventsGetReply } from './event-types.js';
 import type { MessagesGetMessage, MessagesGetReply } from './messages-types.js';
 import type { ProtocolsConfigureMessage, ProtocolsQueryMessage, ProtocolsQueryReply } from './protocols-types.js';
 import type { RecordsDeleteMessage, RecordsQueryMessage, RecordsQueryReply, RecordsReadMessage, RecordsReadReply, RecordsWriteMessage } from './records-types.js';
-import type { BaseMessageReply } from '../core/message-reply.js';
 
 export type DwnMessageMap = {
     EventsGet : EventsGetMessage;

--- a/src/types/method-handler.ts
+++ b/src/types/method-handler.ts
@@ -1,5 +1,5 @@
 import type { BaseMessage } from './message-types.js';
-import type { MessageReply } from '../core/message-reply.js';
+import type { CommonMessageReply } from '../core/message-reply.js';
 import type { Readable } from 'readable-stream';
 
 /**
@@ -13,5 +13,5 @@ export interface MethodHandler {
     tenant: string;
     message: BaseMessage;
     dataStream?: Readable
-  }): Promise<MessageReply>;
+  }): Promise<CommonMessageReply>;
 }

--- a/src/types/method-handler.ts
+++ b/src/types/method-handler.ts
@@ -1,17 +1,16 @@
-import type { BaseMessage } from './message-types.js';
-import type { CommonMessageReply } from '../core/message-reply.js';
 import type { Readable } from 'readable-stream';
+import type { DwnMessage, DwnMessageMap, DwnMessageReply } from './dwn-types.js';
 
 /**
  * Interface that defines a message handler of a specific method.
  */
-export interface MethodHandler {
+export interface MethodHandler<M extends keyof DwnMessageMap> {
   /**
    * Handles the given message and returns a `MessageReply` response.
    */
   handle(input: {
     tenant: string;
-    message: BaseMessage;
+    message: DwnMessage<M>;
     dataStream?: Readable
-  }): Promise<CommonMessageReply>;
+  }): Promise<DwnMessageReply<M>>;
 }

--- a/src/types/protocols-types.ts
+++ b/src/types/protocols-types.ts
@@ -1,4 +1,5 @@
-import type { BaseMessage } from './message-types.js';
+import type { BaseMessage, QueryResultEntry } from './message-types.js';
+import type { BaseMessageReply } from '../core/message-reply.js';
 import type { DwnInterfaceName, DwnMethodName } from '../core/message.js';
 
 export type ProtocolsConfigureDescriptor = {
@@ -66,3 +67,7 @@ export type ProtocolsQueryDescriptor = {
 export type ProtocolsQueryMessage = BaseMessage & {
   descriptor: ProtocolsQueryDescriptor;
 };
+
+export type ProtocolsQueryReply = BaseMessageReply & {
+  entries?: QueryResultEntry[];
+}

--- a/src/types/protocols-types.ts
+++ b/src/types/protocols-types.ts
@@ -1,5 +1,5 @@
-import type { BaseMessage, QueryResultEntry } from './message-types.js';
 import type { BaseMessageReply } from '../core/message-reply.js';
+import type { BaseMessage, QueryResultEntry } from './message-types.js';
 import type { DwnInterfaceName, DwnMethodName } from '../core/message.js';
 
 export type ProtocolsConfigureDescriptor = {
@@ -70,4 +70,4 @@ export type ProtocolsQueryMessage = BaseMessage & {
 
 export type ProtocolsQueryReply = BaseMessageReply & {
   entries?: QueryResultEntry[];
-}
+};

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -1,4 +1,3 @@
-import type { BaseMessage, QueryResultEntry } from './message-types.js';
 import type { BaseMessageReply } from '../core/message-reply.js';
 import type { DateSort } from '../interfaces/records/messages/records-query.js';
 import type { EncryptionAlgorithm } from '../utils/encryption.js';
@@ -6,6 +5,7 @@ import type { GeneralJws } from './jws-types.js';
 import type { KeyDerivationScheme } from '../utils/hd-key.js';
 import type { PublicJwk } from './jose-types.js';
 import type { Readable } from 'readable-stream';
+import type { BaseMessage, QueryResultEntry } from './message-types.js';
 import type { DwnInterfaceName, DwnMethodName } from '../core/message.js';
 
 export type RecordsWriteDescriptor = {
@@ -120,7 +120,7 @@ export type RecordsQueryMessage = BaseMessage & {
 
 export type RecordsQueryReply = BaseMessageReply & {
   entries?: QueryResultEntry[];
-}
+};
 
 export type RecordsReadMessage = {
   authorization?: GeneralJws;

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -1,4 +1,4 @@
-import type { BaseMessage } from './message-types.js';
+import type { BaseMessage, QueryResultEntry } from './message-types.js';
 import type { BaseMessageReply } from '../core/message-reply.js';
 import type { DateSort } from '../interfaces/records/messages/records-query.js';
 import type { EncryptionAlgorithm } from '../utils/encryption.js';
@@ -117,6 +117,10 @@ export type RecordsWriteAuthorizationPayload = {
 export type RecordsQueryMessage = BaseMessage & {
   descriptor: RecordsQueryDescriptor;
 };
+
+export type RecordsQueryReply = BaseMessageReply & {
+  entries?: QueryResultEntry[];
+}
 
 export type RecordsReadMessage = {
   authorization?: GeneralJws;

--- a/tests/dwn.spec.ts
+++ b/tests/dwn.spec.ts
@@ -11,7 +11,7 @@ import { Encoder } from '../src/index.js';
 import { EventLogLevel } from '../src/event-log/event-log-level.js';
 import { MessageStoreLevel } from '../src/store/message-store-level.js';
 import { TestDataGenerator } from './utils/test-data-generator.js';
-import { DwnInterfaceName, DwnMessageName, DwnMethodName, Message } from '../src/core/message.js';
+import { DwnMessageName, DwnMethodName, Message } from '../src/core/message.js';
 import { Jws, RecordsRead } from '../src/index.js';
 
 chai.use(chaiAsPromised);
@@ -107,10 +107,10 @@ describe('DWN', () => {
       const validateJsonSchemaSpy = sinon.spy(Message, 'validateJsonSchema');
 
       const alice = await DidKeyResolver.generate();
-      const reply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, message);
+      await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, message);
 
       sinon.assert.calledOnce(validateJsonSchemaSpy);
-  });
+    });
 
     it('should throw 401 if message is targeted at a non-tenant', async () => {
       // tenant gate that blocks everyone

--- a/tests/dwn.spec.ts
+++ b/tests/dwn.spec.ts
@@ -271,7 +271,7 @@ describe('DWN', () => {
       expect(newRecordsWriteReply.status.code).to.equal(202);
 
       // verify new `RecordsWrite` has overwritten the existing record with new data
-      const newRecordsQueryReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, recordsQueryMessageData.message);
+      const newRecordsQueryReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsQuery, recordsQueryMessageData.message);
 
       expect(newRecordsQueryReply.status.code).to.equal(200);
       expect(newRecordsQueryReply.entries?.length).to.equal(1);
@@ -328,23 +328,13 @@ describe('DWN', () => {
 
     it('should throw 400 if given incorrect DWN interface or method', async () => {
       const alice = await DidKeyResolver.generate();
-      const reply1 = await dwn.synchronizePrunedInitialRecordsWrite(alice.did, undefined as unknown as RecordsWriteMessage ); // missing message
-      expect(reply1.status.code).to.equal(400);
-      expect(reply1.status.detail).to.contain('Both interface and method must be present');
 
-      const reply2 = await dwn.synchronizePrunedInitialRecordsWrite(
+      const reply = await dwn.synchronizePrunedInitialRecordsWrite(
         alice.did,
         { descriptor: { interface: 'IncorrectInterface', method: DwnMethodName.Write } } as RecordsWriteMessage
       );
-      expect(reply2.status.code).to.equal(400);
-      expect(reply2.status.detail).to.contain(`Expected interface ${DwnInterfaceName.Records}`);
-
-      const reply3 = await dwn.synchronizePrunedInitialRecordsWrite(
-        alice.did,
-        { descriptor: { interface: DwnInterfaceName.Records, method: 'IncorrectMethod' } } as RecordsWriteMessage
-      );
-      expect(reply3.status.code).to.equal(400);
-      expect(reply3.status.detail).to.contain(`Expected method ${DwnInterfaceName.Records}${DwnMethodName.Write}`);
+      expect(reply.status.code).to.equal(400);
+      expect(reply.status.detail).to.contain(`Expected DWN message type ${DwnMessageName.RecordsWrite}`);
     });
   });
 });

--- a/tests/interfaces/events/handlers/events-get.spec.ts
+++ b/tests/interfaces/events/handlers/events-get.spec.ts
@@ -11,7 +11,7 @@ import {
   MessageStoreLevel,
 } from '../../../../src/index.js';
 
-import { Message } from '../../../../src/core/message.js';
+import { DwnMessageName, Message } from '../../../../src/core/message.js';
 
 describe('EventsGetHandler.handle()', () => {
   let didResolver: DidResolver;
@@ -57,11 +57,9 @@ describe('EventsGetHandler.handle()', () => {
     const bob = await DidKeyResolver.generate();
 
     const { message } = await TestDataGenerator.generateEventsGet({ author: alice });
-    const reply = await dwn.processMessage(bob.did, message);
+    const reply = await dwn.processMessage(bob.did, DwnMessageName.EventsGet, message);
 
     expect(reply.status.code).to.equal(401);
-    expect(reply.entries).to.not.exist;
-    expect(reply.data).to.not.exist;
   });
 
   it('returns a 400 if message is invalid', async () => {
@@ -70,11 +68,9 @@ describe('EventsGetHandler.handle()', () => {
     const { message } = await TestDataGenerator.generateEventsGet({ author: alice });
     message['descriptor']['troll'] = 'hehe';
 
-    const reply = await dwn.processMessage(alice.did, message);
+    const reply = await dwn.processMessage(alice.did, DwnMessageName.EventsGet, message);
 
     expect(reply.status.code).to.equal(400);
-    expect(reply.entries).to.not.exist;
-    expect(reply.data).to.not.exist;
   });
 
   it('returns all events for a tenant if watermark is not provided', async () => {
@@ -83,7 +79,7 @@ describe('EventsGetHandler.handle()', () => {
 
     for (let i = 0; i < 5; i += 1) {
       const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice });
-      const reply = await dwn.processMessage(alice.did, message, dataStream);
+      const reply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, message, dataStream);
 
       expect(reply.status.code).to.equal(202);
       const messageCid = await Message.getCid(message);
@@ -92,7 +88,7 @@ describe('EventsGetHandler.handle()', () => {
     }
 
     const { message } = await TestDataGenerator.generateEventsGet({ author: alice });
-    const reply: EventsGetReply = await dwn.processMessage(alice.did, message);
+    const reply: EventsGetReply = await dwn.processMessage(alice.did, DwnMessageName.EventsGet, message);
 
     expect(reply.status.code).to.equal(200);
     expect(reply['data']).to.not.exist;
@@ -108,13 +104,13 @@ describe('EventsGetHandler.handle()', () => {
 
     for (let i = 0; i < 5; i += 1) {
       const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice });
-      const reply = await dwn.processMessage(alice.did, message, dataStream);
+      const reply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, message, dataStream);
 
       expect(reply.status.code).to.equal(202);
     }
 
     const { message } = await TestDataGenerator.generateEventsGet({ author: alice });
-    let reply: EventsGetReply = await dwn.processMessage(alice.did, message);
+    let reply: EventsGetReply = await dwn.processMessage(alice.did, DwnMessageName.EventsGet, message);
 
     expect(reply.status.code).to.equal(200);
 
@@ -123,7 +119,7 @@ describe('EventsGetHandler.handle()', () => {
 
     for (let i = 0; i < 3; i += 1) {
       const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice });
-      const reply = await dwn.processMessage(alice.did, message, dataStream);
+      const reply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, message, dataStream);
 
       expect(reply.status.code).to.equal(202);
       const messageCid = await Message.getCid(message);
@@ -131,7 +127,7 @@ describe('EventsGetHandler.handle()', () => {
     }
 
     const { message: m } = await TestDataGenerator.generateEventsGet({ author: alice, watermark });
-    reply = await dwn.processMessage(alice.did, m);
+    reply = await dwn.processMessage(alice.did, DwnMessageName.EventsGet, m);
 
     expect(reply.status.code).to.equal(200);
     expect(reply['data']).to.not.exist;

--- a/tests/interfaces/messages/handlers/messages-get.spec.ts
+++ b/tests/interfaces/messages/handlers/messages-get.spec.ts
@@ -1,7 +1,7 @@
 import type { MessagesGetReply } from '../../../../src/index.js';
 
 import { expect } from 'chai';
-import { Message } from '../../../../src/core/message.js';
+import { DwnMessageName, Message } from '../../../../src/core/message.js';
 import { MessagesGetHandler } from '../../../../src/interfaces/messages/handlers/messages-get.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import {
@@ -66,11 +66,9 @@ describe('MessagesGetHandler.handle()', () => {
       messageCids : [await Message.getCid(recordsWrite.message)]
     });
 
-    const reply = await dwn.processMessage(bob.did, message);
+    const reply = await dwn.processMessage(bob.did, DwnMessageName.MessagesGet, message);
 
     expect(reply.status.code).to.equal(401);
-    expect(reply.entries).to.not.exist;
-    expect(reply.data).to.not.exist;
   });
 
   it('returns a 400 if message is invalid', async () => {
@@ -84,11 +82,9 @@ describe('MessagesGetHandler.handle()', () => {
 
     message['descriptor']['troll'] = 'hehe';
 
-    const reply = await dwn.processMessage(alice.did, message);
+    const reply = await dwn.processMessage(alice.did, DwnMessageName.MessagesGet, message);
 
     expect(reply.status.code).to.equal(400);
-    expect(reply.entries).to.not.exist;
-    expect(reply.data).to.not.exist;
   });
 
   it('returns a 400 if message contains an invalid message cid', async () => {
@@ -102,7 +98,7 @@ describe('MessagesGetHandler.handle()', () => {
 
     message.descriptor.messageCids = ['hehetroll'];
 
-    const reply: MessagesGetReply = await dwn.processMessage(alice.did, message);
+    const reply: MessagesGetReply = await dwn.processMessage(alice.did, DwnMessageName.MessagesGet, message);
 
     expect(reply.status.code).to.equal(400);
     expect(reply.status.detail).to.include('is not a valid CID');
@@ -121,7 +117,7 @@ describe('MessagesGetHandler.handle()', () => {
     let messageCid = await Message.getCid(recordsWrite.message);
     messageCids.push(messageCid);
 
-    let reply = await dwn.processMessage(alice.did, recordsWrite.toJSON(), dataStream);
+    let reply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, recordsWrite.message, dataStream);
     expect(reply.status.code).to.equal(202);
 
     const { recordsDelete } = await TestDataGenerator.generateRecordsDelete({
@@ -132,7 +128,7 @@ describe('MessagesGetHandler.handle()', () => {
     messageCid = await Message.getCid(recordsDelete.message);
     messageCids.push(messageCid);
 
-    reply = await dwn.processMessage(alice.did, recordsDelete.toJSON());
+    reply = await dwn.processMessage(alice.did, DwnMessageName.RecordsDelete, recordsDelete.message);
     expect(reply.status.code).to.equal(202);
 
     const { protocolsConfigure } = await TestDataGenerator.generateProtocolsConfigure({
@@ -142,7 +138,7 @@ describe('MessagesGetHandler.handle()', () => {
     messageCid = await Message.getCid(protocolsConfigure.message);
     messageCids.push(messageCid);
 
-    reply = await dwn.processMessage(alice.did, protocolsConfigure.toJSON());
+    reply = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, protocolsConfigure.message);
     expect(reply.status.code).to.equal(202);
 
     const { messagesGet } = await TestDataGenerator.generateMessagesGet({
@@ -150,7 +146,7 @@ describe('MessagesGetHandler.handle()', () => {
       messageCids
     });
 
-    const messagesGetReply: MessagesGetReply = await dwn.processMessage(alice.did, messagesGet.toJSON());
+    const messagesGetReply: MessagesGetReply = await dwn.processMessage(alice.did, DwnMessageName.MessagesGet, messagesGet.message);
     expect(messagesGetReply.status.code).to.equal(200);
     expect(messagesGetReply.messages!.length).to.equal(messageCids.length);
 
@@ -175,7 +171,7 @@ describe('MessagesGetHandler.handle()', () => {
     });
 
     // 0 messages expected because the RecordsWrite created above was never stored
-    const reply: MessagesGetReply = await dwn.processMessage(alice.did, message);
+    const reply: MessagesGetReply = await dwn.processMessage(alice.did, DwnMessageName.MessagesGet, message);
     expect(reply.status.code).to.equal(200);
     expect(reply.messages!.length).to.equal(1);
 
@@ -221,7 +217,7 @@ describe('MessagesGetHandler.handle()', () => {
       author: alice
     });
 
-    const reply = await dwn.processMessage(alice.did, recordsWrite.toJSON(), dataStream);
+    const reply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, recordsWrite.message, dataStream);
     expect(reply.status.code).to.equal(202);
 
     const recordsWriteMessageCid = await Message.getCid(recordsWrite.message);
@@ -230,7 +226,7 @@ describe('MessagesGetHandler.handle()', () => {
       messageCids : [recordsWriteMessageCid]
     });
 
-    const messagesGetReply: MessagesGetReply = await dwn.processMessage(alice.did, message);
+    const messagesGetReply: MessagesGetReply = await dwn.processMessage(alice.did, DwnMessageName.MessagesGet, message);
     expect(messagesGetReply.status.code).to.equal(200);
     expect(messagesGetReply.messages!.length).to.equal(1);
 
@@ -251,7 +247,7 @@ describe('MessagesGetHandler.handle()', () => {
       author: alice
     });
 
-    const reply = await dwn.processMessage(alice.did, recordsWrite.toJSON(), dataStream);
+    const reply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, recordsWrite.message, dataStream);
     expect(reply.status.code).to.equal(202);
 
     const recordsWriteMessageCid = await Message.getCid(recordsWrite.message);
@@ -261,7 +257,7 @@ describe('MessagesGetHandler.handle()', () => {
     });
 
     // 0 messages expected because the RecordsWrite created above is not bob's
-    const messagesGetReply: MessagesGetReply = await dwn.processMessage(bob.did, message);
+    const messagesGetReply: MessagesGetReply = await dwn.processMessage(bob.did, DwnMessageName.MessagesGet, message);
     expect(messagesGetReply.status.code).to.equal(200);
     expect(messagesGetReply.messages!.length).to.equal(1);
 

--- a/tests/interfaces/messages/handlers/messages-get.spec.ts
+++ b/tests/interfaces/messages/handlers/messages-get.spec.ts
@@ -1,7 +1,6 @@
 import type { MessagesGetReply } from '../../../../src/index.js';
 
 import { expect } from 'chai';
-import { DwnMessageName, Message } from '../../../../src/core/message.js';
 import { MessagesGetHandler } from '../../../../src/interfaces/messages/handlers/messages-get.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import {
@@ -12,6 +11,7 @@ import {
   EventLogLevel,
   MessageStoreLevel
 } from '../../../../src/index.js';
+import { DwnMessageName, Message } from '../../../../src/core/message.js';
 
 import sinon from 'sinon';
 

--- a/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
@@ -12,13 +12,13 @@ import { DidKeyResolver } from '../../../../src/did/did-key-resolver.js';
 import { EventLogLevel } from '../../../../src/event-log/event-log-level.js';
 import { GeneralJwsSigner } from '../../../../src/jose/jws/general/signer.js';
 import { lexicographicalCompare } from '../../../../src/utils/string.js';
-import { DwnMessageName, Message } from '../../../../src/core/message.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
 import { sleep } from '../../../../src/utils/time.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
 
 import { DidResolver, Dwn, DwnErrorCode, Encoder, Jws } from '../../../../src/index.js';
+import { DwnMessageName, Message } from '../../../../src/core/message.js';
 
 chai.use(chaiAsPromised);
 
@@ -125,11 +125,13 @@ describe('ProtocolsConfigureHandler.handle()', () => {
       });
 
       // first ProtocolsConfigure
-      const reply1 = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, middleProtocolsConfigure.message, middleProtocolsConfigure.dataStream);
+      const reply1 = await dwn.processMessage(
+        alice.did, DwnMessageName.ProtocolsConfigure, middleProtocolsConfigure.message, middleProtocolsConfigure.dataStream);
       expect(reply1.status.code).to.equal(202);
 
       // older messages will not overwrite the existing
-      const reply2 = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, oldProtocolsConfigure.message, oldProtocolsConfigure.dataStream);
+      const reply2 = await dwn.processMessage(
+        alice.did, DwnMessageName.ProtocolsConfigure, oldProtocolsConfigure.message, oldProtocolsConfigure.dataStream);
       expect(reply2.status.code).to.equal(409);
 
       // newer message can overwrite the existing message
@@ -137,7 +139,8 @@ describe('ProtocolsConfigureHandler.handle()', () => {
         author: alice,
         protocolDefinition,
       });
-      const reply3 = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, newProtocolsConfigure.message, newProtocolsConfigure.dataStream);
+      const reply3 = await dwn.processMessage(
+        alice.did, DwnMessageName.ProtocolsConfigure, newProtocolsConfigure.message, newProtocolsConfigure.dataStream);
       expect(reply3.status.code).to.equal(202);
 
       // only the newest protocol should remain
@@ -199,15 +202,18 @@ describe('ProtocolsConfigureHandler.handle()', () => {
         = messageDataWithCid.sort((messageDataA, messageDataB) => { return lexicographicalCompare(messageDataA.cid, messageDataB.cid); });
 
       // write the protocol with the middle lexicographic value
-      const reply1 = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, middleProtocolsConfigure.message, middleProtocolsConfigure.dataStream);
+      const reply1 = await dwn.processMessage(
+        alice.did, DwnMessageName.ProtocolsConfigure, middleProtocolsConfigure.message, middleProtocolsConfigure.dataStream);
       expect(reply1.status.code).to.equal(202);
 
       // test that the protocol with the smallest lexicographic value cannot be written
-      const reply2 = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, lowestProtocolsConfigure.message, lowestProtocolsConfigure.dataStream);
+      const reply2 = await dwn.processMessage(
+        alice.did, DwnMessageName.ProtocolsConfigure, lowestProtocolsConfigure.message, lowestProtocolsConfigure.dataStream);
       expect(reply2.status.code).to.equal(409);
 
       // test that the protocol with the largest lexicographic value can be written
-      const reply3 = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, highestProtocolsConfigure.message, highestProtocolsConfigure.dataStream);
+      const reply3 = await dwn.processMessage(
+        alice.did, DwnMessageName.ProtocolsConfigure, highestProtocolsConfigure.message, highestProtocolsConfigure.dataStream);
       expect(reply3.status.code).to.equal(202);
 
       // test that lower lexicographic protocol message is removed from DB and only the newer protocol message remains

--- a/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-configure.spec.ts
@@ -146,27 +146,27 @@ describe('ProtocolsConfigureHandler.handle()', () => {
         = messageDataWithCid.sort((messageDataA, messageDataB) => { return lexicographicalCompare(messageDataA.cid, messageDataB.cid); });
 
       // write the protocol with the middle lexicographic value
-      let reply = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, middleWrite.message, middleWrite.dataStream);
-      expect(reply.status.code).to.equal(202);
+      const configureReply1 = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, middleWrite.message, middleWrite.dataStream);
+      expect(configureReply1.status.code).to.equal(202);
 
       // test that the protocol with the smallest lexicographic value cannot be written
-      reply = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, oldestWrite.message, oldestWrite.dataStream);
-      expect(reply.status.code).to.equal(409);
+      const configureReply2 = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, oldestWrite.message, oldestWrite.dataStream);
+      expect(configureReply2.status.code).to.equal(409);
 
       // test that the protocol with the largest lexicographic value can be written
-      reply = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, newestWrite.message, newestWrite.dataStream);
-      expect(reply.status.code).to.equal(202);
+      const configureReply3 = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, newestWrite.message, newestWrite.dataStream);
+      expect(configureReply3.status.code).to.equal(202);
 
       // test that old protocol message is removed from DB and only the newer protocol message remains
       const queryMessageData = await TestDataGenerator.generateProtocolsQuery({ author: alice, filter: { protocol } });
-      reply = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsQuery, queryMessageData.message);
+      const queryReply = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsQuery, queryMessageData.message);
 
-      expect(reply.status.code).to.equal(200);
-      expect(reply.entries?.length).to.equal(1);
+      expect(queryReply.status.code).to.equal(200);
+      expect(queryReply.entries?.length).to.equal(1);
 
       const initialDefinition = middleWrite.message.descriptor.definition;
       const expectedDefinition = newestWrite.message.descriptor.definition;
-      const actualDefinition = reply.entries![0]['descriptor']['definition'];
+      const actualDefinition = queryReply.entries![0]['descriptor']['definition'];
       expect(actualDefinition).to.not.deep.equal(initialDefinition);
       expect(actualDefinition).to.deep.equal(expectedDefinition);
     });

--- a/tests/interfaces/protocols/handlers/protocols-query.spec.ts
+++ b/tests/interfaces/protocols/handlers/protocols-query.spec.ts
@@ -6,12 +6,12 @@ import { DataStoreLevel } from '../../../../src/store/data-store-level.js';
 import { DidKeyResolver } from '../../../../src/did/did-key-resolver.js';
 import { EventLogLevel } from '../../../../src/event-log/event-log-level.js';
 import { GeneralJwsSigner } from '../../../../src/jose/jws/general/signer.js';
-import { DwnMessageName, Message } from '../../../../src/core/message.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
 
 import { DidResolver, Dwn, DwnErrorCode, Encoder, Jws } from '../../../../src/index.js';
+import { DwnMessageName, Message } from '../../../../src/core/message.js';
 
 chai.use(chaiAsPromised);
 

--- a/tests/interfaces/records/handlers/records-delete.spec.ts
+++ b/tests/interfaces/records/handlers/records-delete.spec.ts
@@ -7,12 +7,12 @@ import { Cid } from '../../../../src/utils/cid.js';
 import { DataStoreLevel } from '../../../../src/store/data-store-level.js';
 import { DidKeyResolver } from '../../../../src/did/did-key-resolver.js';
 import { EventLogLevel } from '../../../../src/event-log/event-log-level.js';
-import { DwnMessageName, Message } from '../../../../src/core/message.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
 import { RecordsDeleteHandler } from '../../../../src/interfaces/records/handlers/records-delete.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
 import { DidResolver, Dwn, Encoder, Jws, RecordsDelete, RecordsWrite } from '../../../../src/index.js';
+import { DwnMessageName, Message } from '../../../../src/core/message.js';
 
 chai.use(chaiAsPromised);
 
@@ -118,7 +118,8 @@ describe('RecordsDeleteHandler.handle()', () => {
 
       // initial write
       const initialWriteData = await TestDataGenerator.generateRecordsWrite({ author: alice });
-      const initialWriteReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, initialWriteData.message, initialWriteData.dataStream);
+      const initialWriteReply = await dwn.processMessage(
+        alice.did, DwnMessageName.RecordsWrite, initialWriteData.message, initialWriteData.dataStream);
       expect(initialWriteReply.status.code).to.equal(202);
 
       // generate subsequent write and delete with the delete having an earlier timestamp
@@ -133,7 +134,8 @@ describe('RecordsDeleteHandler.handle()', () => {
       });
 
       // subsequent write
-      const subsequentWriteReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, subsequentWriteData.message, subsequentWriteData.dataStream);
+      const subsequentWriteReply = await dwn.processMessage(
+        alice.did, DwnMessageName.RecordsWrite, subsequentWriteData.message, subsequentWriteData.dataStream);
       expect(subsequentWriteReply.status.code).to.equal(202);
 
       // test that a delete with an earlier `dateModified` results in a 409
@@ -206,7 +208,8 @@ describe('RecordsDeleteHandler.handle()', () => {
         author: alice,
         data
       });
-      const aliceRewriteReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, aliceRewriteData.message, aliceRewriteData.dataStream);
+      const aliceRewriteReply = await dwn.processMessage(
+        alice.did, DwnMessageName.RecordsWrite, aliceRewriteData.message, aliceRewriteData.dataStream);
       expect(aliceRewriteReply.status.code).to.equal(202);
 
       const aliceQueryWriteAfterAliceRewriteData = await TestDataGenerator.generateRecordsQuery({
@@ -244,7 +247,8 @@ describe('RecordsDeleteHandler.handle()', () => {
 
       // alice writes another record with the same data
       const aliceAssociateData = await TestDataGenerator.generateRecordsWrite({ author: alice, data });
-      const aliceAssociateReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, aliceAssociateData.message, aliceAssociateData.dataStream);
+      const aliceAssociateReply = await dwn.processMessage(
+        alice.did, DwnMessageName.RecordsWrite, aliceAssociateData.message, aliceAssociateData.dataStream);
       expect(aliceAssociateReply.status.code).to.equal(202);
 
       await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfAliceOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -15,7 +15,6 @@ import { Encoder } from '../../../../src/utils/encoder.js';
 import { Encryption } from '../../../../src/index.js';
 import { EventLogLevel } from '../../../../src/event-log/event-log-level.js';
 import { Jws } from '../../../../src/utils/jws.js';
-import { DwnMessageName, Message } from '../../../../src/core/message.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
 import { RecordsQueryHandler } from '../../../../src/interfaces/records/handlers/records-query.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
@@ -25,6 +24,7 @@ import { toTemporalInstant } from '@js-temporal/polyfill';
 import { constructRecordsWriteIndexes, RecordsWriteHandler } from '../../../../src/interfaces/records/handlers/records-write.js';
 import { DataStream, DidResolver, Dwn, HdKey, KeyDerivationScheme, Records } from '../../../../src/index.js';
 import { DateSort, RecordsQuery } from '../../../../src/interfaces/records/messages/records-query.js';
+import { DwnMessageName, Message } from '../../../../src/core/message.js';
 
 chai.use(chaiAsPromised);
 
@@ -351,8 +351,10 @@ describe('RecordsQueryHandler.handle()', () => {
       sinon.stub(didResolver, 'resolve').resolves(mockResolution);
 
       // insert data
-      const publishedWriteReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, publishedWriteData.message, publishedWriteData.dataStream);
-      const unpublishedWriteReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, unpublishedWriteData.message, unpublishedWriteData.dataStream);
+      const publishedWriteReply = await dwn.processMessage(
+        alice.did, DwnMessageName.RecordsWrite, publishedWriteData.message, publishedWriteData.dataStream);
+      const unpublishedWriteReply = await dwn.processMessage(
+        alice.did, DwnMessageName.RecordsWrite, unpublishedWriteData.message, unpublishedWriteData.dataStream);
       expect(publishedWriteReply.status.code).to.equal(202);
       expect(unpublishedWriteReply.status.code).to.equal(202);
 
@@ -533,7 +535,8 @@ describe('RecordsQueryHandler.handle()', () => {
         { author: alice, schema, data: Encoder.stringToBytes('1'), published: false } // explicitly setting `published` to `false`
       );
 
-      const result1 = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, unpublishedRecordsWrite.message, unpublishedRecordsWrite.dataStream);
+      const result1 = await dwn.processMessage(
+        alice.did, DwnMessageName.RecordsWrite, unpublishedRecordsWrite.message, unpublishedRecordsWrite.dataStream);
       expect(result1.status.code).to.equal(202);
 
       // alice should be able to see the unpublished record
@@ -673,7 +676,8 @@ describe('RecordsQueryHandler.handle()', () => {
           protocolDefinition
         });
 
-        const protocolsConfigureReply = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, protocolsConfig.message, protocolsConfig.dataStream);
+        const protocolsConfigureReply = await dwn.processMessage(
+          alice.did, DwnMessageName.ProtocolsConfigure, protocolsConfig.message, protocolsConfig.dataStream);
         expect(protocolsConfigureReply.status.code).to.equal(202);
 
         // encrypt bob's message

--- a/tests/interfaces/records/handlers/records-read.spec.ts
+++ b/tests/interfaces/records/handlers/records-read.spec.ts
@@ -11,6 +11,7 @@ import { ArrayUtility } from '../../../../src/utils/array.js';
 import { DataStoreLevel } from '../../../../src/store/data-store-level.js';
 import { DidKeyResolver } from '../../../../src/did/did-key-resolver.js';
 import { DwnErrorCode } from '../../../../src/core/dwn-error.js';
+import { DwnMessageName } from '../../../../src/core/message.js';
 import { Encryption } from '../../../../src/utils/encryption.js';
 import { EventLogLevel } from '../../../../src/event-log/event-log-level.js';
 import { HdKey } from '../../../../src/utils/hd-key.js';
@@ -21,7 +22,6 @@ import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
 
 import { DataStream, DidResolver, Dwn, Encoder, Jws, Records, RecordsDelete, RecordsRead } from '../../../../src/index.js';
-import { DwnMessageName } from '../../../../src/core/message.js';
 
 chai.use(chaiAsPromised);
 
@@ -168,7 +168,8 @@ describe('RecordsReadHandler.handle()', () => {
           author: alice,
           protocolDefinition
         });
-        const protocolWriteReply = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, protocolsConfig.message, protocolsConfig.dataStream);
+        const protocolWriteReply = await dwn.processMessage(
+          alice.did, DwnMessageName.ProtocolsConfigure, protocolsConfig.message, protocolsConfig.dataStream);
         expect(protocolWriteReply.status.code).to.equal(202);
 
         // Alice writes image to her DWN
@@ -209,7 +210,8 @@ describe('RecordsReadHandler.handle()', () => {
           author: alice,
           protocolDefinition
         });
-        const protocolWriteReply = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, protocolsConfig.message, protocolsConfig.dataStream);
+        const protocolWriteReply = await dwn.processMessage(
+          alice.did, DwnMessageName.ProtocolsConfigure, protocolsConfig.message, protocolsConfig.dataStream);
         expect(protocolWriteReply.status.code).to.equal(202);
 
         // Alice writes an email with Bob as recipient
@@ -258,7 +260,8 @@ describe('RecordsReadHandler.handle()', () => {
           author: alice,
           protocolDefinition
         });
-        const protocolWriteReply = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, protocolsConfig.message, protocolsConfig.dataStream);
+        const protocolWriteReply = await dwn.processMessage(
+          alice.did, DwnMessageName.ProtocolsConfigure, protocolsConfig.message, protocolsConfig.dataStream);
         expect(protocolWriteReply.status.code).to.equal(202);
 
         // Alice writes an email with Bob as recipient
@@ -460,7 +463,8 @@ describe('RecordsReadHandler.handle()', () => {
           protocolDefinition
         });
 
-        const protocolsConfigureReply = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, protocolsConfig.message, protocolsConfig.dataStream);
+        const protocolsConfigureReply = await dwn.processMessage(
+          alice.did, DwnMessageName.ProtocolsConfigure, protocolsConfig.message, protocolsConfig.dataStream);
         expect(protocolsConfigureReply.status.code).to.equal(202);
 
         // encrypt bob's message

--- a/tests/interfaces/records/handlers/records-read.spec.ts
+++ b/tests/interfaces/records/handlers/records-read.spec.ts
@@ -21,6 +21,7 @@ import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
 
 import { DataStream, DidResolver, Dwn, Encoder, Jws, Records, RecordsDelete, RecordsRead } from '../../../../src/index.js';
+import { DwnMessageName } from '../../../../src/core/message.js';
 
 chai.use(chaiAsPromised);
 
@@ -71,7 +72,7 @@ describe('RecordsReadHandler.handle()', () => {
 
       // insert data
       const { message, dataStream, dataBytes } = await TestDataGenerator.generateRecordsWrite({ author: alice });
-      const writeReply = await dwn.processMessage(alice.did, message, dataStream);
+      const writeReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, message, dataStream);
       expect(writeReply.status.code).to.equal(202);
 
       // testing RecordsRead
@@ -94,7 +95,7 @@ describe('RecordsReadHandler.handle()', () => {
 
       // insert data
       const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice });
-      const writeReply = await dwn.processMessage(alice.did, message, dataStream);
+      const writeReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, message, dataStream);
       expect(writeReply.status.code).to.equal(202);
 
       // testing RecordsRead
@@ -105,7 +106,7 @@ describe('RecordsReadHandler.handle()', () => {
         authorizationSignatureInput : Jws.createSignatureInput(bob)
       });
 
-      const readReply = await dwn.processMessage(alice.did, recordsRead.message);
+      const readReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsRead, recordsRead.message);
       expect(readReply.status.code).to.equal(401);
     });
 
@@ -114,7 +115,7 @@ describe('RecordsReadHandler.handle()', () => {
 
       // insert public data
       const { message, dataStream, dataBytes } = await TestDataGenerator.generateRecordsWrite({ author: alice, published: true });
-      const writeReply = await dwn.processMessage(alice.did, message, dataStream);
+      const writeReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, message, dataStream);
       expect(writeReply.status.code).to.equal(202);
 
       // testing public RecordsRead
@@ -135,7 +136,7 @@ describe('RecordsReadHandler.handle()', () => {
 
       // insert public data
       const { message, dataStream, dataBytes } = await TestDataGenerator.generateRecordsWrite({ author: alice, published: true });
-      const writeReply = await dwn.processMessage(alice.did, message, dataStream);
+      const writeReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, message, dataStream);
       expect(writeReply.status.code).to.equal(202);
 
       // testing public RecordsRead
@@ -167,7 +168,7 @@ describe('RecordsReadHandler.handle()', () => {
           author: alice,
           protocolDefinition
         });
-        const protocolWriteReply = await dwn.processMessage(alice.did, protocolsConfig.message, protocolsConfig.dataStream);
+        const protocolWriteReply = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, protocolsConfig.message, protocolsConfig.dataStream);
         expect(protocolWriteReply.status.code).to.equal(202);
 
         // Alice writes image to her DWN
@@ -181,7 +182,7 @@ describe('RecordsReadHandler.handle()', () => {
           data         : encodedImage,
           recipient    : alice.did
         });
-        const imageReply = await dwn.processMessage(alice.did, imageRecordsWrite.message, imageRecordsWrite.dataStream);
+        const imageReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, imageRecordsWrite.message, imageRecordsWrite.dataStream);
         expect(imageReply.status.code).to.equal(202);
 
         // Bob (anyone) reads the image that Alice wrote
@@ -189,7 +190,7 @@ describe('RecordsReadHandler.handle()', () => {
           recordId                    : imageRecordsWrite.message.recordId,
           authorizationSignatureInput : Jws.createSignatureInput(bob)
         });
-        const imageReadReply = await dwn.processMessage(alice.did, imageRecordsRead.message);
+        const imageReadReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsRead, imageRecordsRead.message);
         expect(imageReadReply.status.code).to.equal(200);
       });
 
@@ -208,7 +209,7 @@ describe('RecordsReadHandler.handle()', () => {
           author: alice,
           protocolDefinition
         });
-        const protocolWriteReply = await dwn.processMessage(alice.did, protocolsConfig.message, protocolsConfig.dataStream);
+        const protocolWriteReply = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, protocolsConfig.message, protocolsConfig.dataStream);
         expect(protocolWriteReply.status.code).to.equal(202);
 
         // Alice writes an email with Bob as recipient
@@ -222,7 +223,7 @@ describe('RecordsReadHandler.handle()', () => {
           data         : encodedEmail,
           recipient    : bob.did
         });
-        const imageReply = await dwn.processMessage(alice.did, emailRecordsWrite.message, emailRecordsWrite.dataStream);
+        const imageReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, emailRecordsWrite.message, emailRecordsWrite.dataStream);
         expect(imageReply.status.code).to.equal(202);
 
         // Bob reads Alice's email
@@ -230,7 +231,7 @@ describe('RecordsReadHandler.handle()', () => {
           recordId                    : emailRecordsWrite.message.recordId,
           authorizationSignatureInput : Jws.createSignatureInput(bob)
         });
-        const bobReadReply = await dwn.processMessage(alice.did, bobRecordsRead.message);
+        const bobReadReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsRead, bobRecordsRead.message);
         expect(bobReadReply.status.code).to.equal(200);
 
         // ImposterBob is not able to read Alice's email
@@ -238,7 +239,7 @@ describe('RecordsReadHandler.handle()', () => {
           recordId                    : emailRecordsWrite.message.recordId,
           authorizationSignatureInput : Jws.createSignatureInput(imposterBob)
         });
-        const imposterReadReply = await dwn.processMessage(alice.did, imposterRecordsRead.message);
+        const imposterReadReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsRead, imposterRecordsRead.message);
         expect(imposterReadReply.status.code).to.equal(401);
         expect(imposterReadReply.status.detail).to.include(DwnErrorCode.ProtocolAuthorizationActionNotAllowed);
       });
@@ -257,7 +258,7 @@ describe('RecordsReadHandler.handle()', () => {
           author: alice,
           protocolDefinition
         });
-        const protocolWriteReply = await dwn.processMessage(alice.did, protocolsConfig.message, protocolsConfig.dataStream);
+        const protocolWriteReply = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, protocolsConfig.message, protocolsConfig.dataStream);
         expect(protocolWriteReply.status.code).to.equal(202);
 
         // Alice writes an email with Bob as recipient
@@ -271,7 +272,7 @@ describe('RecordsReadHandler.handle()', () => {
           data         : encodedEmail,
           recipient    : alice.did
         });
-        const imageReply = await dwn.processMessage(alice.did, emailRecordsWrite.message, emailRecordsWrite.dataStream);
+        const imageReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, emailRecordsWrite.message, emailRecordsWrite.dataStream);
         expect(imageReply.status.code).to.equal(202);
 
         // Bob reads the email he just sent
@@ -279,7 +280,7 @@ describe('RecordsReadHandler.handle()', () => {
           recordId                    : emailRecordsWrite.message.recordId,
           authorizationSignatureInput : Jws.createSignatureInput(bob)
         });
-        const bobReadReply = await dwn.processMessage(alice.did, bobRecordsRead.message);
+        const bobReadReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsRead, bobRecordsRead.message);
         expect(bobReadReply.status.code).to.equal(200);
 
         // ImposterBob is not able to read the email
@@ -287,7 +288,7 @@ describe('RecordsReadHandler.handle()', () => {
           recordId                    : emailRecordsWrite.message.recordId,
           authorizationSignatureInput : Jws.createSignatureInput(imposterBob)
         });
-        const imposterReadReply = await dwn.processMessage(alice.did, imposterRecordsRead.message);
+        const imposterReadReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsRead, imposterRecordsRead.message);
         expect(imposterReadReply.status.code).to.equal(401);
         expect(imposterReadReply.status.detail).to.include(DwnErrorCode.ProtocolAuthorizationActionNotAllowed);
       });
@@ -301,7 +302,7 @@ describe('RecordsReadHandler.handle()', () => {
         authorizationSignatureInput : Jws.createSignatureInput(alice)
       });
 
-      const readReply = await dwn.processMessage(alice.did, recordsRead.message);
+      const readReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsRead, recordsRead.message);
       expect(readReply.status.code).to.equal(404);
     });
 
@@ -310,7 +311,7 @@ describe('RecordsReadHandler.handle()', () => {
 
       // insert public data
       const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice, published: true });
-      const writeReply = await dwn.processMessage(alice.did, message, dataStream);
+      const writeReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, message, dataStream);
       expect(writeReply.status.code).to.equal(202);
 
       // ensure data is inserted
@@ -319,7 +320,7 @@ describe('RecordsReadHandler.handle()', () => {
         filter : { recordId: message.recordId }
       });
 
-      const reply = await dwn.processMessage(alice.did, queryData.message);
+      const reply = await dwn.processMessage(alice.did, DwnMessageName.RecordsQuery, queryData.message);
       expect(reply.status.code).to.equal(200);
       expect(reply.entries?.length).to.equal(1);
 
@@ -329,7 +330,7 @@ describe('RecordsReadHandler.handle()', () => {
         authorizationSignatureInput : Jws.createSignatureInput(alice)
       });
 
-      const deleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
+      const deleteReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsDelete, recordsDelete.message);
       expect(deleteReply.status.code).to.equal(202);
 
       // RecordsRead
@@ -338,7 +339,7 @@ describe('RecordsReadHandler.handle()', () => {
         authorizationSignatureInput : Jws.createSignatureInput(alice)
       });
 
-      const readReply = await dwn.processMessage(alice.did, recordsRead.message);
+      const readReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsRead, recordsRead.message);
       expect(readReply.status.code).to.equal(404);
     });
 
@@ -349,7 +350,7 @@ describe('RecordsReadHandler.handle()', () => {
 
       // insert data
       const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice });
-      const writeReply = await dwn.processMessage(alice.did, message, dataStream);
+      const writeReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, message, dataStream);
       expect(writeReply.status.code).to.equal(202);
 
       // testing RecordsRead
@@ -358,7 +359,7 @@ describe('RecordsReadHandler.handle()', () => {
         authorizationSignatureInput : Jws.createSignatureInput(alice)
       });
 
-      const readReply = await dwn.processMessage(alice.did, recordsRead.message);
+      const readReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsRead, recordsRead.message);
       expect(readReply.status.code).to.equal(404);
     });
 
@@ -393,7 +394,7 @@ describe('RecordsReadHandler.handle()', () => {
           encryptionInput
         });
 
-        const writeReply = await dwn.processMessage(alice.did, message, dataStream);
+        const writeReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, message, dataStream);
         expect(writeReply.status.code).to.equal(202);
 
         const recordsRead = await RecordsRead.create({
@@ -459,7 +460,7 @@ describe('RecordsReadHandler.handle()', () => {
           protocolDefinition
         });
 
-        const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message, protocolsConfig.dataStream);
+        const protocolsConfigureReply = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, protocolsConfig.message, protocolsConfig.dataStream);
         expect(protocolsConfigureReply.status.code).to.equal(202);
 
         // encrypt bob's message
@@ -493,7 +494,7 @@ describe('RecordsReadHandler.handle()', () => {
           }
         );
 
-        const bobWriteReply = await dwn.processMessage(alice.did, message, dataStream);
+        const bobWriteReply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, message, dataStream);
         expect(bobWriteReply.status.code).to.equal(202);
 
         const recordsRead = await RecordsRead.create({

--- a/tests/interfaces/records/handlers/records-write.spec.ts
+++ b/tests/interfaces/records/handlers/records-write.spec.ts
@@ -27,7 +27,6 @@ import { GeneralJwsSigner } from '../../../../src/jose/jws/general/signer.js';
 import { getCurrentTimeInHighPrecision } from '../../../../src/utils/time.js';
 import { Jws } from '../../../../src/utils/jws.js';
 import { KeyDerivationScheme } from '../../../../src/index.js';
-import { DwnMessageName, Message } from '../../../../src/core/message.js';
 import { MessageStoreLevel } from '../../../../src/store/message-store-level.js';
 import { ProtocolActor } from '../../../../src/types/protocols-types.js';
 import { RecordsRead } from '../../../../src/interfaces/records/messages/records-read.js';
@@ -37,6 +36,7 @@ import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { TestStubGenerator } from '../../../utils/test-stub-generator.js';
 
 import { Cid, computeCid } from '../../../../src/utils/cid.js';
+import { DwnMessageName, Message } from '../../../../src/core/message.js';
 import { Encryption, EncryptionAlgorithm } from '../../../../src/utils/encryption.js';
 
 chai.use(chaiAsPromised);
@@ -90,7 +90,8 @@ describe('RecordsWriteHandler.handle()', () => {
       const recordsWriteMessageData = await TestDataGenerator.generateRecordsWrite({ author, data: data1 });
 
       const tenant = author.did;
-      const recordsWriteReply = await dwn.processMessage(tenant, DwnMessageName.RecordsWrite, recordsWriteMessageData.message, recordsWriteMessageData.dataStream);
+      const recordsWriteReply = await dwn.processMessage(
+        tenant, DwnMessageName.RecordsWrite, recordsWriteMessageData.message, recordsWriteMessageData.dataStream);
       expect(recordsWriteReply.status.code).to.equal(202);
 
       const recordId = recordsWriteMessageData.message.recordId;
@@ -129,7 +130,8 @@ describe('RecordsWriteHandler.handle()', () => {
       expect(newRecordsQueryReply.entries![0].encodedData).to.equal(newDataEncoded);
 
       // try to write the older message to store again and verify that it is not accepted
-      const thirdRecordsWriteReply = await dwn.processMessage(tenant, DwnMessageName.RecordsWrite, recordsWriteMessageData.message, recordsWriteMessageData.dataStream);
+      const thirdRecordsWriteReply = await dwn.processMessage(
+        tenant, DwnMessageName.RecordsWrite, recordsWriteMessageData.message, recordsWriteMessageData.dataStream);
       expect(thirdRecordsWriteReply.status.code).to.equal(409); // expecting to fail
 
       // expecting unchanged
@@ -151,7 +153,8 @@ describe('RecordsWriteHandler.handle()', () => {
       // setting up a stub DID resolver
       TestStubGenerator.stubDidResolver(didResolver, [author]);
 
-      const originatingMessageWriteReply = await dwn.processMessage(tenant, DwnMessageName.RecordsWrite, originatingMessageData.message, originatingMessageData.dataStream);
+      const originatingMessageWriteReply = await dwn.processMessage(
+        tenant, DwnMessageName.RecordsWrite, originatingMessageData.message, originatingMessageData.dataStream);
       expect(originatingMessageWriteReply.status.code).to.equal(202);
 
       // generate two new RecordsWrite messages with the same `dateModified` value
@@ -1304,7 +1307,8 @@ describe('RecordsWriteHandler.handle()', () => {
           protocolDefinition
         });
 
-        const protocolConfigureReply = await dwn.processMessage(alice.did, DwnMessageName.ProtocolsConfigure, protocolConfig.message, protocolConfig.dataStream);
+        const protocolConfigureReply = await dwn.processMessage(
+          alice.did, DwnMessageName.ProtocolsConfigure, protocolConfig.message, protocolConfig.dataStream);
         expect(protocolConfigureReply.status.code).to.equal(202);
 
         // test that Alice is allowed to write to her own DWN
@@ -1755,7 +1759,8 @@ describe('RecordsWriteHandler.handle()', () => {
           author: alice,
           data
         });
-        const aliceWrite2Reply = await dwn.processMessage(alice.did, DwnMessageName.RecordsWrite, aliceWrite2Data.message, aliceWrite2Data.dataStream);
+        const aliceWrite2Reply = await dwn.processMessage(
+          alice.did, DwnMessageName.RecordsWrite, aliceWrite2Data.message, aliceWrite2Data.dataStream);
         expect(aliceWrite2Reply.status.code).to.equal(202);
 
         const aliceQueryWrite1AfterAliceWrite2Data = await TestDataGenerator.generateRecordsQuery({
@@ -1889,7 +1894,8 @@ describe('RecordsWriteHandler.handle()', () => {
           dataCid,
           dataSize : 4
         });
-        const bobAssociateReply = await dwn.processMessage(bob.did, DwnMessageName.RecordsWrite, bobAssociateData.message, bobAssociateData.dataStream);
+        const bobAssociateReply = await dwn.processMessage(
+          bob.did, DwnMessageName.RecordsWrite, bobAssociateData.message, bobAssociateData.dataStream);
         expect(bobAssociateReply.status.code).to.equal(400); // expecting an error
         expect(bobAssociateReply.status.detail).to.contain(DwnErrorCode.RecordsWriteMissingDataStream);
 


### PR DESCRIPTION
Thanks to @mistermoe for this genius idea. I am but a medium through which his divine knowledge becomes a PR.

The aim is that typescript can determine what kind of message reply will be returned from `Dwn.processMessage` based on what type of DWN message it is processing.

### Changes
1. Bump Version
2. Update `Dwn.processMessage` to use generics, in order to provide better typing for the message and message reply.
  a. This involves adding a message name parameter to `processMessage`. This is a significant change so we're bumping version number.
3. Remove common `MessageReply` type. Return either `BaseMessage = { status: ...}` from a handler or return a DWN message specific reply type, e.g. `RecordsQueryReply`.

This involved updating a LOT of tests. 