### PR TITLE
Use esm for react-native directive

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
   "@comment react-native": [
     "directive for metro (react native build tool)."
   ],
-  "react-native": "./dist/esm/src/index.js",
+  "react-native": {
+    "./dist/esm/src/index.js": "./dist/esm/src/index.js",
+    "./dist/cjs/src/index.js": "./dist/esm/src/index.js"
+  },
   "scripts": {
     "build:esm": "tsc",
     "build:cjs": "tsc --project tsconfig.cjs.json && echo '{\"type\": \"commonjs\"}' > ./dist/cjs/package.json",


### PR DESCRIPTION
In React Native, the directive priority order goes:
`react-native > browser > main`

`react-native` previously did not set values for `./dist/esm/src/index.js` or `./dist/cjs/src/index.js`, so it would instead use the values from the `browser` directive. This caused react native to consume `./dist/bundles/browser.js`, which causes issues in that environment, which requires workarounds in the react native apps that consume it.

To fix, this PR directly sets values for `./dist/esm/src/index.js` and `./dist/cjs/src/index.js` to always point to the esm version.