### PR TITLE
Standardize message timestamp naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.31%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.26%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.68%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.31%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.31%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.01%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.68%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.31%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/json-schemas/events/events-get.json
+++ b/json-schemas/events/events-get.json
@@ -16,7 +16,8 @@
       "additionalProperties": false,
       "required": [
         "interface",
-        "method"
+        "method",
+        "messageTimestamp"
       ],
       "properties": {
         "interface": {
@@ -29,6 +30,9 @@
           "enum": [
             "Get"
           ],
+          "type": "string"
+        },
+        "messageTimestamp": {
           "type": "string"
         },
         "watermark": {

--- a/json-schemas/hooks/hooks-write.json
+++ b/json-schemas/hooks/hooks-write.json
@@ -17,7 +17,7 @@
       "required": [
         "interface",
         "method",
-        "dateCreated",
+        "messageTimestamp",
         "uri",
         "filter"
       ],
@@ -34,7 +34,7 @@
           ],
           "type": "string"
         },
-        "dateCreated": {
+        "messageTimestamp": {
           "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
         },
         "schema": {

--- a/json-schemas/interface-methods/messages-get.json
+++ b/json-schemas/interface-methods/messages-get.json
@@ -16,7 +16,8 @@
       "additionalProperties": false,
       "required": [
         "interface",
-        "method"
+        "method",
+        "messageTimestamp"
       ],
       "properties": {
         "interface": {
@@ -29,6 +30,9 @@
           "enum": [
             "Get"
           ],
+          "type": "string"
+        },
+        "messageTimestamp": {
           "type": "string"
         },
         "messageCids": {

--- a/json-schemas/interface-methods/permissions-grant.json
+++ b/json-schemas/interface-methods/permissions-grant.json
@@ -21,10 +21,10 @@
       "required": [
         "interface",
         "method",
-        "dateCreated"
+        "messageTimestamp"
       ],
       "properties": {
-        "dateCreated": {
+        "messageTimestamp": {
           "type": "string"
         },
         "description": {

--- a/json-schemas/interface-methods/permissions-request.json
+++ b/json-schemas/interface-methods/permissions-request.json
@@ -17,7 +17,7 @@
       "required": [
         "interface",
         "method",
-        "dateCreated",
+        "messageTimestamp",
         "grantedBy",
         "grantedTo",
         "grantedFor",
@@ -36,7 +36,7 @@
           ],
           "type": "string"
         },
-        "dateCreated": {
+        "messageTimestamp": {
           "type": "string"
         },
         "description": {

--- a/json-schemas/interface-methods/protocols-configure.json
+++ b/json-schemas/interface-methods/protocols-configure.json
@@ -17,7 +17,7 @@
       "required": [
         "interface",
         "method",
-        "dateModified",
+        "messageTimestamp",
         "definition"
       ],
       "properties": {
@@ -33,7 +33,7 @@
           ],
           "type": "string"
         },
-        "dateModified": {
+        "messageTimestamp": {
           "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
         },
         "definition": {

--- a/json-schemas/interface-methods/protocols-query.json
+++ b/json-schemas/interface-methods/protocols-query.json
@@ -17,7 +17,7 @@
       "required": [
         "interface",
         "method",
-        "dateCreated"
+        "messageTimestamp"
       ],
       "properties": {
         "interface": {
@@ -32,7 +32,7 @@
           ],
           "type": "string"
         },
-        "dateCreated": {
+        "messageTimestamp": {
           "type": "string"
         },
         "filter": {

--- a/json-schemas/interface-methods/records-delete.json
+++ b/json-schemas/interface-methods/records-delete.json
@@ -17,7 +17,7 @@
       "required": [
         "interface",
         "method",
-        "dateModified",
+        "messageTimestamp",
         "recordId"
       ],
       "properties": {
@@ -33,7 +33,7 @@
           ],
           "type": "string"
         },
-        "dateModified": {
+        "messageTimestamp": {
           "type": "string"
         },
         "recordId": {

--- a/json-schemas/interface-methods/records-query.json
+++ b/json-schemas/interface-methods/records-query.json
@@ -16,7 +16,7 @@
       "required": [
         "interface",
         "method",
-        "dateCreated",
+        "messageTimestamp",
         "filter"
       ],
       "properties": {
@@ -32,7 +32,7 @@
           ],
           "type": "string"
         },
-        "dateCreated": {
+        "messageTimestamp": {
           "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
         },
         "filter": {

--- a/json-schemas/interface-methods/records-read.json
+++ b/json-schemas/interface-methods/records-read.json
@@ -16,7 +16,7 @@
       "required": [
         "interface",
         "method",
-        "date",
+        "messageTimestamp",
         "recordId"
       ],
       "properties": {
@@ -32,7 +32,7 @@
           ],
           "type": "string"
         },
-        "date": {
+        "messageTimestamp": {
           "type": "string"
         },
         "recordId": {

--- a/json-schemas/interface-methods/records-write.json
+++ b/json-schemas/interface-methods/records-write.json
@@ -129,7 +129,7 @@
         "dateCreated": {
           "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
         },
-        "dateModified": {
+        "messageTimestamp": {
           "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
         },
         "published": {
@@ -149,7 +149,7 @@
         "dataCid",
         "dataSize",
         "dateCreated",
-        "dateModified",
+        "messageTimestamp",
         "dataFormat"
       ],
       "allOf": [

--- a/json-schemas/interface-methods/snapshots-create.json
+++ b/json-schemas/interface-methods/snapshots-create.json
@@ -17,7 +17,7 @@
       "required": [
         "interface",
         "method",
-        "dateCreated",
+        "messageTimestamp",
         "definitionCid"
       ],
       "properties": {
@@ -33,7 +33,7 @@
           ],
           "type": "string"
         },
-        "dateCreated": {
+        "messageTimestamp": {
           "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
         },
         "definitionCid": {

--- a/src/core/message.ts
+++ b/src/core/message.ts
@@ -164,7 +164,7 @@ export abstract class Message<M extends GenericMessage> {
    * @returns `true` if `a` is newer than `b`; `false` otherwise
    */
   public static async isNewer(a: TimestampedMessage, b: TimestampedMessage): Promise<boolean> {
-    const aIsNewer = (await Message.compareModifiedTime(a, b) > 0);
+    const aIsNewer = (await Message.compareMessageTimestamp(a, b) > 0);
     return aIsNewer;
   }
 
@@ -173,22 +173,22 @@ export abstract class Message<M extends GenericMessage> {
    * @returns `true` if `a` is older than `b`; `false` otherwise
    */
   public static async isOlder(a: TimestampedMessage, b: TimestampedMessage): Promise<boolean> {
-    const aIsNewer = (await Message.compareModifiedTime(a, b) < 0);
+    const aIsNewer = (await Message.compareMessageTimestamp(a, b) < 0);
     return aIsNewer;
   }
 
   /**
-   * Compares the `dateModified` of the given messages with a fallback to message CID according to the spec.
+   * Compares the `messageTimestamp` of the given messages with a fallback to message CID according to the spec.
    * @returns 1 if `a` is larger/newer than `b`; -1 if `a` is smaller/older than `b`; 0 otherwise (same age)
    */
-  public static async compareModifiedTime(a: TimestampedMessage, b: TimestampedMessage): Promise<number> {
-    if (a.descriptor.dateModified > b.descriptor.dateModified) {
+  public static async compareMessageTimestamp(a: TimestampedMessage, b: TimestampedMessage): Promise<number> {
+    if (a.descriptor.messageTimestamp > b.descriptor.messageTimestamp) {
       return 1;
-    } else if (a.descriptor.dateModified < b.descriptor.dateModified) {
+    } else if (a.descriptor.messageTimestamp < b.descriptor.messageTimestamp) {
       return -1;
     }
 
-    // else `dateModified` is the same between a and b
+    // else `messageTimestamp` is the same between a and b
     // compare the `dataCid` instead, the < and > operators compare strings in lexicographical order
     return Message.compareCid(a, b);
   }

--- a/src/interfaces/events-get.ts
+++ b/src/interfaces/events-get.ts
@@ -1,12 +1,14 @@
 import type { SignatureInput } from '../types/jws-types.js';
 import type { EventsGetDescriptor, EventsGetMessage } from '../types/event-types.js';
 
+import { getCurrentTimeInHighPrecision } from '../utils/time.js';
 import { validateAuthorizationIntegrity } from '../core/auth.js';
 import { DwnInterfaceName, DwnMethodName, Message } from '../core/message.js';
 
 export type EventsGetOptions = {
   watermark?: string;
   authorizationSignatureInput: SignatureInput;
+  messageTimestamp?: string;
 };
 
 export class EventsGet extends Message<EventsGetMessage> {
@@ -20,8 +22,9 @@ export class EventsGet extends Message<EventsGetMessage> {
 
   public static async create(options: EventsGetOptions): Promise<EventsGet> {
     const descriptor: EventsGetDescriptor = {
-      interface : DwnInterfaceName.Events,
-      method    : DwnMethodName.Get,
+      interface        : DwnInterfaceName.Events,
+      method           : DwnMethodName.Get,
+      messageTimestamp : options.messageTimestamp ?? getCurrentTimeInHighPrecision(),
     };
 
     if (options.watermark) {

--- a/src/interfaces/hooks-write.ts
+++ b/src/interfaces/hooks-write.ts
@@ -10,7 +10,7 @@ import { DwnInterfaceName, DwnMethodName, Message } from '../core/message.js';
  * Input to `HookssWrite.create()`.
  */
 export type HooksWriteOptions = {
-  dateCreated?: string,
+  messageTimestamp?: string,
   /**
    * leave as `undefined` for customer handler.
    * ie. DWN processing will use `undefined` check to attempt to invoke the registered handler.
@@ -32,11 +32,11 @@ export class HooksWrite extends Message<HooksWriteMessage> {
    */
   static async create(options: HooksWriteOptions): Promise<HooksWrite> {
     const descriptor: HooksWriteDescriptor = {
-      interface   : DwnInterfaceName.Hooks,
-      method      : DwnMethodName.Write,
-      dateCreated : options.dateCreated ?? getCurrentTimeInHighPrecision(),
-      uri         : options.uri,
-      filter      : options.filter
+      interface        : DwnInterfaceName.Hooks,
+      method           : DwnMethodName.Write,
+      messageTimestamp : options.messageTimestamp ?? getCurrentTimeInHighPrecision(),
+      uri              : options.uri,
+      filter           : options.filter
     };
 
     // delete all descriptor properties that are `undefined` else the code will encounter the following IPLD issue when attempting to generate CID:

--- a/src/interfaces/messages-get.ts
+++ b/src/interfaces/messages-get.ts
@@ -2,12 +2,14 @@ import type { SignatureInput } from '../types/jws-types.js';
 import type { MessagesGetDescriptor, MessagesGetMessage } from '../types/messages-types.js';
 
 import { Cid } from '../utils/cid.js';
+import { getCurrentTimeInHighPrecision } from '../utils/time.js';
 import { validateAuthorizationIntegrity } from '../core/auth.js';
 import { DwnInterfaceName, DwnMethodName, Message } from '../core/message.js';
 
 export type MessagesGetOptions = {
   messageCids: string[];
   authorizationSignatureInput: SignatureInput;
+  messageTimestamp?: string;
 };
 
 export class MessagesGet extends Message<MessagesGetMessage> {
@@ -22,9 +24,10 @@ export class MessagesGet extends Message<MessagesGetMessage> {
 
   public static async create(options: MessagesGetOptions): Promise<MessagesGet> {
     const descriptor: MessagesGetDescriptor = {
-      interface   : DwnInterfaceName.Messages,
-      method      : DwnMethodName.Get,
-      messageCids : options.messageCids
+      interface        : DwnInterfaceName.Messages,
+      method           : DwnMethodName.Get,
+      messageCids      : options.messageCids,
+      messageTimestamp : options?.messageTimestamp ?? getCurrentTimeInHighPrecision(),
     };
 
     const authorization = await Message.signAsAuthorization(descriptor, options.authorizationSignatureInput);

--- a/src/interfaces/permissions-grant.ts
+++ b/src/interfaces/permissions-grant.ts
@@ -10,7 +10,7 @@ import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 import { DwnInterfaceName, DwnMethodName, Message } from '../core/message.js';
 
 export type PermissionsGrantOptions = {
-  dateCreated?: string;
+  messageTimestamp?: string;
   description?: string;
   grantedTo: string;
   grantedBy: string;
@@ -42,7 +42,7 @@ export class PermissionsGrant extends Message<PermissionsGrantMessage> {
     const descriptor: PermissionsGrantDescriptor = {
       interface            : DwnInterfaceName.Permissions,
       method               : DwnMethodName.Grant,
-      dateCreated          : options.dateCreated ?? getCurrentTimeInHighPrecision(),
+      messageTimestamp     : options.messageTimestamp ?? getCurrentTimeInHighPrecision(),
       description          : options.description,
       grantedTo            : options.grantedTo,
       grantedBy            : options.grantedBy,

--- a/src/interfaces/permissions-request.ts
+++ b/src/interfaces/permissions-request.ts
@@ -8,7 +8,7 @@ import { validateAuthorizationIntegrity } from '../core/auth.js';
 import { DwnInterfaceName, DwnMethodName, Message } from '../core/message.js';
 
 type PermissionsRequestOptions = {
-  dateCreated?: string;
+  messageTimestamp?: string;
   description?: string;
   grantedTo: string;
   grantedBy: string;
@@ -28,15 +28,15 @@ export class PermissionsRequest extends Message<PermissionsRequestMessage> {
 
   public static async create(options: PermissionsRequestOptions): Promise<PermissionsRequest> {
     const descriptor: PermissionsRequestDescriptor = {
-      interface   : DwnInterfaceName.Permissions,
-      method      : DwnMethodName.Request,
-      dateCreated : options.dateCreated ?? getCurrentTimeInHighPrecision(),
-      description : options.description,
-      grantedTo   : options.grantedTo,
-      grantedBy   : options.grantedBy,
-      grantedFor  : options.grantedFor,
-      scope       : options.scope,
-      conditions  : options.conditions,
+      interface        : DwnInterfaceName.Permissions,
+      method           : DwnMethodName.Request,
+      messageTimestamp : options.messageTimestamp ?? getCurrentTimeInHighPrecision(),
+      description      : options.description,
+      grantedTo        : options.grantedTo,
+      grantedBy        : options.grantedBy,
+      grantedFor       : options.grantedFor,
+      scope            : options.scope,
+      conditions       : options.conditions,
     };
 
     // delete all descriptor properties that are `undefined` else the code will encounter the following IPLD issue when attempting to generate CID:

--- a/src/interfaces/protocols-configure.ts
+++ b/src/interfaces/protocols-configure.ts
@@ -8,7 +8,7 @@ import { DwnInterfaceName, DwnMethodName, Message } from '../core/message.js';
 import { normalizeProtocolUrl, normalizeSchemaUrl, validateProtocolUrlNormalized, validateSchemaUrlNormalized } from '../utils/url.js';
 
 export type ProtocolsConfigureOptions = {
-  dateCreated? : string;
+  messageTimestamp? : string;
   definition : ProtocolDefinition;
   authorizationSignatureInput: SignatureInput;
 };
@@ -24,10 +24,10 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
 
   public static async create(options: ProtocolsConfigureOptions): Promise<ProtocolsConfigure> {
     const descriptor: ProtocolsConfigureDescriptor = {
-      interface    : DwnInterfaceName.Protocols,
-      method       : DwnMethodName.Configure,
-      dateModified : options.dateCreated ?? getCurrentTimeInHighPrecision(),
-      definition   : ProtocolsConfigure.normalizeDefinition(options.definition)
+      interface        : DwnInterfaceName.Protocols,
+      method           : DwnMethodName.Configure,
+      messageTimestamp : options.messageTimestamp ?? getCurrentTimeInHighPrecision(),
+      definition       : ProtocolsConfigure.normalizeDefinition(options.definition)
     };
 
     const authorization = await Message.signAsAuthorization(descriptor, options.authorizationSignatureInput);

--- a/src/interfaces/protocols-query.ts
+++ b/src/interfaces/protocols-query.ts
@@ -8,7 +8,7 @@ import { DwnInterfaceName, DwnMethodName, Message } from '../core/message.js';
 import { normalizeProtocolUrl, validateProtocolUrlNormalized } from '../utils/url.js';
 
 export type ProtocolsQueryOptions = {
-  dateCreated?: string;
+  messageTimestamp?: string;
   filter?: ProtocolsQueryFilter,
   authorizationSignatureInput: SignatureInput;
 };
@@ -27,10 +27,10 @@ export class ProtocolsQuery extends Message<ProtocolsQueryMessage> {
 
   public static async create(options: ProtocolsQueryOptions): Promise<ProtocolsQuery> {
     const descriptor: ProtocolsQueryDescriptor = {
-      interface   : DwnInterfaceName.Protocols,
-      method      : DwnMethodName.Query,
-      dateCreated : options.dateCreated ?? getCurrentTimeInHighPrecision(),
-      filter      : ProtocolsQuery.normalizeFilter(options.filter),
+      interface        : DwnInterfaceName.Protocols,
+      method           : DwnMethodName.Query,
+      messageTimestamp : options.messageTimestamp ?? getCurrentTimeInHighPrecision(),
+      filter           : ProtocolsQuery.normalizeFilter(options.filter),
     };
 
     // delete all descriptor properties that are `undefined` else the code will encounter the following IPLD issue when attempting to generate CID:

--- a/src/interfaces/records-delete.ts
+++ b/src/interfaces/records-delete.ts
@@ -9,7 +9,7 @@ import { DwnInterfaceName, DwnMethodName } from '../core/message.js';
 
 export type RecordsDeleteOptions = {
   recordId: string;
-  dateModified?: string;
+  messageTimestamp?: string;
   authorizationSignatureInput: SignatureInput;
 };
 
@@ -25,17 +25,17 @@ export class RecordsDelete extends Message<RecordsDeleteMessage> {
   /**
    * Creates a RecordsDelete message.
    * @param options.recordId If `undefined`, will be auto-filled as a originating message as convenience for developer.
-   * @param options.dateModified If `undefined`, it will be auto-filled with current time.
+   * @param options.messageTimestamp If `undefined`, it will be auto-filled with current time.
    */
   public static async create(options: RecordsDeleteOptions): Promise<RecordsDelete> {
     const recordId = options.recordId;
     const currentTime = getCurrentTimeInHighPrecision();
 
     const descriptor: RecordsDeleteDescriptor = {
-      interface    : DwnInterfaceName.Records,
-      method       : DwnMethodName.Delete,
+      interface        : DwnInterfaceName.Records,
+      method           : DwnMethodName.Delete,
       recordId,
-      dateModified : options.dateModified ?? currentTime
+      messageTimestamp : options.messageTimestamp ?? currentTime
     };
 
     const authorization = await Message.signAsAuthorization(descriptor, options.authorizationSignatureInput);

--- a/src/interfaces/records-query.ts
+++ b/src/interfaces/records-query.ts
@@ -17,7 +17,7 @@ export enum DateSort {
 }
 
 export type RecordsQueryOptions = {
-  dateCreated?: string;
+  messageTimestamp?: string;
   filter: RecordsQueryFilter;
   dateSort?: DateSort;
   authorizationSignatureInput?: SignatureInput;
@@ -42,11 +42,11 @@ export class RecordsQuery extends Message<RecordsQueryMessage> {
 
   public static async create(options: RecordsQueryOptions): Promise<RecordsQuery> {
     const descriptor: RecordsQueryDescriptor = {
-      interface   : DwnInterfaceName.Records,
-      method      : DwnMethodName.Query,
-      dateCreated : options.dateCreated ?? getCurrentTimeInHighPrecision(),
-      filter      : RecordsQuery.normalizeFilter(options.filter),
-      dateSort    : options.dateSort
+      interface        : DwnInterfaceName.Records,
+      method           : DwnMethodName.Query,
+      messageTimestamp : options.messageTimestamp ?? getCurrentTimeInHighPrecision(),
+      filter           : RecordsQuery.normalizeFilter(options.filter),
+      dateSort         : options.dateSort
     };
 
     // delete all descriptor properties that are `undefined` else the code will encounter the following IPLD issue when attempting to generate CID:

--- a/src/interfaces/records-read.ts
+++ b/src/interfaces/records-read.ts
@@ -37,10 +37,10 @@ export class RecordsRead extends Message<RecordsReadMessage> {
     const currentTime = getCurrentTimeInHighPrecision();
 
     const descriptor: RecordsReadDescriptor = {
-      interface : DwnInterfaceName.Records,
-      method    : DwnMethodName.Read,
+      interface        : DwnInterfaceName.Records,
+      method           : DwnMethodName.Read,
       recordId,
-      date      : options.date ?? currentTime
+      messageTimestamp : options.date ?? currentTime
     };
 
     // only generate the `authorization` property if signature input is given

--- a/src/interfaces/snapshots-create.ts
+++ b/src/interfaces/snapshots-create.ts
@@ -8,7 +8,7 @@ import { validateAuthorizationIntegrity } from '../core/auth.js';
 import { DwnInterfaceName, DwnMethodName, Message } from '../core/message.js';
 
 export type SnapshotsCreateOptions = {
-  dateCreated? : string;
+  messageTimestamp? : string;
   definition : SnapshotDefinition;
   authorizationSignatureInput: SignatureInput;
 };
@@ -26,9 +26,9 @@ export class SnapshotsCreate extends Message<SnapshotsCreateMessage> {
     const definitionCid = await Cid.computeCid(options.definition);
 
     const descriptor: SnapshotsCreateDescriptor = {
-      interface   : DwnInterfaceName.Snapshots,
-      method      : DwnMethodName.Create,
-      dateCreated : options.dateCreated ?? getCurrentTimeInHighPrecision(),
+      interface        : DwnInterfaceName.Snapshots,
+      method           : DwnMethodName.Create,
+      messageTimestamp : options.messageTimestamp ?? getCurrentTimeInHighPrecision(),
       definitionCid
     };
 

--- a/src/types/event-types.ts
+++ b/src/types/event-types.ts
@@ -7,6 +7,7 @@ export type EventsGetDescriptor = {
   interface : DwnInterfaceName.Events;
   method: DwnMethodName.Get;
   watermark?: string;
+  messageTimestamp: string;
 };
 
 export type EventsGetMessage = GenericMessage & {

--- a/src/types/hooks-types.ts
+++ b/src/types/hooks-types.ts
@@ -7,7 +7,7 @@ import type { DwnInterfaceName, DwnMethodName } from '../core/message.js';
 export type HooksWriteDescriptor = {
   interface: DwnInterfaceName.Hooks;
   method: DwnMethodName.Write;
-  dateCreated: string;
+  messageTimestamp: string;
 
   /**
    * Leave as `undefined` for customer handler.

--- a/src/types/message-types.ts
+++ b/src/types/message-types.ts
@@ -24,11 +24,11 @@ export type Descriptor = {
 };
 
 /**
- * Messages that have `dateModified` in their `descriptor` property.
+ * Messages that have `messageTimestamp` in their `descriptor` property.
  */
 export type TimestampedMessage = GenericMessage & {
   descriptor: {
-    dateModified: string;
+    messageTimestamp: string;
   }
 };
 

--- a/src/types/message-types.ts
+++ b/src/types/message-types.ts
@@ -21,6 +21,8 @@ export type BaseDecodedAuthorizationPayload = {
 export type Descriptor = {
   interface: string;
   method: string;
+  messageTimestamp: string;
+
 };
 
 /**

--- a/src/types/messages-types.ts
+++ b/src/types/messages-types.ts
@@ -6,6 +6,7 @@ export type MessagesGetDescriptor = {
   interface : DwnInterfaceName.Messages;
   method: DwnMethodName.Get;
   messageCids: string[];
+  messageTimestamp: string;
 };
 
 export type MessagesGetMessage = GenericMessage & {

--- a/src/types/permissions-types.ts
+++ b/src/types/permissions-types.ts
@@ -16,7 +16,7 @@ export type PermissionConditions = {
 export type PermissionsRequestDescriptor = {
   interface: DwnInterfaceName.Permissions;
   method: DwnMethodName.Request;
-  dateCreated: string;
+  messageTimestamp: string;
   // The DID of the DWN which the grantee will be given access
   grantedFor: string;
   // The recipient of the grant. Usually this is the author of the PermissionsRequest message
@@ -36,7 +36,7 @@ export type PermissionsRequestMessage = GenericMessage & {
 export type PermissionsGrantDescriptor = {
   interface: DwnInterfaceName.Permissions;
   method: DwnMethodName.Grant;
-  dateCreated: string;
+  messageTimestamp: string;
   // Optional CID of a PermissionsRequest message. This is optional because grants may be given without being officially requested
   permissionsRequestId?: string;
   // Optional timestamp at which this grant will no longer be active.

--- a/src/types/protocols-types.ts
+++ b/src/types/protocols-types.ts
@@ -5,7 +5,7 @@ import type { GenericMessage, QueryResultEntry } from './message-types.js';
 export type ProtocolsConfigureDescriptor = {
   interface : DwnInterfaceName.Protocols;
   method: DwnMethodName.Configure;
-  dateModified: string;
+  messageTimestamp: string;
   definition: ProtocolDefinition;
 };
 
@@ -60,7 +60,7 @@ export type ProtocolsQueryFilter = {
 export type ProtocolsQueryDescriptor = {
   interface : DwnInterfaceName.Protocols,
   method: DwnMethodName.Query;
-  dateCreated: string;
+  messageTimestamp: string;
   filter?: ProtocolsQueryFilter
 };
 

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -19,7 +19,7 @@ export type RecordsWriteDescriptor = {
   dataCid: string;
   dataSize: number;
   dateCreated: string;
-  dateModified: string;
+  messageTimestamp: string;
   published?: boolean;
   datePublished?: string;
   dataFormat: string;
@@ -72,7 +72,7 @@ export type RecordsQueryReplyEntry = UnsignedRecordsWriteMessage & {
 export type RecordsQueryDescriptor = {
   interface: DwnInterfaceName.Records;
   method: DwnMethodName.Query;
-  dateCreated: string;
+  messageTimestamp: string;
   filter: RecordsQueryFilter;
   dateSort?: DateSort;
 };
@@ -143,7 +143,7 @@ export type RecordsReadDescriptor = {
   interface: DwnInterfaceName.Records;
   method: DwnMethodName.Read;
   recordId: string;
-  date: string;
+  messageTimestamp: string;
 };
 
 export type RecordsDeleteMessage = GenericMessage & {
@@ -154,5 +154,5 @@ export type RecordsDeleteDescriptor = {
   interface: DwnInterfaceName.Records;
   method: DwnMethodName.Delete;
   recordId: string;
-  dateModified: string;
+  messageTimestamp: string;
 };

--- a/src/types/snapshots-types.ts
+++ b/src/types/snapshots-types.ts
@@ -4,7 +4,7 @@ import type { DwnInterfaceName, DwnMethodName } from '../core/message.js';
 export type SnapshotsCreateDescriptor = {
   interface : DwnInterfaceName.Snapshots;
   method: DwnMethodName.Create;
-  dateCreated: string;
+  messageTimestamp: string;
   definitionCid: string;
 };
 

--- a/tests/handlers/protocols-configure.spec.ts
+++ b/tests/handlers/protocols-configure.spec.ts
@@ -176,12 +176,12 @@ describe('ProtocolsConfigureHandler.handle()', () => {
       const messageData2 = await TestDataGenerator.generateProtocolsConfigure({
         author             : alice,
         protocolDefinition : protocolDefinition2,
-        dateModified       : messageData1.message.descriptor.dateModified
+        messageTimestamp   : messageData1.message.descriptor.messageTimestamp
       });
       const messageData3 = await TestDataGenerator.generateProtocolsConfigure({
         author             : alice,
         protocolDefinition : protocolDefinition3,
-        dateModified       : messageData1.message.descriptor.dateModified
+        messageTimestamp   : messageData1.message.descriptor.messageTimestamp
       });
 
       const messageDataWithCid: (GenerateProtocolsConfigureOutput & { cid: string })[] = [];

--- a/tests/handlers/records-delete.spec.ts
+++ b/tests/handlers/records-delete.spec.ts
@@ -122,7 +122,7 @@ describe('RecordsDeleteHandler.handle()', () => {
       expect(initialWriteReply.status.code).to.equal(202);
 
       // generate subsequent write and delete with the delete having an earlier timestamp
-      // NOTE: creating RecordsDelete first ensures it has an earlier `dateModified` time
+      // NOTE: creating RecordsDelete first ensures it has an earlier `messageTimestamp` time
       const recordsDelete = await RecordsDelete.create({
         recordId                    : initialWriteData.message.recordId,
         authorizationSignatureInput : Jws.createSignatureInput(alice)
@@ -136,7 +136,7 @@ describe('RecordsDeleteHandler.handle()', () => {
       const subsequentWriteReply = await dwn.processMessage(alice.did, subsequentWriteData.message, subsequentWriteData.dataStream);
       expect(subsequentWriteReply.status.code).to.equal(202);
 
-      // test that a delete with an earlier `dateModified` results in a 409
+      // test that a delete with an earlier `messageTimestamp` results in a 409
       const deleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
       expect(deleteReply.status.code).to.equal(409);
 

--- a/tests/handlers/records-query.spec.ts
+++ b/tests/handlers/records-query.spec.ts
@@ -192,9 +192,9 @@ describe('RecordsQueryHandler.handle()', () => {
       const firstDayOf2022 = createDateString(new Date(2022, 1, 1));
       const firstDayOf2023 = createDateString(new Date(2023, 1, 1));
       const alice = await DidKeyResolver.generate();
-      const write1 = await TestDataGenerator.generateRecordsWrite({ author: alice, dateCreated: firstDayOf2021, dateModified: firstDayOf2021 });
-      const write2 = await TestDataGenerator.generateRecordsWrite({ author: alice, dateCreated: firstDayOf2022, dateModified: firstDayOf2022 });
-      const write3 = await TestDataGenerator.generateRecordsWrite({ author: alice, dateCreated: firstDayOf2023, dateModified: firstDayOf2023 });
+      const write1 = await TestDataGenerator.generateRecordsWrite({ author: alice, dateCreated: firstDayOf2021, messageTimestamp: firstDayOf2021 });
+      const write2 = await TestDataGenerator.generateRecordsWrite({ author: alice, dateCreated: firstDayOf2022, messageTimestamp: firstDayOf2022 });
+      const write3 = await TestDataGenerator.generateRecordsWrite({ author: alice, dateCreated: firstDayOf2023, messageTimestamp: firstDayOf2023 });
 
       // insert data
       const writeReply1 = await dwn.processMessage(alice.did, write1.message, write1.dataStream);
@@ -258,13 +258,13 @@ describe('RecordsQueryHandler.handle()', () => {
       const alice = await DidKeyResolver.generate();
       const schema = '2021And2022Schema';
       const write1 = await TestDataGenerator.generateRecordsWrite({
-        author: alice, dateCreated: firstDayOf2021, dateModified: firstDayOf2021, schema
+        author: alice, dateCreated: firstDayOf2021, messageTimestamp: firstDayOf2021, schema
       });
       const write2 = await TestDataGenerator.generateRecordsWrite({
-        author: alice, dateCreated: firstDayOf2022, dateModified: firstDayOf2022, schema
+        author: alice, dateCreated: firstDayOf2022, messageTimestamp: firstDayOf2022, schema
       });
       const write3 = await TestDataGenerator.generateRecordsWrite({
-        author: alice, dateCreated: firstDayOf2023, dateModified: firstDayOf2023
+        author: alice, dateCreated: firstDayOf2023, messageTimestamp: firstDayOf2023
       });
 
       // insert data

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -83,7 +83,7 @@ describe('RecordsWriteHandler.handle()', () => {
       await dwn.close();
     });
 
-    it('should only be able to overwrite existing record if new record has a later `dateModified` value', async () => {
+    it('should only be able to overwrite existing record if new record has a later `messageTimestamp` value', async () => {
       // write a message into DB
       const author = await DidKeyResolver.generate();
       const data1 = new TextEncoder().encode('data1');
@@ -106,7 +106,7 @@ describe('RecordsWriteHandler.handle()', () => {
       expect(recordsQueryReply.entries![0].encodedData).to.equal(base64url.baseEncode(data1));
 
       // generate and write a new RecordsWrite to overwrite the existing record
-      // a new RecordsWrite by default will have a later `dateModified`
+      // a new RecordsWrite by default will have a later `messageTimestamp`
       const newDataBytes = Encoder.stringToBytes('new data');
       const newDataEncoded = Encoder.bytesToBase64Url(newDataBytes);
       const newRecordsWrite = await TestDataGenerator.generateFromRecordsWrite({
@@ -139,7 +139,7 @@ describe('RecordsWriteHandler.handle()', () => {
       expect(thirdRecordsQueryReply.entries![0].encodedData).to.equal(newDataEncoded);
     });
 
-    it('should only be able to overwrite existing record if new message CID is larger when `dateModified` value is the same', async () => {
+    it('should only be able to overwrite existing record if new message CID is larger when `messageTimestamp` value is the same', async () => {
       // start by writing an originating message
       const author = await TestDataGenerator.generatePersona();
       const tenant = author.did;
@@ -154,17 +154,17 @@ describe('RecordsWriteHandler.handle()', () => {
       const originatingMessageWriteReply = await dwn.processMessage(tenant, originatingMessageData.message, originatingMessageData.dataStream);
       expect(originatingMessageWriteReply.status.code).to.equal(202);
 
-      // generate two new RecordsWrite messages with the same `dateModified` value
+      // generate two new RecordsWrite messages with the same `messageTimestamp` value
       const dateModified = getCurrentTimeInHighPrecision();
       const recordsWrite1 = await TestDataGenerator.generateFromRecordsWrite({
         author,
-        existingWrite: originatingMessageData.recordsWrite,
-        dateModified
+        existingWrite    : originatingMessageData.recordsWrite,
+        messageTimestamp : dateModified
       });
       const recordsWrite2 = await TestDataGenerator.generateFromRecordsWrite({
         author,
-        existingWrite: originatingMessageData.recordsWrite,
-        dateModified
+        existingWrite    : originatingMessageData.recordsWrite,
+        messageTimestamp : dateModified
       });
 
       // determine the lexicographical order of the two messages
@@ -482,10 +482,10 @@ describe('RecordsWriteHandler.handle()', () => {
         expect(reply.status.detail).to.contain('initial write is not found');
       });
 
-      it('should return 400 if `dateCreated` and `dateModified` are not the same in an initial write', async () => {
+      it('should return 400 if `dateCreated` and `messageTimestamp` are not the same in an initial write', async () => {
         const { author, message, dataStream } = await TestDataGenerator.generateRecordsWrite({
-          dateCreated  : '2023-01-10T10:20:30.405060Z',
-          dateModified : getCurrentTimeInHighPrecision() // this always generate a different timestamp
+          dateCreated      : '2023-01-10T10:20:30.405060Z',
+          messageTimestamp : getCurrentTimeInHighPrecision() // this always generate a different timestamp
         });
         const tenant = author.did;
 

--- a/tests/interfaces/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols-configure.spec.ts
@@ -13,18 +13,18 @@ chai.use(chaiAsPromised);
 
 describe('ProtocolsConfigure', () => {
   describe('create()', () => {
-    it('should use `dateCreated` as is if given', async () => {
+    it('should use `messageTimestamp` as is if given', async () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const currentTime = getCurrentTimeInHighPrecision();
       const definition = { ...dexProtocolDefinition };
       const protocolsConfigure = await ProtocolsConfigure.create({
-        dateCreated                 : currentTime,
+        messageTimestamp            : currentTime,
         definition,
         authorizationSignatureInput : Jws.createSignatureInput(alice),
       });
 
-      expect(protocolsConfigure.message.descriptor.dateModified).to.equal(currentTime);
+      expect(protocolsConfigure.message.descriptor.messageTimestamp).to.equal(currentTime);
     });
 
     it('should auto-normalize protocol URI', async () => {

--- a/tests/interfaces/protocols-query.spec.ts
+++ b/tests/interfaces/protocols-query.spec.ts
@@ -13,17 +13,17 @@ chai.use(chaiAsPromised);
 
 describe('ProtocolsQuery', () => {
   describe('create()', () => {
-    it('should use `dateCreated` as is if given', async () => {
+    it('should use `messageTimestamp` as is if given', async () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const currentTime = getCurrentTimeInHighPrecision();
       const protocolsQuery = await ProtocolsQuery.create({
         filter                      : { protocol: 'anyValue' },
-        dateCreated                 : currentTime,
+        messageTimestamp            : currentTime,
         authorizationSignatureInput : Jws.createSignatureInput(alice),
       });
 
-      expect(protocolsQuery.message.descriptor.dateCreated).to.equal(currentTime);
+      expect(protocolsQuery.message.descriptor.messageTimestamp).to.equal(currentTime);
     });
 
 

--- a/tests/interfaces/records-delete.spec.ts
+++ b/tests/interfaces/records-delete.spec.ts
@@ -10,20 +10,20 @@ chai.use(chaiAsPromised);
 
 describe('RecordsDelete', () => {
   describe('create()', () => {
-    it('should use `dateModified` as is if given', async () => {
+    it('should use `messageTimestamp` as is if given', async () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const currentTime = getCurrentTimeInHighPrecision();
       const recordsDelete = await RecordsDelete.create({
         recordId                    : 'anything',
         authorizationSignatureInput : Jws.createSignatureInput(alice),
-        dateModified                : currentTime
+        messageTimestamp            : currentTime
       });
 
-      expect(recordsDelete.message.descriptor.dateModified).to.equal(currentTime);
+      expect(recordsDelete.message.descriptor.messageTimestamp).to.equal(currentTime);
     });
 
-    it('should auto-fill `dateModified` if not given', async () => {
+    it('should auto-fill `messageTimestamp` if not given', async () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const recordsDelete = await RecordsDelete.create({
@@ -31,7 +31,7 @@ describe('RecordsDelete', () => {
         authorizationSignatureInput : Jws.createSignatureInput(alice)
       });
 
-      expect(recordsDelete.message.descriptor.dateModified).to.exist;
+      expect(recordsDelete.message.descriptor.messageTimestamp).to.exist;
     });
   });
 });

--- a/tests/interfaces/records-query.spec.ts
+++ b/tests/interfaces/records-query.spec.ts
@@ -13,17 +13,17 @@ chai.use(chaiAsPromised);
 
 describe('RecordsQuery', () => {
   describe('create()', () => {
-    it('should use `dateCreated` as is if given', async () => {
+    it('should use `messageTimestamp` as is if given', async () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const currentTime = getCurrentTimeInHighPrecision();
       const recordsQuery = await RecordsQuery.create({
         filter                      : { schema: 'anything' },
-        dateCreated                 : currentTime,
+        messageTimestamp            : currentTime,
         authorizationSignatureInput : Jws.createSignatureInput(alice),
       });
 
-      expect(recordsQuery.message.descriptor.dateCreated).to.equal(currentTime);
+      expect(recordsQuery.message.descriptor.messageTimestamp).to.equal(currentTime);
     });
 
     it('should auto-normalize protocol URL', async () => {

--- a/tests/interfaces/records-read.spec.ts
+++ b/tests/interfaces/records-read.spec.ts
@@ -10,7 +10,7 @@ chai.use(chaiAsPromised);
 
 describe('RecordsRead', () => {
   describe('create()', () => {
-    it('should use `dateModified` as is if given', async () => {
+    it('should use `messageTimestamp` as is if given', async () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const currentTime = getCurrentTimeInHighPrecision();
@@ -20,7 +20,7 @@ describe('RecordsRead', () => {
         date                        : currentTime
       });
 
-      expect(recordsRead.message.descriptor.date).to.equal(currentTime);
+      expect(recordsRead.message.descriptor.messageTimestamp).to.equal(currentTime);
     });
   });
 });

--- a/tests/interfaces/records-write.spec.ts
+++ b/tests/interfaces/records-write.spec.ts
@@ -247,10 +247,10 @@ describe('RecordsWrite', () => {
   describe('compareModifiedTime', () => {
     it('should return 0 if age is same', async () => {
       const dateModified = getCurrentTimeInHighPrecision();
-      const a = (await TestDataGenerator.generateRecordsWrite({ dateModified })).message;
+      const a = (await TestDataGenerator.generateRecordsWrite({ messageTimestamp: dateModified })).message;
       const b = JSON.parse(JSON.stringify(a)); // create a deep copy of `a`
 
-      const compareResult = await RecordsWrite.compareModifiedTime(a, b);
+      const compareResult = await RecordsWrite.compareMessageTimestamp(a, b);
       expect(compareResult).to.equal(0);
     });
   });

--- a/tests/interfaces/snapshots-create.spec.ts
+++ b/tests/interfaces/snapshots-create.spec.ts
@@ -30,12 +30,12 @@ describe('SnapshotsCreate', () => {
       };
 
       const snapshotsCreate = await SnapshotsCreate.create({
-        dateCreated                 : currentTime,
+        messageTimestamp            : currentTime,
         definition,
         authorizationSignatureInput : Jws.createSignatureInput(alice),
       });
 
-      expect(snapshotsCreate.message.descriptor.dateCreated).to.equal(currentTime);
+      expect(snapshotsCreate.message.descriptor.messageTimestamp).to.equal(currentTime);
     });
   });
 });

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -63,7 +63,7 @@ export type Persona = {
 
 export type GenerateProtocolsConfigureInput = {
   author?: Persona;
-  dateModified?: string;
+  messageTimestamp?: string;
   protocolDefinition?: ProtocolDefinition;
 };
 
@@ -76,7 +76,7 @@ export type GenerateProtocolsConfigureOutput = {
 
 export type GenerateProtocolsQueryInput = {
   author?: Persona;
-  dateCreated?: string;
+  messageTimestamp?: string;
   filter?: {
     protocol: string;
   }
@@ -104,7 +104,7 @@ export type GenerateRecordsWriteInput = {
   dataSize?: number;
   dataFormat?: string;
   dateCreated?: string;
-  dateModified?: string;
+  messageTimestamp?: string;
   datePublished?: string;
   encryptionInput?: EncryptionInput;
 };
@@ -114,7 +114,7 @@ export type GenerateFromRecordsWriteInput = {
   existingWrite: RecordsWrite,
   data?: Uint8Array;
   published?: boolean;
-  dateModified?: string;
+  messageTimestamp?: string;
   datePublished?: string;
 };
 
@@ -141,7 +141,7 @@ export type GenerateRecordsQueryInput = {
    */
   anonymous?: boolean;
   author?: Persona;
-  dateCreated?: string;
+  messageTimestamp?: string;
   filter?: RecordsQueryFilter;
   dateSort?: DateSort;
 };
@@ -164,7 +164,7 @@ export type GenerateRecordsDeleteOutput = {
 
 export type GenerateHooksWriteInput = {
   author?: Persona;
-  dateCreated?: string;
+  messageTimestamp?: string;
   filter?: {
     method: string;
   }
@@ -178,7 +178,7 @@ export type GenerateHooksWriteOutput = {
 
 export type GeneratePermissionsRequestInput = {
   author: Persona;
-  dateCreated?: string;
+  messageTimestamp?: string;
   description?: string;
   grantedTo?: string;
   grantedBy?: string;
@@ -189,7 +189,7 @@ export type GeneratePermissionsRequestInput = {
 
 export type GeneratePermissionsGrantInput = {
   author: Persona;
-  dateCreated?: string;
+  messageTimestamp?: string;
   description?: string;
   grantedTo?: string;
   grantedBy?: string;
@@ -299,7 +299,7 @@ export class TestDataGenerator {
     const authorizationSignatureInput = Jws.createSignatureInput(author);
 
     const options: ProtocolsConfigureOptions = {
-      dateCreated: input?.dateModified,
+      messageTimestamp: input?.messageTimestamp,
       definition,
       authorizationSignatureInput
     };
@@ -324,8 +324,8 @@ export class TestDataGenerator {
     const authorizationSignatureInput = Jws.createSignatureInput(author);
 
     const options: ProtocolsQueryOptions = {
-      dateCreated : input?.dateCreated,
-      filter      : input?.filter,
+      messageTimestamp : input?.messageTimestamp,
+      filter           : input?.filter,
       authorizationSignatureInput
     };
     removeUndefinedProperties(options);
@@ -364,24 +364,24 @@ export class TestDataGenerator {
     }
 
     const options: RecordsWriteOptions = {
-      recipient       : input?.recipient,
-      protocol        : input?.protocol,
-      protocolPath    : input?.protocolPath,
-      contextId       : input?.contextId,
-      schema          : input?.schema ?? `http://${TestDataGenerator.randomString(20)}`,
-      recordId        : input?.recordId,
-      parentId        : input?.parentId,
-      published       : input?.published,
-      dataFormat      : input?.dataFormat ?? 'application/json',
-      dateCreated     : input?.dateCreated,
-      dateModified    : input?.dateModified,
-      datePublished   : input?.datePublished,
-      data            : dataBytes,
+      recipient        : input?.recipient,
+      protocol         : input?.protocol,
+      protocolPath     : input?.protocolPath,
+      contextId        : input?.contextId,
+      schema           : input?.schema ?? `http://${TestDataGenerator.randomString(20)}`,
+      recordId         : input?.recordId,
+      parentId         : input?.parentId,
+      published        : input?.published,
+      dataFormat       : input?.dataFormat ?? 'application/json',
+      dateCreated      : input?.dateCreated,
+      messageTimestamp : input?.messageTimestamp,
+      datePublished    : input?.datePublished,
+      data             : dataBytes,
       dataCid,
       dataSize,
       authorizationSignatureInput,
       attestationSignatureInputs,
-      encryptionInput : input?.encryptionInput
+      encryptionInput  : input?.encryptionInput
     };
 
     const recordsWrite = await RecordsWrite.create(options);
@@ -418,7 +418,7 @@ export class TestDataGenerator {
       data                        : dataBytes,
       published,
       datePublished,
-      dateModified                : input.dateModified,
+      messageTimestamp            : input.messageTimestamp,
       authorizationSignatureInput : Jws.createSignatureInput(input.author)
     };
 
@@ -453,10 +453,10 @@ export class TestDataGenerator {
     }
 
     const options: RecordsQueryOptions = {
-      dateCreated : input?.dateCreated,
+      messageTimestamp : input?.messageTimestamp,
       authorizationSignatureInput,
-      filter      : input?.filter ?? { schema: TestDataGenerator.randomString(10) }, // must have one filter property if no filter is given
-      dateSort    : input?.dateSort
+      filter           : input?.filter ?? { schema: TestDataGenerator.randomString(10) }, // must have one filter property if no filter is given
+      dateSort         : input?.dateSort
     };
     removeUndefinedProperties(options);
 
@@ -496,9 +496,9 @@ export class TestDataGenerator {
     const authorizationSignatureInput = Jws.createSignatureInput(author);
 
     const options: HooksWriteOptions = {
-      dateCreated : input?.dateCreated,
+      messageTimestamp : input?.messageTimestamp,
       authorizationSignatureInput,
-      filter      : input?.filter ?? { method: 'RecordsWrite' }, // hardcode to filter on `RecordsWrite` if no filter is given
+      filter           : input?.filter ?? { method: 'RecordsWrite' }, // hardcode to filter on `RecordsWrite` if no filter is given
     };
     removeUndefinedProperties(options);
 
@@ -516,12 +516,12 @@ export class TestDataGenerator {
   public static async generatePermissionsRequest(input?: GeneratePermissionsRequestInput): Promise<GeneratePermissionsRequestOutput> {
     const author = input?.author ?? await TestDataGenerator.generatePersona();
     const permissionsRequest = await PermissionsRequest.create({
-      dateCreated : getCurrentTimeInHighPrecision(),
-      description : input?.description,
-      grantedBy   : input?.grantedBy ?? 'did:jank:bob',
-      grantedTo   : input?.grantedTo ?? 'did:jank:alice',
-      grantedFor  : input?.grantedFor ?? input?.grantedBy ?? 'did:jank:bob',
-      scope       : input?.scope ?? {
+      messageTimestamp : getCurrentTimeInHighPrecision(),
+      description      : input?.description,
+      grantedBy        : input?.grantedBy ?? 'did:jank:bob',
+      grantedTo        : input?.grantedTo ?? 'did:jank:alice',
+      grantedFor       : input?.grantedFor ?? input?.grantedBy ?? 'did:jank:bob',
+      scope            : input?.scope ?? {
         interface : DwnInterfaceName.Records,
         method    : DwnMethodName.Write
       },
@@ -542,7 +542,7 @@ export class TestDataGenerator {
   public static async generatePermissionsGrant(input?: GeneratePermissionsGrantInput): Promise<GeneratePermissionsGrantOutput> {
     const author = input?.author ?? await TestDataGenerator.generatePersona();
     const permissionsGrant = await PermissionsGrant.create({
-      dateCreated          : getCurrentTimeInHighPrecision(),
+      messageTimestamp     : getCurrentTimeInHighPrecision(),
       description          : input?.description ?? 'drugs',
       grantedBy            : input?.grantedBy ?? 'did:jank:bob',
       grantedTo            : input?.grantedTo ?? 'did:jank:alice',

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -28,10 +28,10 @@ describe('ProtocolsConfigure schema definition', () => {
 
     const message: ProtocolsConfigureMessage = {
       descriptor: {
-        interface    : DwnInterfaceName.Protocols,
-        method       : DwnMethodName.Configure,
-        dateModified : '2022-10-14T10:20:30.405060Z',
-        definition   : protocolDefinition
+        interface        : DwnInterfaceName.Protocols,
+        method           : DwnMethodName.Configure,
+        messageTimestamp : '2022-10-14T10:20:30.405060Z',
+        definition       : protocolDefinition
       },
       authorization: {
         payload    : 'anyPayload',

--- a/tests/validation/json-schemas/records/records-query.spec.ts
+++ b/tests/validation/json-schemas/records/records-query.spec.ts
@@ -5,10 +5,10 @@ describe('RecordsQuery schema validation', () => {
   it('should allow descriptor with only required properties', async () => {
     const validMessage = {
       descriptor: {
-        interface   : 'Records',
-        method      : 'Query',
-        dateCreated : '2022-10-14T10:20:30.405060Z',
-        filter      : { schema: 'anySchema' }
+        interface        : 'Records',
+        method           : 'Query',
+        messageTimestamp : '2022-10-14T10:20:30.405060Z',
+        filter           : { schema: 'anySchema' }
       },
       authorization: {
         payload    : 'anyPayload',
@@ -24,10 +24,10 @@ describe('RecordsQuery schema validation', () => {
   it('should throw if unknown property is given in message', () => {
     const invalidMessage = {
       descriptor: {
-        interface   : 'Records',
-        method      : 'Query',
-        dateCreated : '2022-10-14T10:20:30.405060Z',
-        filter      : { schema: 'anySchema' }
+        interface        : 'Records',
+        method           : 'Query',
+        messageTimestamp : '2022-10-14T10:20:30.405060Z',
+        filter           : { schema: 'anySchema' }
       },
       authorization: {
         payload    : 'anyPayload',
@@ -47,11 +47,11 @@ describe('RecordsQuery schema validation', () => {
   it('should throw if unknown property is given in the `descriptor`', () => {
     const invalidMessage = {
       descriptor: {
-        interface       : 'Records',
-        method          : 'Query',
-        dateCreated     : '2022-10-14T10:20:30.405060Z',
-        filter          : { schema: 'anySchema' },
-        unknownProperty : 'unknownProperty' // unknown property
+        interface        : 'Records',
+        method           : 'Query',
+        messageTimestamp : '2022-10-14T10:20:30.405060Z',
+        filter           : { schema: 'anySchema' },
+        unknownProperty  : 'unknownProperty' // unknown property
       },
       authorization: {
         payload    : 'anyPayload',
@@ -73,11 +73,11 @@ describe('RecordsQuery schema validation', () => {
     for (const dateSortValue of allowedDateSortValues) {
       const validMessage = {
         descriptor: {
-          interface   : 'Records',
-          method      : 'Query',
-          dateCreated : '2022-10-14T10:20:30.405060Z',
-          filter      : { schema: 'anySchema' },
-          dateSort    : dateSortValue
+          interface        : 'Records',
+          method           : 'Query',
+          messageTimestamp : '2022-10-14T10:20:30.405060Z',
+          filter           : { schema: 'anySchema' },
+          dateSort         : dateSortValue
         },
         authorization: {
           payload    : 'anyPayload',
@@ -94,11 +94,11 @@ describe('RecordsQuery schema validation', () => {
     // test an invalid values of `dateSort`
     const invalidMessage = {
       descriptor: {
-        interface   : 'Records',
-        method      : 'Query',
-        dateCreated : '2022-10-14T10:20:30.405060Z',
-        filter      : { schema: 'anySchema' },
-        dateSort    : 'unacceptable', // bad value
+        interface        : 'Records',
+        method           : 'Query',
+        messageTimestamp : '2022-10-14T10:20:30.405060Z',
+        filter           : { schema: 'anySchema' },
+        dateSort         : 'unacceptable', // bad value
       },
       authorization: {
         payload    : 'anyPayload',
@@ -118,10 +118,10 @@ describe('RecordsQuery schema validation', () => {
     it('should throw if empty `filter` property is given in the `descriptor`', () => {
       const invalidMessage = {
         descriptor: {
-          interface   : 'Records',
-          method      : 'Query',
-          dateCreated : '2022-10-14T10:20:30.405060Z',
-          filter      : { }
+          interface        : 'Records',
+          method           : 'Query',
+          messageTimestamp : '2022-10-14T10:20:30.405060Z',
+          filter           : { }
         },
         authorization: {
           payload    : 'anyPayload',
@@ -140,10 +140,10 @@ describe('RecordsQuery schema validation', () => {
     it('should throw if `dateCreated` criteria given is an empty object', () => {
       const invalidMessage = {
         descriptor: {
-          interface   : 'Records',
-          method      : 'Query',
-          dateCreated : '2022-10-14T10:20:30.405060Z',
-          filter      : { dateCreated: { } } // empty `dateCreated` criteria
+          interface        : 'Records',
+          method           : 'Query',
+          messageTimestamp : '2022-10-14T10:20:30.405060Z',
+          filter           : { dateCreated: { } } // empty `dateCreated` criteria
         },
         authorization: {
           payload    : 'anyPayload',
@@ -162,10 +162,10 @@ describe('RecordsQuery schema validation', () => {
     it('should throw if `dateCreated` criteria has unexpected properties', () => {
       const invalidMessage = {
         descriptor: {
-          interface   : 'Records',
-          method      : 'Query',
-          dateCreated : '2022-10-14T10:20:30.405060Z',
-          filter      : { dateCreated: { unexpectedProperty: 'anyValue' } } // unexpected property in `dateCreated` criteria
+          interface        : 'Records',
+          method           : 'Query',
+          messageTimestamp : '2022-10-14T10:20:30.405060Z',
+          filter           : { dateCreated: { unexpectedProperty: 'anyValue' } } // unexpected property in `dateCreated` criteria
         },
         authorization: {
           payload    : 'anyPayload',

--- a/tests/validation/json-schemas/records/records-write.spec.ts
+++ b/tests/validation/json-schemas/records/records-write.spec.ts
@@ -6,13 +6,13 @@ describe('RecordsWrite schema definition', () => {
     const validMessage = {
       recordId   : 'anyRecordId',
       descriptor : {
-        interface    : 'Records',
-        method       : 'Write',
-        dataCid      : 'anyCid',
-        dataFormat   : 'application/json',
-        dataSize     : 123,
-        dateCreated  : '2022-12-19T10:20:30.123456Z',
-        dateModified : '2022-12-19T10:20:30.123456Z',
+        interface        : 'Records',
+        method           : 'Write',
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        messageTimestamp : '2022-12-19T10:20:30.123456Z',
       },
       authorization: {
         payload    : 'anyPayload',
@@ -28,13 +28,13 @@ describe('RecordsWrite schema definition', () => {
   it('should throw if `recordId` is missing', async () => {
     const message = {
       descriptor: {
-        interface    : 'Records',
-        method       : 'Write',
-        dataCid      : 'anyCid',
-        dataFormat   : 'application/json',
-        dataSize     : 123,
-        dateCreated  : '2022-12-19T10:20:30.123456Z',
-        dateModified : '2022-12-19T10:20:30.123456Z'
+        interface        : 'Records',
+        method           : 'Write',
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
       authorization: {
         payload    : 'anyPayload',
@@ -54,13 +54,13 @@ describe('RecordsWrite schema definition', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
       descriptor : {
-        interface    : 'Records',
-        method       : 'Write',
-        dataCid      : 'anyCid',
-        dataFormat   : 'application/json',
-        dataSize     : 123,
-        dateCreated  : '2022-12-19T10:20:30.123456Z',
-        dateModified : '2022-12-19T10:20:30.123456Z'
+        interface        : 'Records',
+        method           : 'Write',
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        messageTimestamp : '2022-12-19T10:20:30.123456Z'
       }
     };
 
@@ -73,13 +73,13 @@ describe('RecordsWrite schema definition', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
       descriptor : {
-        interface    : 'Records',
-        method       : 'Write',
-        dataCid      : 'anyCid',
-        dataFormat   : 'application/json',
-        dataSize     : 123,
-        dateCreated  : '2022-12-19T10:20:30.123456Z',
-        dateModified : '2022-12-19T10:20:30.123456Z'
+        interface        : 'Records',
+        method           : 'Write',
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
       authorization: {
         payload    : 'anyPayload',
@@ -100,14 +100,14 @@ describe('RecordsWrite schema definition', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
       descriptor : {
-        interface       : 'Records',
-        method          : 'Write',
-        dataCid         : 'anyCid',
-        dataFormat      : 'application/json',
-        dataSize        : 123,
-        dateCreated     : '2022-12-19T10:20:30.123456Z',
-        dateModified    : '2022-12-19T10:20:30.123456Z',
-        unknownProperty : 'unknownProperty' // unknown property
+        interface        : 'Records',
+        method           : 'Write',
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        messageTimestamp : '2022-12-19T10:20:30.123456Z',
+        unknownProperty  : 'unknownProperty' // unknown property
       },
       authorization: {
         payload    : 'anyPayload',
@@ -128,16 +128,16 @@ describe('RecordsWrite schema definition', () => {
       recordId   : 'anyRecordId',
       contextId  : 'someContext', // must exist because `protocol` exists
       descriptor : {
-        interface    : 'Records',
-        method       : 'Write',
-        protocol     : 'someProtocolId',
-        protocolPath : 'foo/bar', // must exist because `protocol` exists
-        schema       : 'http://foo.bar/schema', // must exist because `protocol` exists
-        dataCid      : 'anyCid',
-        dataFormat   : 'application/json',
-        dataSize     : 123,
-        dateCreated  : '2022-12-19T10:20:30.123456Z',
-        dateModified : '2022-12-19T10:20:30.123456Z'
+        interface        : 'Records',
+        method           : 'Write',
+        protocol         : 'someProtocolId',
+        protocolPath     : 'foo/bar', // must exist because `protocol` exists
+        schema           : 'http://foo.bar/schema', // must exist because `protocol` exists
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
       authorization: {
         payload    : 'anyPayload',
@@ -156,16 +156,16 @@ describe('RecordsWrite schema definition', () => {
       recordId   : 'anyRecordId',
       contextId  : 'someContext',
       descriptor : {
-        interface    : 'Records',
-        method       : 'Write',
-        protocol     : 'http://foo.bar',
-        protocolPath : 'invalid:path', // `:` is not a valid char in `protocolPath`
-        schema       : 'http://foo.bar/schema',
-        dataCid      : 'anyCid',
-        dataFormat   : 'application/json',
-        dataSize     : 123,
-        dateCreated  : '2022-12-19T10:20:30.123456Z',
-        dateModified : '2022-12-19T10:20:30.123456Z'
+        interface        : 'Records',
+        method           : 'Write',
+        protocol         : 'http://foo.bar',
+        protocolPath     : 'invalid:path', // `:` is not a valid char in `protocolPath`
+        schema           : 'http://foo.bar/schema',
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
       authorization: {
         payload    : 'anyPayload',
@@ -185,13 +185,13 @@ describe('RecordsWrite schema definition', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
       descriptor : {
-        interface    : 'Records',
-        method       : 'Write',
-        dataCid      : 'anyCid',
-        dataFormat   : 'application/json',
-        dataSize     : 123,
-        dateCreated  : '2022-12-19T10:20:30.123456Z',
-        dateModified : '2022-12-19T10:20:30.123456Z'
+        interface        : 'Records',
+        method           : 'Write',
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
       authorization: {
         payload    : 'anyPayload',
@@ -210,13 +210,13 @@ describe('RecordsWrite schema definition', () => {
       recordId   : 'anyRecordId',
       contextId  : 'invalid', // must have `protocol` to exist
       descriptor : {
-        interface    : 'Records',
-        method       : 'Write',
-        dataCid      : 'anyCid',
-        dataFormat   : 'application/json',
-        dataSize     : 123,
-        dateCreated  : '2022-12-19T10:20:30.123456Z',
-        dateModified : '2022-12-19T10:20:30.123456Z'
+        interface        : 'Records',
+        method           : 'Write',
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
       authorization: {
         payload    : 'anyPayload',
@@ -236,14 +236,14 @@ describe('RecordsWrite schema definition', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
       descriptor : {
-        interface    : 'Records',
-        method       : 'Write',
-        protocol     : 'invalid', // must have `contextId` to exist
-        dataCid      : 'anyCid',
-        dataFormat   : 'application/json',
-        dataSize     : 123,
-        dateCreated  : '2022-12-19T10:20:30.123456Z',
-        dateModified : '2022-12-19T10:20:30.123456Z'
+        interface        : 'Records',
+        method           : 'Write',
+        protocol         : 'invalid', // must have `contextId` to exist
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
       authorization: {
         payload    : 'anyPayload',
@@ -264,15 +264,15 @@ describe('RecordsWrite schema definition', () => {
       recordId   : 'anyRecordId',
       contextId  : 'anyContextId', // required by protocol-based message
       descriptor : {
-        interface    : 'Records',
-        method       : 'Write',
-        protocol     : 'http://foo.bar',
+        interface        : 'Records',
+        method           : 'Write',
+        protocol         : 'http://foo.bar',
         // protocolPath : 'foo/bar', // intentionally missing
-        dataCid      : 'anyCid',
-        dataFormat   : 'application/json',
-        dataSize     : 123,
-        dateCreated  : '2022-12-19T10:20:30.123456Z',
-        dateModified : '2022-12-19T10:20:30.123456Z'
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
       authorization: {
         payload    : 'anyPayload',
@@ -293,15 +293,15 @@ describe('RecordsWrite schema definition', () => {
       recordId   : 'anyRecordId',
       contextId  : 'anyContextId',
       descriptor : {
-        interface    : 'Records',
-        method       : 'Write',
+        interface        : 'Records',
+        method           : 'Write',
         // protocol     : 'http://foo.bar', // intentionally missing
-        protocolPath : 'foo/bar',
-        dataCid      : 'anyCid',
-        dataFormat   : 'application/json',
-        dataSize     : 123,
-        dateCreated  : '2022-12-19T10:20:30.123456Z',
-        dateModified : '2022-12-19T10:20:30.123456Z'
+        protocolPath     : 'foo/bar',
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
       authorization: {
         payload    : 'anyPayload',
@@ -322,16 +322,16 @@ describe('RecordsWrite schema definition', () => {
       recordId   : 'anyRecordId',
       contextId  : 'anyContextId', // required by protocol-based message
       descriptor : {
-        interface    : 'Records',
-        method       : 'Write',
-        protocol     : 'http://foo.bar',
-        protocolPath : 'foo/bar',
+        interface        : 'Records',
+        method           : 'Write',
+        protocol         : 'http://foo.bar',
+        protocolPath     : 'foo/bar',
         // schema       : 'http://foo.bar/schema', // intentionally missing
-        dataCid      : 'anyCid',
-        dataFormat   : 'application/json',
-        dataSize     : 123,
-        dateCreated  : '2022-12-19T10:20:30.123456Z',
-        dateModified : '2022-12-19T10:20:30.123456Z'
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
       authorization: {
         payload    : 'anyPayload',
@@ -352,17 +352,17 @@ describe('RecordsWrite schema definition', () => {
       recordId   : 'anyRecordId',
       contextId  : 'anyContextId',
       descriptor : {
-        interface    : 'Records',
-        method       : 'Write',
+        interface        : 'Records',
+        method           : 'Write',
         // protocol     : 'http://foo.bar', // intentionally missing
-        recipient    : 'did:example:anyone',
+        recipient        : 'did:example:anyone',
         // protocolPath : 'foo/bar', // intentionally missing
-        schema       : 'http://foo.bar/schema',
-        dataCid      : 'anyCid',
-        dataFormat   : 'application/json',
-        dataSize     : 123,
-        dateCreated  : '2022-12-19T10:20:30.123456Z',
-        dateModified : '2022-12-19T10:20:30.123456Z'
+        schema           : 'http://foo.bar/schema',
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
       authorization: {
         payload    : 'anyPayload',
@@ -383,17 +383,17 @@ describe('RecordsWrite schema definition', () => {
       recordId   : 'anyRecordId',
       contextId  : 'anyContextId',
       descriptor : {
-        interface    : 'Records',
-        method       : 'Write',
-        protocol     : 'http://foo.bar',
+        interface        : 'Records',
+        method           : 'Write',
+        protocol         : 'http://foo.bar',
         // recipient    : 'did:example:anyone', // intentionally missing
-        protocolPath : 'foo/bar',
-        schema       : 'http://foo.bar/schema',
-        dataCid      : 'anyCid',
-        dataFormat   : 'application/json',
-        dataSize     : 123,
-        dateCreated  : '2022-12-19T10:20:30.123456Z',
-        dateModified : '2022-12-19T10:20:30.123456Z'
+        protocolPath     : 'foo/bar',
+        schema           : 'http://foo.bar/schema',
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
       authorization: {
         payload    : 'anyPayload',
@@ -412,17 +412,17 @@ describe('RecordsWrite schema definition', () => {
       recordId   : 'anyRecordId',
       contextId  : 'anyContextId',
       descriptor : {
-        interface    : 'Records',
-        method       : 'Write',
-        protocol     : 'http://foo.bar',
-        recipient    : 'did:example:anyone',
-        protocolPath : 'foo/bar',
-        schema       : 'http://foo.bar/schema',
-        dataCid      : 'anyCid',
-        dataFormat   : 'application/json',
-        dataSize     : 123,
-        dateCreated  : '2022-12-19T10:20:30.123456Z',
-        dateModified : '2022-12-19T10:20:30.123456Z'
+        interface        : 'Records',
+        method           : 'Write',
+        protocol         : 'http://foo.bar',
+        recipient        : 'did:example:anyone',
+        protocolPath     : 'foo/bar',
+        schema           : 'http://foo.bar/schema',
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
       authorization: {
         payload    : 'anyPayload',
@@ -440,15 +440,15 @@ describe('RecordsWrite schema definition', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
       descriptor : {
-        interface     : 'Records',
-        method        : 'Write',
-        dataCid       : 'anyCid',
-        dataFormat    : 'application/json',
-        dataSize      : 123,
-        dateModified  : '2022-12-19T10:20:30.123456Z',
-        published     : false,
-        dateCreated   : '2022-12-19T10:20:30.123456Z',
-        datePublished : '2022-12-19T10:20:30.123456Z' // must not be present when not published
+        interface        : 'Records',
+        method           : 'Write',
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        messageTimestamp : '2022-12-19T10:20:30.123456Z',
+        published        : false,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        datePublished    : '2022-12-19T10:20:30.123456Z' // must not be present when not published
       },
       authorization: {
         payload    : 'anyPayload',
@@ -468,14 +468,14 @@ describe('RecordsWrite schema definition', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
       descriptor : {
-        interface    : 'Records',
-        method       : 'Write',
-        dataCid      : 'anyCid',
-        dataFormat   : 'application/json',
-        dataSize     : 123,
-        dateCreated  : '2022-12-19T10:20:30.123456Z',
-        dateModified : '2022-12-19T10:20:30.123456Z',
-        published    : true //datePublished must be present
+        interface        : 'Records',
+        method           : 'Write',
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        messageTimestamp : '2022-12-19T10:20:30.123456Z',
+        published        : true //datePublished must be present
       },
       authorization: {
         payload    : 'anyPayload',
@@ -495,14 +495,14 @@ describe('RecordsWrite schema definition', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
       descriptor : {
-        interface     : 'Records',
-        method        : 'Write',
-        dataCid       : 'anyCid',
-        dataFormat    : 'application/json',
-        dataSize      : 123,
-        dateCreated   : '2022-12-19T10:20:30.123456Z',
-        dateModified  : '2022-12-19T10:20:30.123456Z',
-        datePublished : '2022-12-19T10:20:30.123456Z' //published must be present
+        interface        : 'Records',
+        method           : 'Write',
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        messageTimestamp : '2022-12-19T10:20:30.123456Z',
+        datePublished    : '2022-12-19T10:20:30.123456Z' //published must be present
       },
       authorization: {
         payload    : 'anyPayload',


### PR DESCRIPTION
Taking approach 1 from #406.
> Require all DWN message to have messageTimestamp
dateCreated is a method specific property, ie. in RecordsWrite.
Remove/rename all other variant of date related properties accordingly.


* In `RecordsWrite`, `RecordsDelete`, and `ProtocolsConfigure`: `dateModified` -> `messageTimestamp`.
* `RecordsWrite` retains the `dateCreated` field, which refers to the time that the _record_ was created.
* In `RecordsRead`: `date` -> `messageTimestamp`
* `EventsGet` and `MessagesGet` do not have timestamps of any kind.
* In all other DWN messages, `dateCreated` -> `messageTimestamp`

