### PR TITLE
#298 - enabled noImplicitAny rule and fixed all errors triggered

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-96.99%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.41%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.28%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-96.99%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.25%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.32%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.62%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.25%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/src/core/message-reply.ts
+++ b/src/core/message-reply.ts
@@ -40,7 +40,7 @@ export class MessageReply {
     this.data = data;
   }
 
-  static fromError(e: unknown, code: number): MessageReply {
+  static fromError(e: unknown, code: number): BaseMessageReply {
 
     const detail = e instanceof Error ? e.message : 'Error';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export type { EventsGetMessage, EventsGetReply } from './types/event-types.js';
 export type { HooksWriteMessage } from './types/hooks-types.js';
 export type { MessagesGetMessage, MessagesGetReply } from './types/messages-types.js';
 export type { ProtocolsConfigureDescriptor, ProtocolDefinition, ProtocolRuleSet, ProtocolsQueryFilter, ProtocolsConfigureMessage, ProtocolsQueryMessage } from './types/protocols-types.js';
-export type { EncryptionProperty, RecordsDeleteMessage, RecordsQueryMessage, RecordsQueryReplyEntry, RecordsReadReply, RecordsWriteDescriptor, RecordsWriteMessage } from './types/records-types.js';
+export type { EncryptionProperty, RecordsDeleteMessage, RecordsQueryMessage, RecordsQueryReply, RecordsQueryReplyEntry, RecordsReadReply, RecordsWriteDescriptor, RecordsWriteMessage } from './types/records-types.js';
 export { AllowAllTenantGate, TenantGate } from './core/tenant-gate.js';
 export { Cid } from './utils/cid.js';
 export { DataStore } from './types/data-store.js';

--- a/src/interfaces/protocols/handlers/protocols-query.ts
+++ b/src/interfaces/protocols/handlers/protocols-query.ts
@@ -44,8 +44,8 @@ export class ProtocolsQueryHandler implements MethodHandler {
     // strip away `authorization` property for each record before responding
     const entries: QueryResultEntry[] = [];
     for (const message of messages) {
-      const { authorization: _, ...objectWithRemainingProperties } = message; // a trick to stripping away `authorization`
-      entries.push(objectWithRemainingProperties);
+      const { authorization: _, ...objectWithRemainingProperties } = message; // a trick to strip away `authorization`
+      entries.push(objectWithRemainingProperties as QueryResultEntry);
     }
 
     return new MessageReply({

--- a/src/interfaces/records/handlers/records-query.ts
+++ b/src/interfaces/records/handlers/records-query.ts
@@ -1,11 +1,11 @@
 import type { MethodHandler } from '../../../types/method-handler.js';
+import type { RecordsWriteMessageWithOptionalEncodedData } from '../../../store/storage-controller.js';
 import type { DataStore, DidResolver, MessageStore } from '../../../index.js';
-import type { RecordsQueryMessage, RecordsQueryReplyEntry, RecordsWriteMessage } from '../../../types/records-types.js';
+import type { RecordsQueryMessage, RecordsQueryReply, RecordsQueryReplyEntry, RecordsWriteMessage } from '../../../types/records-types.js';
 
 import { authenticate } from '../../../core/auth.js';
 import { lexicographicalCompare } from '../../../utils/string.js';
 import { MessageReply } from '../../../core/message-reply.js';
-import type { RecordsWriteMessageWithOptionalEncodedData } from '../../../store/storage-controller.js';
 import { StorageController } from '../../../store/storage-controller.js';
 
 import { DateSort, RecordsQuery } from '../messages/records-query.js';
@@ -18,7 +18,7 @@ export class RecordsQueryHandler implements MethodHandler {
   public async handle({
     tenant,
     message
-  }: {tenant: string, message: RecordsQueryMessage}): Promise<MessageReply> {
+  }: {tenant: string, message: RecordsQueryMessage}): Promise<RecordsQueryReply> {
     let recordsQuery: RecordsQuery;
     try {
       recordsQuery = await RecordsQuery.parse(message);
@@ -52,10 +52,10 @@ export class RecordsQueryHandler implements MethodHandler {
       entries.push(objectWithRemainingProperties);
     }
 
-    return new MessageReply({
+    return {
       status: { code: 200, detail: 'OK' },
       entries
-    });
+    };
   }
 
   /**

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -118,6 +118,10 @@ export type RecordsQueryMessage = BaseMessage & {
   descriptor: RecordsQueryDescriptor;
 };
 
+export type RecordsQueryReply = BaseMessageReply & {
+  entries?: RecordsQueryReplyEntry[];
+};
+
 export type RecordsReadMessage = {
   authorization?: GeneralJws;
   descriptor: RecordsReadDescriptor;

--- a/tests/dwn.spec.ts
+++ b/tests/dwn.spec.ts
@@ -98,7 +98,7 @@ describe('DWN', () => {
 
       expect(reply.status.code).to.equal(200);
       expect(reply.events).to.be.empty;
-      expect(reply['data']).to.not.exist;
+      expect((reply as any).data).to.not.exist;
     });
 
     it('#191 - regression - should run JSON schema validation', async () => {

--- a/tests/event-log/event-log-level.spec.ts
+++ b/tests/event-log/event-log-level.spec.ts
@@ -106,7 +106,7 @@ describe('EventLogLevel Tests', () => {
       await eventLog.append(author.did, messageCid);
 
       const messageCids: string[] = [];
-      let testWatermark;
+      let testWatermark = '';
 
       for (let i = 0; i < 9; i += 1) {
         const { message } = await TestDataGenerator.generateRecordsWrite({ author });

--- a/tests/interfaces/events/handlers/events-get.spec.ts
+++ b/tests/interfaces/events/handlers/events-get.spec.ts
@@ -68,7 +68,7 @@ describe('EventsGetHandler.handle()', () => {
     const alice = await DidKeyResolver.generate();
 
     const { message } = await TestDataGenerator.generateEventsGet({ author: alice });
-    message['descriptor']['troll'] = 'hehe';
+    (message['descriptor'] as any)['troll'] = 'hehe';
 
     const reply = await dwn.processMessage(alice.did, message);
 
@@ -95,7 +95,7 @@ describe('EventsGetHandler.handle()', () => {
     const reply: EventsGetReply = await dwn.processMessage(alice.did, message);
 
     expect(reply.status.code).to.equal(200);
-    expect(reply['data']).to.not.exist;
+    expect((reply as any).data).to.not.exist;
     expect(reply.events?.length).to.equal(expectedCids.length);
 
     for (let i = 0; i < reply.events!.length; i += 1) {
@@ -134,7 +134,7 @@ describe('EventsGetHandler.handle()', () => {
     reply = await dwn.processMessage(alice.did, m);
 
     expect(reply.status.code).to.equal(200);
-    expect(reply['data']).to.not.exist;
+    expect((reply as any).data).to.not.exist;
     expect(reply.events!.length).to.equal(expectedCids.length);
 
     for (let i = 0; i < reply.events!.length; i += 1) {

--- a/tests/interfaces/events/messages/events-get.spec.ts
+++ b/tests/interfaces/events/messages/events-get.spec.ts
@@ -58,7 +58,7 @@ describe('EventsGet Message', () => {
       });
 
       const { message } = eventsGet;
-      message['hehe'] = 'troll';
+      (message as any)['hehe'] = 'troll';
 
       try {
         await EventsGet.parse(message as any);

--- a/tests/interfaces/messages/handlers/messages-get.spec.ts
+++ b/tests/interfaces/messages/handlers/messages-get.spec.ts
@@ -82,7 +82,7 @@ describe('MessagesGetHandler.handle()', () => {
       messageCids : [await Message.getCid(recordsWrite.message)]
     });
 
-    message['descriptor']['troll'] = 'hehe';
+    (message['descriptor'] as any)['troll'] = 'hehe';
 
     const reply = await dwn.processMessage(alice.did, message);
 

--- a/tests/interfaces/permissions/messages/permissions-request.spec.ts
+++ b/tests/interfaces/permissions/messages/permissions-request.spec.ts
@@ -1,4 +1,4 @@
-import type { PermissionsRequestMessage } from '../../../../src/types/permissions-types.js';
+import type { PermissionConditions, PermissionsRequestMessage } from '../../../../src/types/permissions-types.js';
 
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -29,7 +29,8 @@ describe('PermissionsRequest', () => {
           method      : 'PermissionsRequest',
           objectId    : '331806c4-ce15-4759-b1c3-0f742312aae9',
           scope       : { method: 'RecordsWrite' }
-        }
+        },
+        authorization: { } // to be assigned in loop
       };
 
       const testVectors = [
@@ -45,7 +46,7 @@ describe('PermissionsRequest', () => {
         const signer = await GeneralJwsSigner.create(payloadBytes, [{ privateJwk, protectedHeader }]);
         const jws = signer.getJws();
 
-        jsonMessage['authorization'] = jws;
+        jsonMessage.authorization = jws;
 
         await expect(PermissionsRequest.parse(jsonMessage as PermissionsRequestMessage))
           .to.be.rejectedWith(vector.expectedError);
@@ -100,7 +101,7 @@ describe('PermissionsRequest', () => {
       const { conditions } = message;
 
       for (const conditionName in DEFAULT_CONDITIONS) {
-        expect(conditions[conditionName]).to.equal(DEFAULT_CONDITIONS[conditionName]);
+        expect(conditions[conditionName as keyof PermissionConditions]).to.equal(DEFAULT_CONDITIONS[conditionName as keyof PermissionConditions]);
       }
 
       const numConditions = Object.keys(conditions).length;

--- a/tests/interfaces/records/handlers/records-query.spec.ts
+++ b/tests/interfaces/records/handlers/records-query.spec.ts
@@ -310,7 +310,7 @@ describe('RecordsQueryHandler.handle()', () => {
       const queryReply = await dwn.processMessage(alice.did, queryData.message);
       expect(queryReply.status.code).to.equal(200);
       expect(queryReply.entries?.length).to.equal(1);
-      expect(queryReply.entries![0]['authorization']).to.equal(undefined);
+      expect((queryReply.entries![0] as any).authorization).to.equal(undefined);
     });
 
     it('should include `attestation` in returned records', async () => {
@@ -362,7 +362,7 @@ describe('RecordsQueryHandler.handle()', () => {
         dateSort : DateSort.PublishedAscending,
         filter   : { schema }
       });
-      const publishedAscendingQueryReply = await dwn.processMessage(alice.did, publishedAscendingQueryData.message);
+      const publishedAscendingQueryReply = await dwn.handleRecordsQuery(alice.did, publishedAscendingQueryData.message);
 
       expect(publishedAscendingQueryReply.entries?.length).to.equal(1);
       expect(publishedAscendingQueryReply.entries![0].descriptor['datePublished']).to.equal(publishedWriteData.message.descriptor.datePublished);
@@ -373,7 +373,7 @@ describe('RecordsQueryHandler.handle()', () => {
         dateSort : DateSort.PublishedDescending,
         filter   : { schema }
       });
-      const publishedDescendingQueryReply = await dwn.processMessage(alice.did, publishedDescendingQueryData.message);
+      const publishedDescendingQueryReply = await dwn.handleRecordsQuery(alice.did, publishedDescendingQueryData.message);
 
       expect(publishedDescendingQueryReply.entries?.length).to.equal(1);
       expect(publishedDescendingQueryReply.entries![0].descriptor['datePublished']).to.equal(publishedWriteData.message.descriptor.datePublished);
@@ -406,7 +406,7 @@ describe('RecordsQueryHandler.handle()', () => {
         dateSort : DateSort.CreatedAscending,
         filter   : { schema }
       });
-      const createdAscendingQueryReply = await dwn.processMessage(alice.did, createdAscendingQueryData.message);
+      const createdAscendingQueryReply = await dwn.handleRecordsQuery(alice.did, createdAscendingQueryData.message);
 
       expect(createdAscendingQueryReply.entries?.[0].descriptor['dateCreated']).to.equal(write1Data.message.descriptor.dateCreated);
       expect(createdAscendingQueryReply.entries?.[1].descriptor['dateCreated']).to.equal(write2Data.message.descriptor.dateCreated);
@@ -418,7 +418,7 @@ describe('RecordsQueryHandler.handle()', () => {
         dateSort : DateSort.CreatedDescending,
         filter   : { schema }
       });
-      const createdDescendingQueryReply = await dwn.processMessage(alice.did, createdDescendingQueryData.message);
+      const createdDescendingQueryReply = await dwn.handleRecordsQuery(alice.did, createdDescendingQueryData.message);
 
       expect(createdDescendingQueryReply.entries?.[0].descriptor['dateCreated']).to.equal(write3Data.message.descriptor.dateCreated);
       expect(createdDescendingQueryReply.entries?.[1].descriptor['dateCreated']).to.equal(write2Data.message.descriptor.dateCreated);
@@ -430,7 +430,7 @@ describe('RecordsQueryHandler.handle()', () => {
         dateSort : DateSort.PublishedAscending,
         filter   : { schema }
       });
-      const publishedAscendingQueryReply = await dwn.processMessage(alice.did, publishedAscendingQueryData.message);
+      const publishedAscendingQueryReply = await dwn.handleRecordsQuery(alice.did, publishedAscendingQueryData.message);
 
       expect(publishedAscendingQueryReply.entries?.[0].descriptor['datePublished']).to.equal(write1Data.message.descriptor.datePublished);
       expect(publishedAscendingQueryReply.entries?.[1].descriptor['datePublished']).to.equal(write2Data.message.descriptor.datePublished);
@@ -442,7 +442,7 @@ describe('RecordsQueryHandler.handle()', () => {
         dateSort : DateSort.PublishedDescending,
         filter   : { schema }
       });
-      const publishedDescendingQueryReply = await dwn.processMessage(alice.did, publishedDescendingQueryData.message);
+      const publishedDescendingQueryReply = await dwn.handleRecordsQuery(alice.did, publishedDescendingQueryData.message);
 
       expect(publishedDescendingQueryReply.entries?.[0].descriptor['datePublished']).to.equal(write3Data.message.descriptor.datePublished);
       expect(publishedDescendingQueryReply.entries?.[1].descriptor['datePublished']).to.equal(write2Data.message.descriptor.datePublished);

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "strict": true,
-        "noImplicitAny": false, // TODO: #298 - evaluate to see if it's worth it to turn on - https://github.com/TBD54566975/dwn-sdk-js/issues/298
+        "noImplicitAny": true,
         "lib": [
             "DOM",
             "ES5"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "strict": true,
-    "noImplicitAny": false, // TODO: #298 - evaluate to see if it's worth it to turn on - https://github.com/TBD54566975/dwn-sdk-js/issues/298
+    "noImplicitAny": true,
     "lib": [
       "DOM",
       "ES6"


### PR DESCRIPTION
In a future PR, we should remove `MessageReply` as a class and/or consolidate it with `BaseMessageReply`, return type of `processMessage()` is messy at the moment, and we will have a clear path forward tomorrow.