### PR TITLE
Allow recipients to always read their received messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.25%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.16%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.6%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.25%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.26%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.27%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.6%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.26%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/json-schemas/records/records-write.json
+++ b/json-schemas/records/records-write.json
@@ -152,11 +152,6 @@
         "dateModified",
         "dataFormat"
       ],
-      "dependencies": {
-        "recipient": [
-          "protocol"
-        ]
-      },
       "allOf": [
         {
           "$comment": "rule defining `published` and `datePublished` relationship",

--- a/src/interfaces/records-read.ts
+++ b/src/interfaces/records-read.ts
@@ -60,6 +60,9 @@ export class RecordsRead extends Message<RecordsReadMessage> {
     } else if (descriptor.published === true) {
       // authentication is not required for published data
       return;
+    } else if (this.author !== undefined && this.author === descriptor.recipient) {
+      // The recipient of a message may always read it
+      return;
     } else if (descriptor.protocol !== undefined) {
       await ProtocolAuthorization.authorize(tenant, this, this.author, messageStore);
     } else {


### PR DESCRIPTION
This is already allowed in `RecordsQuery`. A recipient may query their received, unpublished messages