### PR TITLE
Create and process PermissionsGrant messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.29%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.18%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.85%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.29%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.36%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.34%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.97%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.36%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.36%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.34%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.97%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.36%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.35%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.32%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.97%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.35%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/json-schemas/permissions/permissions-grant.json
+++ b/json-schemas/permissions/permissions-grant.json
@@ -42,6 +42,10 @@
           "description": "DID of the DWN to which the grantee is given access",
           "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/definitions/grantedFor"
         },
+        "permissionsRequestId": {
+          "description": "CID of an associated PermissionsRequest message",
+          "type": "string"
+        },
         "interface": {
           "enum": [
             "Permissions"

--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -17,6 +17,8 @@ export enum DwnErrorCode {
   AuthorizationMissing = 'AuthorizationMissing',
   AuthorizationUnknownAuthor = 'AuthorizationUnknownAuthor',
   HdKeyDerivationPathInvalid = 'HdKeyDerivationPathInvalid',
+  PermissionsGrantGrantedByMismatch = 'PermissionsGrantGrantedByMismatch',
+  PermissionsGrantUnauthorizedGrant = 'PermissionsGrantUnauthorizedGrant',
   ProtocolAuthorizationActionNotAllowed = 'ProtocolAuthorizationActionNotAllowed',
   ProtocolAuthorizationIncorrectDataFormat = 'ProtocolAuthorizationIncorrectDataFormat',
   ProtocolAuthorizationIncorrectProtocolPath = 'ProtocolAuthorizationIncorrectProtocolPath',

--- a/src/dwn.ts
+++ b/src/dwn.ts
@@ -18,6 +18,7 @@ import { EventsGetHandler } from './handlers/events-get.js';
 import { messageReplyFromError } from './core/message-reply.js';
 import { MessagesGetHandler } from './handlers/messages-get.js';
 import { MessageStoreLevel } from './store/message-store-level.js';
+import { PermissionsGrantHandler } from './handlers/permissions-grant.js';
 import { PermissionsRequestHandler } from './handlers/permissions-request.js';
 import { ProtocolsConfigureHandler } from './handlers/protocols-configure.js';
 import { ProtocolsQueryHandler } from './handlers/protocols-query.js';
@@ -43,9 +44,11 @@ export class Dwn {
     this.tenantGate = config.tenantGate!;
 
     this.methodHandlers = {
-      [DwnInterfaceName.Events + DwnMethodName.Get]          : new EventsGetHandler(this.didResolver, this.eventLog),
-      [DwnInterfaceName.Messages + DwnMethodName.Get]        : new MessagesGetHandler(this.didResolver, this.messageStore, this.dataStore),
-      [DwnInterfaceName.Permissions + DwnMethodName.Request] : new PermissionsRequestHandler(
+      [DwnInterfaceName.Events + DwnMethodName.Get]        : new EventsGetHandler(this.didResolver, this.eventLog),
+      [DwnInterfaceName.Messages + DwnMethodName.Get]      : new MessagesGetHandler(this.didResolver, this.messageStore, this.dataStore),
+      [DwnInterfaceName.Permissions + DwnMethodName.Grant] : new PermissionsGrantHandler(
+        this.didResolver, this.messageStore, this.eventLog),
+      [DwnInterfaceName.Permissions + DwnMethodName.Request]: new PermissionsRequestHandler(
         this.didResolver, this.messageStore, this.eventLog),
       [DwnInterfaceName.Protocols + DwnMethodName.Configure]: new ProtocolsConfigureHandler(
         this.didResolver, this.messageStore, this.dataStore, this.eventLog),

--- a/src/handlers/permissions-grant.ts
+++ b/src/handlers/permissions-grant.ts
@@ -1,0 +1,60 @@
+import type { BaseMessageReply } from '../core/message-reply.js';
+import type { MethodHandler } from '../types/method-handler.js';
+import type { PermissionsGrantMessage } from '../types/permissions-types.js';
+import type { DidResolver, EventLog, MessageStore } from '../index.js';
+
+import { authenticate } from '../core/auth.js';
+import { Message } from '../core/message.js';
+import { messageReplyFromError } from '../core/message-reply.js';
+import { PermissionsGrant } from '../interfaces/permissions-grant.js';
+
+export class PermissionsGrantHandler implements MethodHandler {
+  constructor(private didResolver: DidResolver, private messageStore: MessageStore, private eventLog: EventLog) { }
+
+  public async handle({
+    tenant,
+    message
+  }: { tenant: string, message: PermissionsGrantMessage }): Promise<BaseMessageReply> {
+    let permissionsGrant: PermissionsGrant;
+    try {
+      permissionsGrant = await PermissionsGrant.parse(message);
+    } catch (e) {
+      return messageReplyFromError(e, 400);
+    }
+
+    try {
+      await authenticate(message.authorization, this.didResolver);
+      await permissionsGrant.authorize();
+    } catch (e) {
+      return messageReplyFromError(e, 401);
+    }
+
+    // validate PermissionsRequestId if it is included
+    if (message.descriptor.permissionsRequestId !== undefined) {
+      const permissionsRequestMessage = await this.messageStore.get(tenant, message.descriptor.permissionsRequestId);
+      if (permissionsRequestMessage === undefined) {
+        return {
+          status: { code: 400, detail: `Could not find a PermissionsRequest with CID ${message.descriptor.permissionsRequestId}` }
+        };
+      }
+    }
+
+    const { dataSize, scope, conditions, ...propertiesToIndex } = message.descriptor;
+    const indexes: { [key: string]: string } = {
+      author: permissionsGrant.author!,
+      ...propertiesToIndex,
+    };
+
+    // If we have not seen this message before, store it
+    const messageCid = await Message.getCid(message);
+    const existingMessage = await this.messageStore.get(tenant, messageCid);
+    if (existingMessage === undefined) {
+      await this.messageStore.put(tenant, message, indexes);
+      await this.eventLog.append(tenant, messageCid);
+    }
+
+    return {
+      status: { code: 202, detail: 'Accepted' }
+    };
+  }
+}

--- a/src/handlers/permissions-grant.ts
+++ b/src/handlers/permissions-grant.ts
@@ -29,16 +29,6 @@ export class PermissionsGrantHandler implements MethodHandler {
       return messageReplyFromError(e, 401);
     }
 
-    // validate PermissionsRequestId if it is included
-    if (message.descriptor.permissionsRequestId !== undefined) {
-      const permissionsRequestMessage = await this.messageStore.get(tenant, message.descriptor.permissionsRequestId);
-      if (permissionsRequestMessage === undefined) {
-        return {
-          status: { code: 400, detail: `Could not find a PermissionsRequest with CID ${message.descriptor.permissionsRequestId}` }
-        };
-      }
-    }
-
     const { dataSize, scope, conditions, ...propertiesToIndex } = message.descriptor;
     const indexes: { [key: string]: string } = {
       author: permissionsGrant.author!,

--- a/src/types/permissions-types.ts
+++ b/src/types/permissions-types.ts
@@ -55,5 +55,4 @@ export type PermissionsGrantDescriptor = {
 
 export type PermissionsGrantMessage = BaseMessage & {
   descriptor: PermissionsGrantDescriptor;
-  delegationChain?: PermissionsGrantMessage;
 };

--- a/tests/handlers/permissions-grant.spec.ts
+++ b/tests/handlers/permissions-grant.spec.ts
@@ -1,0 +1,205 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { DataStoreLevel } from '../../src/store/data-store-level.js';
+import { DidKeyResolver } from '../../src/did/did-key-resolver.js';
+import { DidResolver } from '../../src/did/did-resolver.js';
+import { Dwn } from '../../src/dwn.js';
+import { DwnErrorCode } from '../../src/core/dwn-error.js';
+import { EventLogLevel } from '../../src/event-log/event-log-level.js';
+import { Message } from '../../src/core/message.js';
+import { MessageStoreLevel } from '../../src/store/message-store-level.js';
+import { PermissionsGrant } from '../../src/interfaces/permissions-grant.js';
+import { PermissionsGrantHandler } from '../../src/handlers/permissions-grant.js';
+import { TestDataGenerator } from '../utils/test-data-generator.js';
+
+describe('PermissionsGrantHandler.handle()', () => {
+  let didResolver: DidResolver;
+  let messageStore: MessageStoreLevel;
+  let dataStore: DataStoreLevel;
+  let eventLog: EventLogLevel;
+  let dwn: Dwn;
+
+  describe('functional tests', () => {
+    before(async () => {
+      didResolver = new DidResolver([new DidKeyResolver()]);
+
+      // important to follow this pattern to initialize and clean the message and data store in tests
+      // so that different suites can reuse the same block store and index location for testing
+      messageStore = new MessageStoreLevel({
+        blockstoreLocation : 'TEST-MESSAGESTORE',
+        indexLocation      : 'TEST-INDEX'
+      });
+
+      dataStore = new DataStoreLevel({
+        blockstoreLocation: 'TEST-DATASTORE'
+      });
+
+      eventLog = new EventLogLevel({
+        location: 'TEST-EVENTLOG'
+      });
+
+      dwn = await Dwn.create({ didResolver, messageStore, dataStore, eventLog });
+    });
+
+    beforeEach(async () => {
+      sinon.restore(); // wipe all previous stubs/spies/mocks/fakes
+
+      // clean up before each test rather than after so that a test does not depend on other tests to do the clean up
+      await messageStore.clear();
+      await dataStore.clear();
+      await eventLog.clear();
+    });
+
+    after(async () => {
+      await dwn.close();
+    });
+
+    it('should accept a PermissionsGrant with permissionsRequestId omitted', async () => {
+      const alice = await DidKeyResolver.generate();
+
+      const { message } = await TestDataGenerator.generatePermissionsGrant({
+        author     : alice,
+        grantedBy  : alice.did,
+        grantedFor : alice.did,
+      });
+
+      const reply = await dwn.processMessage(alice.did, message);
+      expect(reply.status.code).to.equal(202);
+    });
+
+    it('should accept a PermissionsGrant with associated PermissionsRequest', async () => {
+      const alice = await DidKeyResolver.generate();
+
+      const { permissionsRequest } = await TestDataGenerator.generatePermissionsRequest({
+        author: alice,
+      });
+      const permissionsRequestReply = await dwn.processMessage(alice.did, permissionsRequest.message);
+      expect(permissionsRequestReply.status.code).to.equal(202);
+
+      const { permissionsGrant } = await TestDataGenerator.generatePermissionsGrant({
+        author               : alice,
+        grantedBy            : alice.did,
+        grantedFor           : alice.did,
+        permissionsRequestId : await Message.getCid(permissionsRequest.message),
+      });
+
+      const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.message);
+      expect(permissionsGrantReply.status.code).to.equal(202);
+    });
+
+    it('should reject a PermissionsGrant where associated PermissionsRequest is not found', async () => {
+      const alice = await DidKeyResolver.generate();
+
+      // create but don't process a PermissionsRequest
+      const { permissionsRequest } = await TestDataGenerator.generatePermissionsRequest({
+        author: alice,
+      });
+
+      // Use CID of PermissionsRequest which hasn't been processed
+      const { permissionsGrant } = await TestDataGenerator.generatePermissionsGrant({
+        author               : alice,
+        grantedBy            : alice.did,
+        grantedFor           : alice.did,
+        permissionsRequestId : await Message.getCid(permissionsRequest.message),
+      });
+
+      const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.message);
+      expect(permissionsGrantReply.status.code).to.equal(400);
+      expect(permissionsGrantReply.status.detail).to.contain('Could not find a PermissionsRequest with CID');
+    });
+
+    it('should return 401 if authentication fails', async () => {
+      const alice = await DidKeyResolver.generate();
+      alice.keyId = 'wrongValue'; // to fail authentication
+      const { message } = await TestDataGenerator.generatePermissionsGrant({
+        author: alice,
+      });
+
+      const reply = await dwn.processMessage(alice.did, message);
+      expect(reply.status.code).to.equal(401);
+      expect(reply.status.detail).to.contain('not a valid DID');
+    });
+
+    it('should reject if author does not match grantedBy', async () => {
+      const alice = await DidKeyResolver.generate();
+      const bob = await DidKeyResolver.generate();
+
+      const { message } = await TestDataGenerator.generatePermissionsGrant({
+        author    : alice,
+        grantedBy : bob.did,
+      });
+
+      const reply = await dwn.processMessage(alice.did, message);
+      expect(reply.status.code).to.equal(401);
+      expect(reply.status.detail).to.contain(DwnErrorCode.PermissionsGrantGrantedByMismatch);
+    });
+
+    it('should reject if grantedBy is not a delegate and does not match grantedFor', async () => {
+      const alice = await DidKeyResolver.generate();
+      const bob = await DidKeyResolver.generate();
+
+      const { message } = await TestDataGenerator.generatePermissionsGrant({
+        author     : alice,
+        grantedBy  : alice.did,
+        grantedFor : bob.did,
+      });
+
+      const reply = await dwn.processMessage(alice.did, message);
+      expect(reply.status.code).to.equal(401);
+      expect(reply.status.detail).to.contain(DwnErrorCode.PermissionsGrantUnauthorizedGrant);
+    });
+
+    it('should return 400 if failure parsing the message', async () => {
+      const alice = await DidKeyResolver.generate();
+      const { message } = await TestDataGenerator.generatePermissionsGrant();
+
+      const permissionsRequestHandler = new PermissionsGrantHandler(didResolver, messageStore, eventLog);
+
+      // stub the `parse()` function to throw an error
+      sinon.stub(PermissionsGrant, 'parse').throws('anyError');
+      const reply = await permissionsRequestHandler.handle({ tenant: alice.did, message });
+
+      expect(reply.status.code).to.equal(400);
+    });
+
+    describe('event log', () => {
+      it('should add event for PermissionsGrant', async () => {
+        const alice = await DidKeyResolver.generate();
+        const { message } = await TestDataGenerator.generatePermissionsGrant({
+          author    : alice,
+          grantedBy : alice.did,
+        });
+
+        const reply = await dwn.processMessage(alice.did, message);
+        expect(reply.status.code).to.equal(202);
+
+        const events = await eventLog.getEvents(alice.did);
+        expect(events.length).to.equal(1);
+
+        const messageCid = await Message.getCid(message);
+        expect(events[0].messageCid).to.equal(messageCid);
+      });
+
+      it('should not add a new event if we have already stored this PermissionsRequest', async () => {
+        const alice = await DidKeyResolver.generate();
+        const { message } = await TestDataGenerator.generatePermissionsGrant({
+          author    : alice,
+          grantedBy : alice.did,
+        });
+
+        let reply = await dwn.processMessage(alice.did, message);
+        expect(reply.status.code).to.equal(202);
+
+        reply = await dwn.processMessage(alice.did, message);
+        expect(reply.status.code).to.equal(202);
+
+        const events = await eventLog.getEvents(alice.did);
+        expect(events.length).to.equal(1);
+
+        const messageCid = await Message.getCid(message);
+        expect(events[0].messageCid).to.equal(messageCid);
+      });
+    });
+  });
+});

--- a/tests/handlers/permissions-grant.spec.ts
+++ b/tests/handlers/permissions-grant.spec.ts
@@ -88,27 +88,6 @@ describe('PermissionsGrantHandler.handle()', () => {
       expect(permissionsGrantReply.status.code).to.equal(202);
     });
 
-    it('should reject a PermissionsGrant where associated PermissionsRequest is not found', async () => {
-      const alice = await DidKeyResolver.generate();
-
-      // create but don't process a PermissionsRequest
-      const { permissionsRequest } = await TestDataGenerator.generatePermissionsRequest({
-        author: alice,
-      });
-
-      // Use CID of PermissionsRequest which hasn't been processed
-      const { permissionsGrant } = await TestDataGenerator.generatePermissionsGrant({
-        author               : alice,
-        grantedBy            : alice.did,
-        grantedFor           : alice.did,
-        permissionsRequestId : await Message.getCid(permissionsRequest.message),
-      });
-
-      const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.message);
-      expect(permissionsGrantReply.status.code).to.equal(400);
-      expect(permissionsGrantReply.status.detail).to.contain('Could not find a PermissionsRequest with CID');
-    });
-
     it('should return 401 if authentication fails', async () => {
       const alice = await DidKeyResolver.generate();
       alice.keyId = 'wrongValue'; // to fail authentication

--- a/tests/handlers/permissions-request.spec.ts
+++ b/tests/handlers/permissions-request.spec.ts
@@ -93,7 +93,7 @@ describe('PermissionsRequestHandler.handle()', () => {
       expect(reply.status.detail).to.contain('not a valid DID');
     });
 
-    it('should return 400 if fail parsing the message', async () => {
+    it('should return 400 if failure parsing the message', async () => {
       const alice = await DidKeyResolver.generate();
       const { message } = await TestDataGenerator.generatePermissionsRequest();
 

--- a/tests/interfaces/permissions-grant.spec.ts
+++ b/tests/interfaces/permissions-grant.spec.ts
@@ -1,0 +1,117 @@
+import { expect } from 'chai';
+
+import type { CreateFromPermissionsRequestOverrides } from '../../src/interfaces/permissions-grant.js';
+
+import { DidKeyResolver } from '../../src/index.js';
+import { PermissionsGrant } from '../../src/interfaces/permissions-grant.js';
+import { Secp256k1 } from '../../src/utils/secp256k1.js';
+import { TestDataGenerator } from '../utils/test-data-generator.js';
+import { DwnInterfaceName, DwnMethodName, Message } from '../../src/core/message.js';
+
+describe('PermissionsGrant', () => {
+  describe('create()', async () => {
+    it ('creates a PermissionsGrant message', async () => {
+      const { privateJwk } = await Secp256k1.generateKeyPair();
+      const authorizationSignatureInput = {
+        privateJwk,
+        protectedHeader: {
+          alg : privateJwk.alg as string,
+          kid : 'did:jank:bob'
+        }
+      };
+
+      const { message } = await PermissionsGrant.create({
+        description : 'drugs',
+        grantedBy   : 'did:jank:bob',
+        grantedTo   : 'did:jank:alice',
+        grantedFor  : 'did:jank:bob',
+        scope       : { interface: DwnInterfaceName.Records, method: DwnMethodName.Write },
+        authorizationSignatureInput
+      });
+
+      expect(message.descriptor.grantedTo).to.equal('did:jank:alice');
+      expect(message.descriptor.grantedBy).to.equal('did:jank:bob');
+      expect(message.descriptor.scope).to.eql({ interface: DwnInterfaceName.Records, method: DwnMethodName.Write });
+      expect(message.descriptor.conditions).to.be.undefined;
+      expect(message.descriptor.description).to.eql('drugs');
+    });
+  });
+
+  describe('createFromPermissionsRequest()', async () => {
+    it('should create a PermissionsGrant from a PermissionsRequest with the same properties', async () => {
+      const alice = await TestDataGenerator.generatePersona();
+      const bob = await TestDataGenerator.generatePersona();
+
+      const { privateJwk } = await Secp256k1.generateKeyPair();
+      const authorizationSignatureInput = {
+        privateJwk,
+        protectedHeader: {
+          alg : privateJwk.alg as string,
+          kid : alice.did
+        }
+      };
+
+      const { permissionsRequest } = await TestDataGenerator.generatePermissionsRequest({
+        author      : bob,
+        description : 'friendship',
+        grantedBy   : alice.did,
+        grantedFor  : alice.did,
+        grantedTo   : bob.did,
+      });
+
+      const permissionsGrant = await PermissionsGrant.createFromPermissionsRequest(permissionsRequest, authorizationSignatureInput);
+
+      expect(permissionsGrant.author).to.eq(alice.did);
+      expect(permissionsGrant.message.descriptor.description).to.eq(permissionsRequest.message.descriptor.description);
+      expect(permissionsGrant.message.descriptor.grantedBy).to.eq(permissionsRequest.message.descriptor.grantedBy);
+      expect(permissionsGrant.message.descriptor.grantedTo).to.eq(permissionsRequest.message.descriptor.grantedTo);
+      expect(permissionsGrant.message.descriptor.grantedFor).to.eq(permissionsRequest.message.descriptor.grantedFor);
+      expect(permissionsGrant.message.descriptor.scope).to.eq(permissionsRequest.message.descriptor.scope);
+      expect(permissionsGrant.message.descriptor.conditions).to.eq(permissionsRequest.message.descriptor.conditions);
+      expect(permissionsGrant.message.descriptor.permissionsRequestId).to.eq(await Message.getCid(permissionsRequest.message));
+    });
+
+    it('should create a PermissionsGrant from a PerimssionsRequest and overrides', async () => {
+      const alice = await DidKeyResolver.generate();
+      const bob = await DidKeyResolver.generate();
+      const carol = await DidKeyResolver.generate();
+
+      const { privateJwk } = await Secp256k1.generateKeyPair();
+      const authorizationSignatureInput = {
+        privateJwk,
+        protectedHeader: {
+          alg : privateJwk.alg as string,
+          kid : alice.did
+        }
+      };
+
+      const { permissionsRequest } = await TestDataGenerator.generatePermissionsRequest();
+
+      const description = 'friendship';
+      const overrides: CreateFromPermissionsRequestOverrides = {
+        description,
+        grantedBy  : alice.did,
+        grantedTo  : bob.did,
+        grantedFor : carol.did,
+        scope      : {
+          interface : DwnInterfaceName.Protocols,
+          method    : DwnMethodName.Configure,
+        },
+        conditions: {
+          publication: true,
+        }
+      };
+
+      const permissionsGrant = await PermissionsGrant.createFromPermissionsRequest(permissionsRequest, authorizationSignatureInput, overrides);
+
+      expect(permissionsGrant.author).to.eq(alice.did);
+      expect(permissionsGrant.message.descriptor.description).to.eq(description);
+      expect(permissionsGrant.message.descriptor.grantedBy).to.eq(overrides.grantedBy);
+      expect(permissionsGrant.message.descriptor.grantedTo).to.eq(overrides.grantedTo);
+      expect(permissionsGrant.message.descriptor.grantedFor).to.eq(overrides.grantedFor);
+      expect(permissionsGrant.message.descriptor.scope).to.eq(overrides.scope);
+      expect(permissionsGrant.message.descriptor.conditions).to.eq(overrides.conditions);
+      expect(permissionsGrant.message.descriptor.permissionsRequestId).to.eq(await Message.getCid(permissionsRequest.message));
+    });
+  });
+});

--- a/tests/interfaces/permissions-request.spec.ts
+++ b/tests/interfaces/permissions-request.spec.ts
@@ -37,4 +37,3 @@ describe('PermissionsRequest', () => {
     });
   });
 });
-


### PR DESCRIPTION
This PR creates and processes `PermissionsGrant` messages. It does NOT implement grant-based authorization of other DWN messages. That'll be added in the next PR.