### PR TITLE
Updated BaseMessage in preparation for external Store interface implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ For advanced users wishing to use this repo directly:
 npm install @tbd54566975/dwn-sdk-js
 ```
 
-Additional steps needed for some environments.
+## Additional Steps
 
-Node.js <= 18
+This package has dependency on [`@noble/ed25519`](https://github.com/paulmillr/noble-ed25519#usage) and [`@noble/secp256k1`](https://github.com/paulmillr/noble-secp256k1#usage) v2, additional steps are needed for some environments:
+
+- Node.js <= 18
 
 ```js
 // node.js 18 and earlier,  needs globalThis.crypto polyfill
@@ -34,7 +36,7 @@ import { webcrypto } from "node:crypto";
 if (!globalThis.crypto) globalThis.crypto = webcrypto;
 ```
 
-React Native:
+- React Native:
 
 ```js
 // If you're on react native. React Native needs crypto.getRandomValues polyfill and sha512

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/dwn-sdk-js",
-      "version": "0.0.36",
+      "version": "0.0.37",
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "description": "A reference implementation of https://identity.foundation/decentralized-web-node/spec/",
   "repository": {
     "type": "git",

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -1,7 +1,7 @@
-import type { BaseMessage } from '../types/message-types.js';
 import type { CID } from 'multiformats';
 import type { DidResolver } from '../did/did-resolver.js';
 import type { GeneralJws } from '../types/jws-types.js';
+import type { GenericMessage } from '../types/message-types.js';
 import type { Message } from './message.js';
 
 import { Cid } from '../utils/cid.js';
@@ -22,7 +22,7 @@ type AuthorizationPayloadConstraints = {
  */
 export async function canonicalAuth(
   tenant: string,
-  incomingMessage: Message<BaseMessage>,
+  incomingMessage: Message<GenericMessage>,
   didResolver: DidResolver
 ): Promise<void> {
   await authenticate(incomingMessage.message.authorization, didResolver);
@@ -36,7 +36,7 @@ export async function canonicalAuth(
  * @returns the parsed JSON payload object if validation succeeds.
  */
 export async function validateAuthorizationIntegrity(
-  message: BaseMessage,
+  message: GenericMessage,
   authorizationPayloadConstraints?: AuthorizationPayloadConstraints
 ): Promise<{ descriptorCid: CID, [key: string]: any }> {
   if (message.authorization === undefined) {
@@ -94,7 +94,7 @@ export async function authenticate(jws: GeneralJws | undefined, didResolver: Did
  * Authorizes the incoming message.
  * @throws {Error} if fails authentication
  */
-export async function authorize(tenant: string, incomingMessage: Message<BaseMessage>): Promise<void> {
+export async function authorize(tenant: string, incomingMessage: Message<GenericMessage>): Promise<void> {
   // if author is the same as the target tenant, we can directly grant access
   if (incomingMessage.author === tenant) {
     return;

--- a/src/core/message-reply.ts
+++ b/src/core/message-reply.ts
@@ -20,7 +20,7 @@ export function messageReplyFromError(e: unknown, code: number): BaseMessageRepl
 /**
  * Catch-all message reply type. It is recommended to use BaseMessageReply or a message-specific reply type whereever possible.
  */
-export type GenericMessageReply = BaseMessageReply & {
+export type UnionMessageReply = BaseMessageReply & {
   /**
    * Resulting message entries or events returned from the invocation of the corresponding message.
    * e.g. the resulting messages from a RecordsQuery

--- a/src/core/message-reply.ts
+++ b/src/core/message-reply.ts
@@ -6,11 +6,11 @@ type Status = {
   detail: string
 };
 
-export type BaseMessageReply = {
+export type GenericMessageReply = {
   status: Status;
 };
 
-export function messageReplyFromError(e: unknown, code: number): BaseMessageReply {
+export function messageReplyFromError(e: unknown, code: number): GenericMessageReply {
 
   const detail = e instanceof Error ? e.message : 'Error';
 
@@ -18,9 +18,9 @@ export function messageReplyFromError(e: unknown, code: number): BaseMessageRepl
 }
 
 /**
- * Catch-all message reply type. It is recommended to use BaseMessageReply or a message-specific reply type whereever possible.
+ * Catch-all message reply type. It is recommended to use GenericMessageReply or a message-specific reply type whereever possible.
  */
-export type UnionMessageReply = BaseMessageReply & {
+export type UnionMessageReply = GenericMessageReply & {
   /**
    * Resulting message entries or events returned from the invocation of the corresponding message.
    * e.g. the resulting messages from a RecordsQuery

--- a/src/dwn.ts
+++ b/src/dwn.ts
@@ -1,12 +1,12 @@
-import type { BaseMessage } from './types/message-types.js';
 import type { DataStore } from './types/data-store.js';
 import type { EventLog } from './types/event-log.js';
+import type { GenericMessage } from './types/message-types.js';
 import type { MessageStore } from './types/message-store.js';
 import type { MethodHandler } from './types/method-handler.js';
 import type { Readable } from 'readable-stream';
 import type { RecordsWriteHandlerOptions } from './handlers/records-write.js';
 import type { TenantGate } from './core/tenant-gate.js';
-import type { BaseMessageReply, UnionMessageReply } from './core/message-reply.js';
+import type { GenericMessageReply, UnionMessageReply } from './core/message-reply.js';
 import type { MessagesGetMessage, MessagesGetReply } from './types/messages-types.js';
 import type { RecordsQueryMessage, RecordsQueryReply, RecordsReadMessage, RecordsReadReply, RecordsWriteMessage } from './types/records-types.js';
 
@@ -103,7 +103,7 @@ export class Dwn {
     const handlerKey = rawMessage.descriptor.interface + rawMessage.descriptor.method;
     const methodHandlerReply = await this.methodHandlers[handlerKey].handle({
       tenant,
-      message: rawMessage as BaseMessage,
+      message: rawMessage as GenericMessage,
       dataStream
     });
 
@@ -158,7 +158,7 @@ export class Dwn {
   /**
    * Privileged method for writing a pruned initial `RecordsWrite` to a DWN without needing to supply associated data.
    */
-  public async synchronizePrunedInitialRecordsWrite(tenant: string, message: RecordsWriteMessage): Promise<BaseMessageReply> {
+  public async synchronizePrunedInitialRecordsWrite(tenant: string, message: RecordsWriteMessage): Promise<GenericMessageReply> {
     const errorMessageReply =
       await this.validateTenant(tenant) ??
       await this.validateMessageIntegrity(message, DwnInterfaceName.Records, DwnMethodName.Write);
@@ -178,9 +178,9 @@ export class Dwn {
   /**
    * Checks tenant gate to see if tenant is allowed.
    * @param tenant The tenant DID to route the given message to.
-   * @returns BaseMessageReply if the message has an integrity error, otherwise undefined.
+   * @returns GenericMessageReply if the message has an integrity error, otherwise undefined.
    */
-  public async validateTenant(tenant: string): Promise<BaseMessageReply | undefined> {
+  public async validateTenant(tenant: string): Promise<GenericMessageReply | undefined> {
     const isTenant = await this.tenantGate.isTenant(tenant);
     if (!isTenant) {
       return {
@@ -195,13 +195,13 @@ export class Dwn {
    * @param dwnMessageInterface The interface of DWN message.
    * @param dwnMessageMethod The interface of DWN message.
 
-   * @returns BaseMessageReply if the message has an integrity error, otherwise undefined.
+   * @returns GenericMessageReply if the message has an integrity error, otherwise undefined.
    */
   public async validateMessageIntegrity(
     rawMessage: any,
     expectedInterface?: DwnInterfaceName,
     expectedMethod?: DwnMethodName,
-  ): Promise<BaseMessageReply | undefined> {
+  ): Promise<GenericMessageReply | undefined> {
     // Verify interface and method
     const dwnInterface = rawMessage?.descriptor?.interface;
     const dwnMethod = rawMessage?.descriptor?.method;

--- a/src/dwn.ts
+++ b/src/dwn.ts
@@ -6,7 +6,7 @@ import type { MethodHandler } from './types/method-handler.js';
 import type { Readable } from 'readable-stream';
 import type { RecordsWriteHandlerOptions } from './handlers/records-write.js';
 import type { TenantGate } from './core/tenant-gate.js';
-import type { BaseMessageReply , GenericMessageReply } from './core/message-reply.js';
+import type { BaseMessageReply, UnionMessageReply } from './core/message-reply.js';
 import type { MessagesGetMessage, MessagesGetReply } from './types/messages-types.js';
 import type { RecordsQueryMessage, RecordsQueryReply, RecordsReadMessage, RecordsReadReply, RecordsWriteMessage } from './types/records-types.js';
 
@@ -94,7 +94,7 @@ export class Dwn {
    * Processes the given DWN message and returns with a reply.
    * @param tenant The tenant DID to route the given message to.
    */
-  public async processMessage(tenant: string, rawMessage: any, dataStream?: Readable): Promise<GenericMessageReply> {
+  public async processMessage(tenant: string, rawMessage: any, dataStream?: Readable): Promise<UnionMessageReply> {
     const errorMessageReply = await this.validateTenant(tenant) ?? await this.validateMessageIntegrity(rawMessage);
     if (errorMessageReply !== undefined) {
       return errorMessageReply;

--- a/src/handlers/messages-get.ts
+++ b/src/handlers/messages-get.ts
@@ -2,6 +2,7 @@ import type { DataStore } from '../types/data-store.js';
 import type { DidResolver } from '../did/did-resolver.js';
 import type { MessageStore } from '../types/message-store.js';
 import type { MethodHandler } from '../types/method-handler.js';
+import type { RecordsWriteMessage } from '../types/records-types.js';
 import type { MessagesGetMessage, MessagesGetReply, MessagesGetReplyEntry } from '../types/messages-types.js';
 
 import { DataStream } from '../utils/data-stream.js';
@@ -66,8 +67,10 @@ export class MessagesGetHandler implements MethodHandler {
         continue;
       }
 
-      const dataCid = message.descriptor.dataCid;
-      const dataSize = message.descriptor.dataSize;
+      // RecordsWrite specific handling
+      const recordsWrite = message as RecordsWriteMessage;
+      const dataCid = recordsWrite.descriptor.dataCid;
+      const dataSize = recordsWrite.descriptor.dataSize;
 
       if (dataCid !== undefined && dataSize! <= DwnConstant.maxDataSizeAllowedToBeEncoded) {
         const messageCid = await Message.getCid(message);

--- a/src/handlers/permissions-grant.ts
+++ b/src/handlers/permissions-grant.ts
@@ -1,4 +1,4 @@
-import type { BaseMessageReply } from '../core/message-reply.js';
+import type { GenericMessageReply } from '../core/message-reply.js';
 import type { MethodHandler } from '../types/method-handler.js';
 import type { PermissionsGrantMessage } from '../types/permissions-types.js';
 import type { DidResolver, EventLog, MessageStore } from '../index.js';
@@ -14,7 +14,7 @@ export class PermissionsGrantHandler implements MethodHandler {
   public async handle({
     tenant,
     message
-  }: { tenant: string, message: PermissionsGrantMessage }): Promise<BaseMessageReply> {
+  }: { tenant: string, message: PermissionsGrantMessage }): Promise<GenericMessageReply> {
     let permissionsGrant: PermissionsGrant;
     try {
       permissionsGrant = await PermissionsGrant.parse(message);

--- a/src/handlers/permissions-grant.ts
+++ b/src/handlers/permissions-grant.ts
@@ -29,7 +29,7 @@ export class PermissionsGrantHandler implements MethodHandler {
       return messageReplyFromError(e, 401);
     }
 
-    const { dataSize, scope, conditions, ...propertiesToIndex } = message.descriptor;
+    const { scope, conditions, ...propertiesToIndex } = message.descriptor;
     const indexes: { [key: string]: string } = {
       author: permissionsGrant.author!,
       ...propertiesToIndex,

--- a/src/handlers/permissions-request.ts
+++ b/src/handlers/permissions-request.ts
@@ -1,4 +1,4 @@
-import type { BaseMessageReply } from '../core/message-reply.js';
+import type { GenericMessageReply } from '../core/message-reply.js';
 import type { MethodHandler } from '../types/method-handler.js';
 import type { PermissionsRequestMessage } from '../types/permissions-types.js';
 import type { DidResolver, EventLog, MessageStore } from '../index.js';
@@ -15,7 +15,7 @@ export class PermissionsRequestHandler implements MethodHandler {
   public async handle({
     tenant,
     message
-  }: { tenant: string, message: PermissionsRequestMessage }): Promise<BaseMessageReply> {
+  }: { tenant: string, message: PermissionsRequestMessage }): Promise<GenericMessageReply> {
     let permissionsRequest: PermissionsRequest;
     try {
       permissionsRequest = await PermissionsRequest.parse(message);

--- a/src/handlers/permissions-request.ts
+++ b/src/handlers/permissions-request.ts
@@ -31,7 +31,7 @@ export class PermissionsRequestHandler implements MethodHandler {
     }
 
     // store message
-    const { dataSize, scope, conditions, ...propertiesToIndex } = message.descriptor;
+    const { scope, conditions, ...propertiesToIndex } = message.descriptor;
     const indexes: { [key: string]: string } = {
       ...propertiesToIndex,
       author: permissionsRequest.author!,

--- a/src/handlers/protocols-configure.ts
+++ b/src/handlers/protocols-configure.ts
@@ -1,5 +1,5 @@
-import type { BaseMessageReply } from '../core/message-reply.js';
 import type { EventLog } from '../types/event-log.js';
+import type { GenericMessageReply } from '../core/message-reply.js';
 import type { MethodHandler } from '../types/method-handler.js';
 import type { ProtocolsConfigureMessage } from '../types/protocols-types.js';
 import type { DataStore, DidResolver, MessageStore } from '../index.js';
@@ -18,7 +18,7 @@ export class ProtocolsConfigureHandler implements MethodHandler {
     tenant,
     message,
     dataStream: _dataStream
-  }: {tenant: string, message: ProtocolsConfigureMessage, dataStream: _Readable.Readable}): Promise<BaseMessageReply> {
+  }: {tenant: string, message: ProtocolsConfigureMessage, dataStream: _Readable.Readable}): Promise<GenericMessageReply> {
 
     let protocolsConfigure: ProtocolsConfigure;
     try {
@@ -51,7 +51,7 @@ export class ProtocolsConfigureHandler implements MethodHandler {
     }
 
     // write the incoming message to DB if incoming message is newest
-    let messageReply: BaseMessageReply;
+    let messageReply: GenericMessageReply;
     if (incomingMessageIsNewest) {
       const indexes = ProtocolsConfigureHandler.constructProtocolsConfigureIndexes(protocolsConfigure);
 

--- a/src/handlers/protocols-configure.ts
+++ b/src/handlers/protocols-configure.ts
@@ -7,7 +7,6 @@ import type { DataStore, DidResolver, MessageStore } from '../index.js';
 import { canonicalAuth } from '../core/auth.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { ProtocolsConfigure } from '../interfaces/protocols-configure.js';
-import { StorageController } from '../store/storage-controller.js';
 
 import { DwnInterfaceName, DwnMethodName, Message } from '../core/message.js';
 
@@ -76,7 +75,7 @@ export class ProtocolsConfigureHandler implements MethodHandler {
         const messageCid = await Message.getCid(message);
         deletedMessageCids.push(messageCid);
 
-        await StorageController.delete(this.messageStore, this.dataStore, tenant, message);
+        await this.messageStore.delete(tenant, messageCid);
       }
     }
 
@@ -86,14 +85,13 @@ export class ProtocolsConfigureHandler implements MethodHandler {
   };
 
   private static constructProtocolsConfigureIndexes(protocolsConfigure: ProtocolsConfigure): Record<string, string> {
-    // strip out `dataSize` and `definition` as they are not indexable
-    // retain protocol url from `definition`
-    const { dataSize, definition, ...propertiesToIndex } = protocolsConfigure.message.descriptor;
+    // strip out `definition` as it is not indexable
+    const { definition, ...propertiesToIndex } = protocolsConfigure.message.descriptor;
     const { author } = protocolsConfigure;
 
     const indexes = {
       ...propertiesToIndex,
-      protocol : definition.protocol,
+      protocol : definition.protocol, // retain protocol url from `definition`
       author   : author!
     };
 

--- a/src/handlers/records-delete.ts
+++ b/src/handlers/records-delete.ts
@@ -1,5 +1,5 @@
-import type { BaseMessageReply } from '../core/message-reply.js';
 import type { EventLog } from '../types/event-log.js';
+import type { GenericMessageReply } from '../core/message-reply.js';
 import type { MethodHandler } from '../types/method-handler.js';
 import type { RecordsDeleteMessage } from '../types/records-types.js';
 import type { TimestampedMessage } from '../types/message-types.js';
@@ -19,7 +19,7 @@ export class RecordsDeleteHandler implements MethodHandler {
   public async handle({
     tenant,
     message
-  }: { tenant: string, message: RecordsDeleteMessage}): Promise<BaseMessageReply> {
+  }: { tenant: string, message: RecordsDeleteMessage}): Promise<GenericMessageReply> {
 
     let recordsDelete: RecordsDelete;
     try {

--- a/src/handlers/records-write.ts
+++ b/src/handlers/records-write.ts
@@ -1,16 +1,15 @@
 import type { BaseMessageReply } from '../core/message-reply.js';
 import type { EventLog } from '../types/event-log.js';
 import type { MethodHandler } from '../types/method-handler.js';
-import type { RecordsWriteMessage } from '../types/records-types.js';
-import type { TimestampedMessage } from '../types/message-types.js';
 import type { DataStore, DidResolver, MessageStore } from '../index.js';
+import type { RecordsDeleteMessage, RecordsWriteMessage } from '../types/records-types.js';
 
 import { authenticate } from '../core/auth.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { RecordsWrite } from '../interfaces/records-write.js';
 import { StorageController } from '../store/storage-controller.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
-import { DwnInterfaceName, Message } from '../core/message.js';
+import { DwnInterfaceName, DwnMethodName, Message } from '../core/message.js';
 
 export type RecordsWriteHandlerOptions = {
   skipDataStorage?: boolean; // used for DWN sync
@@ -48,7 +47,7 @@ export class RecordsWriteHandler implements MethodHandler {
       interface : DwnInterfaceName.Records,
       recordId  : message.recordId
     };
-    const existingMessages = await this.messageStore.query(tenant, query) as TimestampedMessage[];
+    const existingMessages = await this.messageStore.query(tenant, query) as (RecordsWriteMessage|RecordsDeleteMessage)[];
 
     // if the incoming write is not the initial write, then it must not modify any immutable properties defined by the initial write
     const newMessageIsInitialWrite = await recordsWrite.isInitialWrite();
@@ -84,7 +83,7 @@ export class RecordsWriteHandler implements MethodHandler {
     try {
       // try to store data, unless options explicitly say to skip storage
       if (options === undefined || !options.skipDataStorage) {
-        await this.putData(tenant, message, dataStream, newestExistingMessage);
+        await this.putData(tenant, message, dataStream, newestExistingMessage as (RecordsWriteMessage|RecordsDeleteMessage) | undefined);
       }
     } catch (error) {
       const e = error as any;
@@ -130,14 +129,15 @@ export class RecordsWriteHandler implements MethodHandler {
     tenant: string,
     message: RecordsWriteMessage,
     dataStream?: _Readable.Readable,
-    newestExistingMessage?: TimestampedMessage
+    newestExistingMessage?: RecordsWriteMessage | RecordsDeleteMessage
   ): Promise<void> {
     let result: { dataCid: string, dataSize: number };
     const messageCid = await Message.getCid(message);
 
     if (dataStream === undefined) {
       // dataStream must be included if message contains a new dataCid
-      if (newestExistingMessage?.descriptor.dataCid !== message.descriptor.dataCid) {
+      if (newestExistingMessage?.descriptor.method === DwnMethodName.Delete ||
+          newestExistingMessage?.descriptor.dataCid !== message.descriptor.dataCid) {
         throw new DwnError(
           DwnErrorCode.RecordsWriteMissingDataStream,
           'Data stream is not provided.'

--- a/src/handlers/records-write.ts
+++ b/src/handlers/records-write.ts
@@ -1,5 +1,5 @@
-import type { BaseMessageReply } from '../core/message-reply.js';
 import type { EventLog } from '../types/event-log.js';
+import type { GenericMessageReply } from '../core/message-reply.js';
 import type { MethodHandler } from '../types/method-handler.js';
 import type { DataStore, DidResolver, MessageStore } from '../index.js';
 import type { RecordsDeleteMessage, RecordsWriteMessage } from '../types/records-types.js';
@@ -26,7 +26,7 @@ export class RecordsWriteHandler implements MethodHandler {
     message,
     options,
     dataStream
-  }: HandlerArgs): Promise<BaseMessageReply> {
+  }: HandlerArgs): Promise<GenericMessageReply> {
     let recordsWrite: RecordsWrite;
     try {
       recordsWrite = await RecordsWrite.parse(message);

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export { Jws } from './utils/jws.js';
 export { KeyMaterial, PrivateJwk, PublicJwk } from './types/jose-types.js';
 export { Message } from './core/message.js';
 export { MessagesGet, MessagesGetOptions } from './interfaces/messages-get.js';
-export { GenericMessageReply as MessageReply } from './core/message-reply.js';
+export { UnionMessageReply as MessageReply } from './core/message-reply.js';
 export { MessageStore, MessageStoreOptions } from './types/message-store.js';
 export { MessageStoreLevel } from './store/message-store-level.js';
 export { ProtocolsConfigure, ProtocolsConfigureOptions } from './interfaces/protocols-configure.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export type { DwnServiceEndpoint, ServiceEndpoint, DidDocument, DidResolutionRes
 export type { EventLog, Event } from './types/event-log.js';
 export type { EventsGetMessage, EventsGetReply } from './types/event-types.js';
 export type { HooksWriteMessage } from './types/hooks-types.js';
-export type { BaseMessage } from './types/message-types.js';
+export type { GenericMessage } from './types/message-types.js';
 export type { MessagesGetMessage, MessagesGetReply } from './types/messages-types.js';
 export type { ProtocolsConfigureDescriptor, ProtocolDefinition, ProtocolRuleSet, ProtocolsQueryFilter, ProtocolsConfigureMessage, ProtocolsQueryMessage } from './types/protocols-types.js';
 export type { EncryptionProperty, RecordsDeleteMessage, RecordsQueryMessage, RecordsQueryReply, RecordsQueryReplyEntry, RecordsReadReply, RecordsWriteDescriptor, RecordsWriteMessage } from './types/records-types.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export { Jws } from './utils/jws.js';
 export { KeyMaterial, PrivateJwk, PublicJwk } from './types/jose-types.js';
 export { Message } from './core/message.js';
 export { MessagesGet, MessagesGetOptions } from './interfaces/messages-get.js';
-export { UnionMessageReply as MessageReply } from './core/message-reply.js';
+export { UnionMessageReply } from './core/message-reply.js';
 export { MessageStore, MessageStoreOptions } from './types/message-store.js';
 export { MessageStoreLevel } from './store/message-store-level.js';
 export { ProtocolsConfigure, ProtocolsConfigureOptions } from './interfaces/protocols-configure.js';

--- a/src/interfaces/records-read.ts
+++ b/src/interfaces/records-read.ts
@@ -1,4 +1,4 @@
-import type { BaseMessage } from '../types/message-types.js';
+import type { GenericMessage } from '../types/message-types.js';
 import type { MessageStore } from '../types/message-store.js';
 import type { RecordsWrite } from './records-write.js';
 import type { SignatureInput } from '../types/jws-types.js';
@@ -20,7 +20,7 @@ export class RecordsRead extends Message<RecordsReadMessage> {
 
   public static async parse(message: RecordsReadMessage): Promise<RecordsRead> {
     if (message.authorization !== undefined) {
-      await validateAuthorizationIntegrity(message as BaseMessage);
+      await validateAuthorizationIntegrity(message as GenericMessage);
     }
 
     const recordsRead = new RecordsRead(message);

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -1,4 +1,4 @@
-import type { BaseMessage } from '../types/message-types.js';
+import type { GenericMessage } from '../types/message-types.js';
 import type { KeyDerivationScheme } from '../index.js';
 import type { MessageStore } from '../types/message-store.js';
 import type { PublicJwk } from '../types/jose-types.js';
@@ -453,7 +453,7 @@ export class RecordsWrite extends Message<RecordsWriteMessage> {
   /**
    * Checks if the given message is the initial entry of a record.
    */
-  public static async isInitialWrite(message: BaseMessage): Promise<boolean> {
+  public static async isInitialWrite(message: GenericMessage): Promise<boolean> {
     // can't be the initial write if the message is not a Records Write
     if (message.descriptor.interface !== DwnInterfaceName.Records ||
         message.descriptor.method !== DwnMethodName.Write) {
@@ -563,7 +563,7 @@ export class RecordsWrite extends Message<RecordsWriteMessage> {
   /**
    * Gets the initial write from the given list or record write.
    */
-  public static async getInitialWrite(messages: BaseMessage[]): Promise<RecordsWriteMessage>{
+  public static async getInitialWrite(messages: GenericMessage[]): Promise<RecordsWriteMessage>{
     for (const message of messages) {
       if (await RecordsWrite.isInitialWrite(message)) {
         return message as RecordsWriteMessage;

--- a/src/store/message-store-level.ts
+++ b/src/store/message-store-level.ts
@@ -1,4 +1,4 @@
-import type { BaseMessage, Filter } from '../types/message-types.js';
+import type { Filter, GenericMessage } from '../types/message-types.js';
 import type { MessageStore, MessageStoreOptions } from '../types/message-store.js';
 
 import * as block from 'multiformats/block';
@@ -58,7 +58,7 @@ export class MessageStoreLevel implements MessageStore {
     await this.index.close();
   }
 
-  async get(tenant: string, cidString: string, options?: MessageStoreOptions): Promise<BaseMessage | undefined> {
+  async get(tenant: string, cidString: string, options?: MessageStoreOptions): Promise<GenericMessage | undefined> {
     options?.signal?.throwIfAborted();
 
     const partition = await executeUnlessAborted(this.blockstore.partition(tenant), options?.signal);
@@ -72,14 +72,14 @@ export class MessageStoreLevel implements MessageStore {
 
     const decodedBlock = await executeUnlessAborted(block.decode({ bytes, codec: cbor, hasher: sha256 }), options?.signal);
 
-    const messageJson = decodedBlock.value as BaseMessage;
-    return messageJson;
+    const message = decodedBlock.value as GenericMessage;
+    return message;
   }
 
-  async query(tenant: string, filter: Filter, options?: MessageStoreOptions): Promise<BaseMessage[]> {
+  async query(tenant: string, filter: Filter, options?: MessageStoreOptions): Promise<GenericMessage[]> {
     options?.signal?.throwIfAborted();
 
-    const messages: BaseMessage[] = [];
+    const messages: GenericMessage[] = [];
 
     const resultIds = await this.index.query({ ...filter, tenant }, options);
 
@@ -103,7 +103,7 @@ export class MessageStoreLevel implements MessageStore {
 
   async put(
     tenant: string,
-    message: BaseMessage,
+    message: GenericMessage,
     indexes: Record<string, string>,
     options?: MessageStoreOptions
   ): Promise<void> {

--- a/src/store/storage-controller.ts
+++ b/src/store/storage-controller.ts
@@ -2,7 +2,7 @@ import type { DataStore } from '../types/data-store.js';
 import type { EventLog } from '../types/event-log.js';
 import type { MessageStore } from '../types/message-store.js';
 import type { RecordsWriteMessage } from '../types/records-types.js';
-import type { BaseMessage, Filter, TimestampedMessage } from '../types/message-types.js';
+import type { Filter, GenericMessage, TimestampedMessage } from '../types/message-types.js';
 
 import { constructRecordsWriteIndexes } from '../handlers/records-write.js';
 import { DataStream } from '../utils/data-stream.js';
@@ -49,7 +49,7 @@ export class StorageController {
     messageStore: MessageStore,
     dataStore: DataStore,
     tenant: string,
-    message: BaseMessage
+    message: GenericMessage
   ): Promise<void> {
     const messageCid = await Message.getCid(message);
 

--- a/src/store/storage-controller.ts
+++ b/src/store/storage-controller.ts
@@ -43,9 +43,9 @@ export class StorageController {
   }
 
   /**
-   * Deletes a Record message.
+   * Deletes a message.
    */
-  public static async deleteRecordMessage(
+  public static async delete(
     messageStore: MessageStore,
     dataStore: DataStore,
     tenant: string,
@@ -84,7 +84,7 @@ export class StorageController {
       // the easiest implementation here is delete each old messages
       // and re-create it with the right index (isLatestBaseState = 'false') if the message is the initial write,
       // but there is room for better/more efficient implementation here
-        await StorageController.deleteRecordMessage(messageStore, dataStore, tenant, message);
+        await StorageController.delete(messageStore, dataStore, tenant, message);
 
         // if the existing message is the initial write
         // we actually need to keep it BUT, need to ensure the message is no longer marked as the latest state

--- a/src/store/storage-controller.ts
+++ b/src/store/storage-controller.ts
@@ -45,7 +45,7 @@ export class StorageController {
   /**
    * Deletes a message.
    */
-  public static async delete(
+  private static async delete(
     messageStore: MessageStore,
     dataStore: DataStore,
     tenant: string,

--- a/src/types/event-types.ts
+++ b/src/types/event-types.ts
@@ -1,6 +1,6 @@
-import type { BaseMessage } from './message-types.js';
-import type { BaseMessageReply } from '../core/message-reply.js';
 import type { Event } from './event-log.js';
+import type { GenericMessage } from './message-types.js';
+import type { GenericMessageReply } from '../core/message-reply.js';
 import type { DwnInterfaceName, DwnMethodName } from '../core/message.js';
 
 export type EventsGetDescriptor = {
@@ -9,10 +9,10 @@ export type EventsGetDescriptor = {
   watermark?: string;
 };
 
-export type EventsGetMessage = BaseMessage & {
+export type EventsGetMessage = GenericMessage & {
   descriptor: EventsGetDescriptor;
 };
 
-export type EventsGetReply = BaseMessageReply & {
+export type EventsGetReply = GenericMessageReply & {
   events?: Event[];
 };

--- a/src/types/hooks-types.ts
+++ b/src/types/hooks-types.ts
@@ -1,4 +1,4 @@
-import type { BaseMessage } from './message-types.js';
+import type { GenericMessage } from './message-types.js';
 import type { DwnInterfaceName, DwnMethodName } from '../core/message.js';
 
 /**
@@ -26,6 +26,6 @@ export type HooksWriteDescriptor = {
 /**
  * Structure for HooksWrite message.
  */
-export type HooksWriteMessage = BaseMessage & {
+export type HooksWriteMessage = GenericMessage & {
   descriptor: HooksWriteDescriptor;
 };

--- a/src/types/message-store.ts
+++ b/src/types/message-store.ts
@@ -1,4 +1,4 @@
-import type { BaseMessage, Filter } from './message-types.js';
+import type { Filter, GenericMessage } from './message-types.js';
 
 export interface MessageStoreOptions {
   signal?: AbortSignal;
@@ -21,7 +21,7 @@ export interface MessageStore {
    */
   put(
     tenant: string,
-    messageJson: BaseMessage,
+    message: GenericMessage,
     indexes: { [key: string]: string },
     options?: MessageStoreOptions
   ): Promise<void>;
@@ -30,12 +30,12 @@ export interface MessageStore {
    * Fetches a single message by `cid` from the underlying store.
    * Returns `undefined` no message was found.
    */
-  get(tenant: string, cid: string, options?: MessageStoreOptions): Promise<BaseMessage | undefined>;
+  get(tenant: string, cid: string, options?: MessageStoreOptions): Promise<GenericMessage | undefined>;
 
   /**
    * Queries the underlying store for messages that match the provided filter.
    */
-  query(tenant: string, filter: Filter, options?: MessageStoreOptions ): Promise<BaseMessage[]>;
+  query(tenant: string, filter: Filter, options?: MessageStoreOptions ): Promise<GenericMessage[]>;
 
   /**
    * Deletes the message associated with the id provided.

--- a/src/types/message-store.ts
+++ b/src/types/message-store.ts
@@ -22,7 +22,7 @@ export interface MessageStore {
   put(
     tenant: string,
     messageJson: BaseMessage,
-    indexes: Record<string, string>,
+    indexes: { [key: string]: string },
     options?: MessageStoreOptions
   ): Promise<void>;
 

--- a/src/types/message-types.ts
+++ b/src/types/message-types.ts
@@ -21,8 +21,6 @@ export type BaseDecodedAuthorizationPayload = {
 export type Descriptor = {
   interface: string;
   method: string;
-  dataCid?: string;
-  dataSize?: number;
 };
 
 /**

--- a/src/types/message-types.ts
+++ b/src/types/message-types.ts
@@ -3,7 +3,7 @@ import type { GeneralJws } from './jws-types.js';
 /**
  * Intersection type for all concrete message types.
  */
-export type BaseMessage = {
+export type GenericMessage = {
   descriptor: Descriptor
   authorization?: GeneralJws;
 };
@@ -26,7 +26,7 @@ export type Descriptor = {
 /**
  * Messages that have `dateModified` in their `descriptor` property.
  */
-export type TimestampedMessage = BaseMessage & {
+export type TimestampedMessage = GenericMessage & {
   descriptor: {
     dateModified: string;
   }

--- a/src/types/messages-types.ts
+++ b/src/types/messages-types.ts
@@ -1,5 +1,5 @@
-import type { BaseMessage } from './message-types.js';
-import type { BaseMessageReply } from '../core/message-reply.js';
+import type { GenericMessage } from './message-types.js';
+import type { GenericMessageReply } from '../core/message-reply.js';
 import type { DwnInterfaceName, DwnMethodName } from '../core/message.js';
 
 export type MessagesGetDescriptor = {
@@ -8,17 +8,17 @@ export type MessagesGetDescriptor = {
   messageCids: string[];
 };
 
-export type MessagesGetMessage = BaseMessage & {
+export type MessagesGetMessage = GenericMessage & {
   descriptor: MessagesGetDescriptor;
 };
 
 export type MessagesGetReplyEntry = {
   messageCid: string;
-  message?: BaseMessage;
+  message?: GenericMessage;
   encodedData?: string;
   error?: string;
 };
 
-export type MessagesGetReply = BaseMessageReply & {
+export type MessagesGetReply = GenericMessageReply & {
   messages?: MessagesGetReplyEntry[];
 };

--- a/src/types/method-handler.ts
+++ b/src/types/method-handler.ts
@@ -1,5 +1,5 @@
 import type { BaseMessage } from './message-types.js';
-import type { GenericMessageReply } from '../core/message-reply.js';
+import type { BaseMessageReply } from '../core/message-reply.js';
 import type { Readable } from 'readable-stream';
 
 /**
@@ -13,5 +13,5 @@ export interface MethodHandler {
     tenant: string;
     message: BaseMessage;
     dataStream?: Readable
-  }): Promise<GenericMessageReply>;
+  }): Promise<BaseMessageReply>;
 }

--- a/src/types/method-handler.ts
+++ b/src/types/method-handler.ts
@@ -1,5 +1,5 @@
-import type { BaseMessage } from './message-types.js';
-import type { BaseMessageReply } from '../core/message-reply.js';
+import type { GenericMessage } from './message-types.js';
+import type { GenericMessageReply } from '../core/message-reply.js';
 import type { Readable } from 'readable-stream';
 
 /**
@@ -11,7 +11,7 @@ export interface MethodHandler {
    */
   handle(input: {
     tenant: string;
-    message: BaseMessage;
+    message: GenericMessage;
     dataStream?: Readable
-  }): Promise<BaseMessageReply>;
+  }): Promise<GenericMessageReply>;
 }

--- a/src/types/permissions-types.ts
+++ b/src/types/permissions-types.ts
@@ -1,4 +1,4 @@
-import type { BaseMessage } from './message-types.js';
+import type { GenericMessage } from './message-types.js';
 import type { DwnInterfaceName, DwnMethodName } from '../index.js';
 
 export type PermissionScope = {
@@ -29,7 +29,7 @@ export type PermissionsRequestDescriptor = {
   conditions?: PermissionConditions;
 };
 
-export type PermissionsRequestMessage = BaseMessage & {
+export type PermissionsRequestMessage = GenericMessage & {
   descriptor: PermissionsRequestDescriptor;
 };
 
@@ -53,6 +53,6 @@ export type PermissionsGrantDescriptor = {
   conditions?: PermissionConditions
 };
 
-export type PermissionsGrantMessage = BaseMessage & {
+export type PermissionsGrantMessage = GenericMessage & {
   descriptor: PermissionsGrantDescriptor;
 };

--- a/src/types/protocols-types.ts
+++ b/src/types/protocols-types.ts
@@ -1,6 +1,6 @@
-import type { BaseMessageReply } from '../core/message-reply.js';
-import type { BaseMessage, QueryResultEntry } from './message-types.js';
+import type { GenericMessageReply } from '../core/message-reply.js';
 import type { DwnInterfaceName, DwnMethodName } from '../core/message.js';
+import type { GenericMessage, QueryResultEntry } from './message-types.js';
 
 export type ProtocolsConfigureDescriptor = {
   interface : DwnInterfaceName.Protocols;
@@ -49,7 +49,7 @@ export type ProtocolRuleSet = {
   [key: string]: any;
 };
 
-export type ProtocolsConfigureMessage = BaseMessage & {
+export type ProtocolsConfigureMessage = GenericMessage & {
   descriptor: ProtocolsConfigureDescriptor;
 };
 
@@ -64,10 +64,10 @@ export type ProtocolsQueryDescriptor = {
   filter?: ProtocolsQueryFilter
 };
 
-export type ProtocolsQueryMessage = BaseMessage & {
+export type ProtocolsQueryMessage = GenericMessage & {
   descriptor: ProtocolsQueryDescriptor;
 };
 
-export type ProtocolsQueryReply = BaseMessageReply & {
+export type ProtocolsQueryReply = GenericMessageReply & {
   entries?: QueryResultEntry[];
 };

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -1,8 +1,8 @@
-import type { BaseMessage } from './message-types.js';
-import type { BaseMessageReply } from '../core/message-reply.js';
 import type { DateSort } from '../interfaces/records-query.js';
 import type { EncryptionAlgorithm } from '../utils/encryption.js';
 import type { GeneralJws } from './jws-types.js';
+import type { GenericMessage } from './message-types.js';
+import type { GenericMessageReply } from '../core/message-reply.js';
 import type { KeyDerivationScheme } from '../utils/hd-key.js';
 import type { PublicJwk } from './jose-types.js';
 import type { Readable } from 'readable-stream';
@@ -25,7 +25,7 @@ export type RecordsWriteDescriptor = {
   dataFormat: string;
 };
 
-export type RecordsWriteMessage = BaseMessage & {
+export type RecordsWriteMessage = GenericMessage & {
   recordId: string,
   contextId?: string;
   descriptor: RecordsWriteDescriptor;
@@ -114,11 +114,11 @@ export type RecordsWriteAuthorizationPayload = {
   encryptionCid?: string;
 };
 
-export type RecordsQueryMessage = BaseMessage & {
+export type RecordsQueryMessage = GenericMessage & {
   descriptor: RecordsQueryDescriptor;
 };
 
-export type RecordsQueryReply = BaseMessageReply & {
+export type RecordsQueryReply = GenericMessageReply & {
   entries?: RecordsQueryReplyEntry[];
 };
 
@@ -127,7 +127,7 @@ export type RecordsReadMessage = {
   descriptor: RecordsReadDescriptor;
 };
 
-export type RecordsReadReply = BaseMessageReply & {
+export type RecordsReadReply = GenericMessageReply & {
   record?: {
     recordId: string,
     contextId?: string;
@@ -146,7 +146,7 @@ export type RecordsReadDescriptor = {
   date: string;
 };
 
-export type RecordsDeleteMessage = BaseMessage & {
+export type RecordsDeleteMessage = GenericMessage & {
   descriptor: RecordsDeleteDescriptor;
 };
 

--- a/src/types/snapshots-types.ts
+++ b/src/types/snapshots-types.ts
@@ -1,4 +1,4 @@
-import type { BaseMessage } from './message-types.js';
+import type { GenericMessage } from './message-types.js';
 import type { DwnInterfaceName, DwnMethodName } from '../core/message.js';
 
 export type SnapshotsCreateDescriptor = {
@@ -30,6 +30,6 @@ export type SnapshotProtocolScope = {
   protocolPath: string
 };
 
-export type SnapshotsCreateMessage = BaseMessage & {
+export type SnapshotsCreateMessage = GenericMessage & {
   descriptor: SnapshotsCreateDescriptor;
 };

--- a/tests/core/message-reply.spec.ts
+++ b/tests/core/message-reply.spec.ts
@@ -1,11 +1,11 @@
-import type { BaseMessageReply } from '../../src/core/message-reply.js';
+import type { GenericMessageReply } from '../../src/core/message-reply.js';
 
 import { expect } from 'chai';
 import { messageReplyFromError } from '../../src/core/message-reply.js';
 
 describe('Message Reply', () => {
   it('handles non-Errors being thrown', () => {
-    let response: BaseMessageReply;
+    let response: GenericMessageReply;
     try {
       throw 'Some error message';
     } catch (e: unknown) {


### PR DESCRIPTION
1. Removed Record specific properties from `BaseMessage`
1. Renamed `BaseMessage` to `GenericMessage` - Makes more sense from the perspective of the store implementor, as they don't care about inheritance/extension
1. Opportunistic rename of `Reply" types

