### PR TITLE
Update vulnerable version of word-wrap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,15 @@
         "node": ">= 16"
       }
     },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@assemblyscript/loader": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.9.4.tgz",
@@ -5446,30 +5455,20 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
       "dev": true,
       "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "type-check": "^0.4.0"
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/optionator/node_modules/word-wrap": {
-      "name": "@aashutoshrathi/word-wrap",
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-plhoNEfSVdHMKXQyAxvH0Zyv3/4NL8r6pwgMQdmHR2vBUXn2t74PN2pBRppqKUa6RMT0yldyvOHG5Dbjwy2mBQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/os-browserify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5462,6 +5462,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/optionator/node_modules/word-wrap": {
+      "name": "@aashutoshrathi/word-wrap",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-plhoNEfSVdHMKXQyAxvH0Zyv3/4NL8r6pwgMQdmHR2vBUXn2t74PN2pBRppqKUa6RMT0yldyvOHG5Dbjwy2mBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/os-browserify": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -7001,15 +7011,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/workerpool": {

--- a/package.json
+++ b/package.json
@@ -141,8 +141,7 @@
       "istanbul-lib-report": {
         "make-dir": "^4.0.0"
       }
-    },
-    "word-wrap" : "npm:@aashutoshrathi/word-wrap@1.2.5"
+    }
   },
   "scripts": {
     "build:esm": "tsc",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,8 @@
       "istanbul-lib-report": {
         "make-dir": "^4.0.0"
       }
-    }
+    },
+    "word-wrap" : "npm:@aashutoshrathi/word-wrap@1.2.5"
   },
   "scripts": {
     "build:esm": "tsc",


### PR DESCRIPTION
`npm audit` is flagging an issue with `word-wrap`.
```
word-wrap  *
Severity: moderate
word-wrap vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-j8xg-fqg3-53r7
No fix available
node_modules/word-wrap
  optionator  >=0.8.3
  Depends on vulnerable versions of word-wrap
  node_modules/optionator
    eslint  2.5.0 - 2.5.2 || >=6.7.0
    Depends on vulnerable versions of optionator
    node_modules/eslint
      eslint-plugin-todo-plz  *
      Depends on vulnerable versions of eslint
      node_modules/eslint-plugin-todo-plz
```

Vuln here: https://security.snyk.io/vuln/SNYK-JS-WORDWRAP-3149973

Community fix here: https://github.com/jonschlinkert/word-wrap/pull/33#issuecomment-1511820080