### PR TITLE
Refactored tests to be independent of store implementation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,16 @@ We suggest the following process when picking up one of these issues:
 * Running the `npm run test:browser` command from the root of the project will run the tests in browser environments.
   * Please make sure there are no failing tests before switching your PR to ready for review! This validation is automated when you open a new pull request.
 
+### Developing and testing custom store implementations
+Here is a guide on how to develop and test a custom implementation of the data store:
+
+> Please note that we aim to improve the experience over time, such as exporting the interface definitions as their own module.
+
+1. Fork the repository.
+1. Implement one or a combination of the `DataStore`, `MessageStore`, and `EventLog` interfaces.
+1. Override the store initialization logic in the `TestStoreInitializer` class.
+1. Run the tests as you would normally to ensure the functionality and correctness of your custom implementation.
+
 ### Running benchmarks
 
 Benchmarks should be run directly using `node` (e.g. `node benchmarks/store/index/search-index.js`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "rimraf": "3.0.2",
         "search-index": "3.4.0",
         "sinon": "13.0.1",
+        "ts-sinon": "^2.0.2",
         "typescript": "4.8.2",
         "util": "0.12.4"
       },
@@ -1011,6 +1012,16 @@
       "dev": true,
       "dependencies": {
         "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinon-chai": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.9.tgz",
+      "integrity": "sha512-/19t63pFYU0ikrdbXKBWj9PCdnKyTd0Qkz0X91Ta081cYsq90OxYdcWwK/dwEoDa6dtXgj2HJfmzgq+QZTHdmQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
       }
     },
     "node_modules/@types/sinonjs__fake-timers": {
@@ -6685,6 +6696,93 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ts-sinon": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ts-sinon/-/ts-sinon-2.0.2.tgz",
+      "integrity": "sha512-Eh6rXPQruACHPn+/e5HsIMaHZa17tGP/scGjUeW5eJ/Levn8hBV6zSP/6QkEDUP7wLkTyY0yeYikjpTzgC9Gew==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^14.6.1",
+        "@types/sinon": "^9.0.5",
+        "@types/sinon-chai": "^3.2.4",
+        "sinon": "^9.0.3"
+      }
+    },
+    "node_modules/ts-sinon/node_modules/@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/ts-sinon/node_modules/@sinonjs/samsam": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
+      "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/ts-sinon/node_modules/@types/node": {
+      "version": "14.18.52",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.52.tgz",
+      "integrity": "sha512-DGhiXKOHSFVVm+PJD+9Y0ObxXLeG6qwc0HoOn+ooQKeNNu+T2mEJCM5UBDUREKAggl9MHYjb5E71PAmx6MbzIg==",
+      "dev": true
+    },
+    "node_modules/ts-sinon/node_modules/@types/sinon": {
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.11.tgz",
+      "integrity": "sha512-PwP4UY33SeeVKodNE37ZlOsR9cReypbMJOhZ7BVE0lB+Hix3efCOxiJWiE5Ia+yL9Cn2Ch72EjFTRze8RZsNtg==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/ts-sinon/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/ts-sinon/node_modules/nise": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.1.0.tgz",
+      "integrity": "sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/ts-sinon/node_modules/sinon": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
+      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/samsam": "^5.3.1",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "rimraf": "3.0.2",
     "search-index": "3.4.0",
     "sinon": "13.0.1",
+    "ts-sinon": "^2.0.2",
     "typescript": "4.8.2",
     "util": "0.12.4"
   },

--- a/src/types/data-store.ts
+++ b/src/types/data-store.ts
@@ -45,6 +45,11 @@ export interface DataStore {
    * @param messageCid CID of the message that references the data.
    */
   delete(tenant: string, messageCid: string, dataCid: string): Promise<void>;
+
+  /**
+   * Clears the entire store. Mainly used for cleaning up in test environment.
+   */
+  clear(): Promise<void>;
 }
 
 /**

--- a/src/types/event-log.ts
+++ b/src/types/event-log.ts
@@ -30,17 +30,17 @@ export interface EventLog {
   /**
    * retrieves all of a tenant's events that occurred after the watermark provided.
    * If no watermark is provided, all events for a given tenant will be returned.
-   *
-   * @param tenant
-   * @param watermark
    */
   getEvents(tenant: string, options?: GetEventsOptions): Promise<Array<Event>>
 
   /**
    * deletes any events that have any of the cids provided
-   * @param tenant
-   * @param cids
    * @returns {Promise<number>} the number of events deleted
    */
   deleteEventsByCid(tenant: string, cids: Array<string>): Promise<number>
+
+  /**
+   * Clears the entire store. Mainly used for cleaning up in test environment.
+   */
+  clear(): Promise<void>;
 }

--- a/src/types/message-store.ts
+++ b/src/types/message-store.ts
@@ -41,4 +41,9 @@ export interface MessageStore {
    * Deletes the message associated with the id provided.
    */
   delete(tenant: string, cid: string, options?: MessageStoreOptions): Promise<void>;
+
+  /**
+   * Clears the entire store. Mainly used for cleaning up in test environment.
+   */
+  clear(): Promise<void>;
 }

--- a/tests/dwn.spec.ts
+++ b/tests/dwn.spec.ts
@@ -1,42 +1,34 @@
+import type { DataStore, EventLog, MessageStore } from '../src/index.js';
 import type { EventsGetReply, RecordsWriteMessage, TenantGate } from '../src/index.js';
 
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
 
-import { DataStoreLevel } from '../src/store/data-store-level.js';
 import { DidKeyResolver } from '../src/did/did-key-resolver.js';
 import { Dwn } from '../src/dwn.js';
 import { Encoder } from '../src/index.js';
-import { EventLogLevel } from '../src/event-log/event-log-level.js';
-import { MessageStoreLevel } from '../src/store/message-store-level.js';
+import { stubInterface } from 'ts-sinon';
 import { TestDataGenerator } from './utils/test-data-generator.js';
+import { TestStoreInitializer } from './test-store-initializer.js';
 import { DwnInterfaceName, DwnMethodName, Message } from '../src/core/message.js';
 import { Jws, RecordsRead } from '../src/index.js';
 
 chai.use(chaiAsPromised);
 
 describe('DWN', () => {
-  let messageStore: MessageStoreLevel;
-  let dataStore: DataStoreLevel;
-  let eventLog: EventLogLevel;
+  let messageStore: MessageStore;
+  let dataStore: DataStore;
+  let eventLog: EventLog;
   let dwn: Dwn;
 
+  // important to follow the `before` and `after` pattern to initialize and clean the stores in tests
+  // so that different test suites can reuse the same backend store for testing
   before(async () => {
-    // important to follow this pattern to initialize the message store in tests
-    // so that different suites can reuse the same block store and index location for testing
-    messageStore = new MessageStoreLevel({
-      blockstoreLocation : 'TEST-MESSAGESTORE',
-      indexLocation      : 'TEST-INDEX'
-    });
-
-    dataStore = new DataStoreLevel({
-      blockstoreLocation: 'TEST-DATASTORE'
-    });
-
-    eventLog = new EventLogLevel({
-      location: 'TEST-EVENTLOG'
-    });
+    const stores = TestStoreInitializer.initializeStores();
+    messageStore = stores.messageStore;
+    dataStore = stores.dataStore;
+    eventLog = stores.eventLog;
 
     dwn = await Dwn.create({ messageStore, dataStore, eventLog });
   });
@@ -144,9 +136,9 @@ describe('DWN', () => {
         }
       };
 
-      const messageStoreStub = sinon.createStubInstance(MessageStoreLevel);
-      const dataStoreStub = sinon.createStubInstance(DataStoreLevel);
-      const eventLogStub = sinon.createStubInstance(EventLogLevel);
+      const messageStoreStub = stubInterface<MessageStore>();
+      const dataStoreStub = stubInterface<DataStore>();
+      const eventLogStub = stubInterface<EventLog>();
 
       const dwnWithConfig = await Dwn.create({
         tenantGate   : blockAllTenantGate,
@@ -285,9 +277,9 @@ describe('DWN', () => {
         }
       };
 
-      const messageStoreStub = sinon.createStubInstance(MessageStoreLevel);
-      const dataStoreStub = sinon.createStubInstance(DataStoreLevel);
-      const eventLogStub = sinon.createStubInstance(EventLogLevel);
+      const messageStoreStub = stubInterface<MessageStore>();
+      const dataStoreStub = stubInterface<DataStore>();
+      const eventLogStub = stubInterface<EventLog>();
 
       const dwnWithConfig = await Dwn.create({
         tenantGate   : blockAllTenantGate,

--- a/tests/handlers/events-get.spec.ts
+++ b/tests/handlers/events-get.spec.ts
@@ -1,42 +1,37 @@
-import type { EventsGetReply } from '../../src/index.js';
+import type {
+  DataStore,
+  EventLog,
+  EventsGetReply,
+  MessageStore
+} from '../../src/index.js';
 
 import { expect } from 'chai';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import {
-  DataStoreLevel,
   DidKeyResolver,
   DidResolver,
-  Dwn,
-  EventLogLevel,
-  MessageStoreLevel,
+  Dwn
 } from '../../src/index.js';
 
 import { Message } from '../../src/core/message.js';
+import { TestStoreInitializer } from '../test-store-initializer.js';
 
 describe('EventsGetHandler.handle()', () => {
   let didResolver: DidResolver;
-  let messageStore: MessageStoreLevel;
-  let dataStore: DataStoreLevel;
-  let eventLog: EventLogLevel;
+  let messageStore: MessageStore;
+  let dataStore: DataStore;
+  let eventLog: EventLog;
   let dwn: Dwn;
 
+  // important to follow the `before` and `after` pattern to initialize and clean the stores in tests
+  // so that different test suites can reuse the same backend store for testing
   before(async () => {
     didResolver = new DidResolver([new DidKeyResolver()]);
 
-    // important to follow this pattern to initialize and clean the message and data store in tests
-    // so that different suites can reuse the same block store and index location for testing
-    messageStore = new MessageStoreLevel({
-      blockstoreLocation : 'TEST-MESSAGESTORE',
-      indexLocation      : 'TEST-INDEX'
-    });
-
-    dataStore = new DataStoreLevel({
-      blockstoreLocation: 'TEST-DATASTORE'
-    });
-
-    eventLog = new EventLogLevel({
-      location: 'TEST-EVENTLOG'
-    });
+    const stores = TestStoreInitializer.initializeStores();
+    messageStore = stores.messageStore;
+    dataStore = stores.dataStore;
+    eventLog = stores.eventLog;
 
     dwn = await Dwn.create({ didResolver, messageStore, dataStore, eventLog });
   });

--- a/tests/handlers/permissions-grant.spec.ts
+++ b/tests/handlers/permissions-grant.spec.ts
@@ -1,43 +1,40 @@
-import { expect } from 'chai';
+import type {
+  DataStore,
+  EventLog,
+  MessageStore
+} from '../../src/index.js';
+
 import sinon from 'sinon';
 
-import { DataStoreLevel } from '../../src/store/data-store-level.js';
 import { DidKeyResolver } from '../../src/did/did-key-resolver.js';
 import { DidResolver } from '../../src/did/did-resolver.js';
 import { Dwn } from '../../src/dwn.js';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
-import { EventLogLevel } from '../../src/event-log/event-log-level.js';
+import { expect } from 'chai';
 import { Message } from '../../src/core/message.js';
-import { MessageStoreLevel } from '../../src/store/message-store-level.js';
 import { PermissionsGrant } from '../../src/interfaces/permissions-grant.js';
 import { PermissionsGrantHandler } from '../../src/handlers/permissions-grant.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
+import { TestStoreInitializer } from '../test-store-initializer.js';
 
 describe('PermissionsGrantHandler.handle()', () => {
   let didResolver: DidResolver;
-  let messageStore: MessageStoreLevel;
-  let dataStore: DataStoreLevel;
-  let eventLog: EventLogLevel;
+  let messageStore: MessageStore;
+  let dataStore: DataStore;
+  let eventLog: EventLog;
   let dwn: Dwn;
 
   describe('functional tests', () => {
+
+    // important to follow the `before` and `after` pattern to initialize and clean the stores in tests
+    // so that different test suites can reuse the same backend store for testing
     before(async () => {
       didResolver = new DidResolver([new DidKeyResolver()]);
 
-      // important to follow this pattern to initialize and clean the message and data store in tests
-      // so that different suites can reuse the same block store and index location for testing
-      messageStore = new MessageStoreLevel({
-        blockstoreLocation : 'TEST-MESSAGESTORE',
-        indexLocation      : 'TEST-INDEX'
-      });
-
-      dataStore = new DataStoreLevel({
-        blockstoreLocation: 'TEST-DATASTORE'
-      });
-
-      eventLog = new EventLogLevel({
-        location: 'TEST-EVENTLOG'
-      });
+      const stores = TestStoreInitializer.initializeStores();
+      messageStore = stores.messageStore;
+      dataStore = stores.dataStore;
+      eventLog = stores.eventLog;
 
       dwn = await Dwn.create({ didResolver, messageStore, dataStore, eventLog });
     });

--- a/tests/handlers/permissions-request.spec.ts
+++ b/tests/handlers/permissions-request.spec.ts
@@ -1,44 +1,40 @@
+import type {
+  DataStore,
+  EventLog,
+  MessageStore
+} from '../../src/index.js';
 
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { DataStoreLevel } from '../../src/store/data-store-level.js';
 import { DidKeyResolver } from '../../src/did/did-key-resolver.js';
 import { DidResolver } from '../../src/did/did-resolver.js';
 import { Dwn } from '../../src/dwn.js';
-import { EventLogLevel } from '../../src/event-log/event-log-level.js';
 import { Message } from '../../src/core/message.js';
-import { MessageStoreLevel } from '../../src/store/message-store-level.js';
 import { PermissionsRequest } from '../../src/interfaces/permissions-request.js';
 import { PermissionsRequestHandler } from '../../src/handlers/permissions-request.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
+import { TestStoreInitializer } from '../test-store-initializer.js';
 import { DwnInterfaceName, DwnMethodName } from '../../src/index.js';
 
 describe('PermissionsRequestHandler.handle()', () => {
   let didResolver: DidResolver;
-  let messageStore: MessageStoreLevel;
-  let dataStore: DataStoreLevel;
-  let eventLog: EventLogLevel;
+  let messageStore: MessageStore;
+  let dataStore: DataStore;
+  let eventLog: EventLog;
   let dwn: Dwn;
 
   describe('functional tests', () => {
+
+    // important to follow the `before` and `after` pattern to initialize and clean the stores in tests
+    // so that different test suites can reuse the same backend store for testing
     before(async () => {
       didResolver = new DidResolver([new DidKeyResolver()]);
 
-      // important to follow this pattern to initialize and clean the message and data store in tests
-      // so that different suites can reuse the same block store and index location for testing
-      messageStore = new MessageStoreLevel({
-        blockstoreLocation : 'TEST-MESSAGESTORE',
-        indexLocation      : 'TEST-INDEX'
-      });
-
-      dataStore = new DataStoreLevel({
-        blockstoreLocation: 'TEST-DATASTORE'
-      });
-
-      eventLog = new EventLogLevel({
-        location: 'TEST-EVENTLOG'
-      });
+      const stores = TestStoreInitializer.initializeStores();
+      messageStore = stores.messageStore;
+      dataStore = stores.dataStore;
+      eventLog = stores.eventLog;
 
       dwn = await Dwn.create({ didResolver, messageStore, dataStore, eventLog });
     });

--- a/tests/handlers/protocols-configure.spec.ts
+++ b/tests/handlers/protocols-configure.spec.ts
@@ -1,4 +1,9 @@
 import type { GenerateProtocolsConfigureOutput } from '../utils/test-data-generator.js';
+import type {
+  DataStore,
+  EventLog,
+  MessageStore
+} from '../../src/index.js';
 
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
@@ -7,15 +12,13 @@ import chai, { expect } from 'chai';
 import dexProtocolDefinition from '../vectors/protocol-definitions/dex.json' assert { type: 'json' };
 import minimalProtocolDefinition from '../vectors/protocol-definitions/minimal.json' assert { type: 'json' };
 
-import { DataStoreLevel } from '../../src/store/data-store-level.js';
 import { DidKeyResolver } from '../../src/did/did-key-resolver.js';
-import { EventLogLevel } from '../../src/event-log/event-log-level.js';
 import { GeneralJwsSigner } from '../../src/jose/jws/general/signer.js';
 import { lexicographicalCompare } from '../../src/utils/string.js';
 import { Message } from '../../src/core/message.js';
-import { MessageStoreLevel } from '../../src/store/message-store-level.js';
 import { sleep } from '../../src/utils/time.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
+import { TestStoreInitializer } from '../test-store-initializer.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
 
 import { DidResolver, Dwn, DwnErrorCode, Encoder, Jws } from '../../src/index.js';
@@ -24,29 +27,22 @@ chai.use(chaiAsPromised);
 
 describe('ProtocolsConfigureHandler.handle()', () => {
   let didResolver: DidResolver;
-  let messageStore: MessageStoreLevel;
-  let dataStore: DataStoreLevel;
-  let eventLog: EventLogLevel;
+  let messageStore: MessageStore;
+  let dataStore: DataStore;
+  let eventLog: EventLog;
   let dwn: Dwn;
 
   describe('functional tests', () => {
+
+    // important to follow the `before` and `after` pattern to initialize and clean the stores in tests
+    // so that different test suites can reuse the same backend store for testing
     before(async () => {
       didResolver = new DidResolver([new DidKeyResolver()]);
 
-      // important to follow this pattern to initialize and clean the message and data store in tests
-      // so that different suites can reuse the same block store and index location for testing
-      messageStore = new MessageStoreLevel({
-        blockstoreLocation : 'TEST-MESSAGESTORE',
-        indexLocation      : 'TEST-INDEX'
-      });
-
-      dataStore = new DataStoreLevel({
-        blockstoreLocation: 'TEST-DATASTORE'
-      });
-
-      eventLog = new EventLogLevel({
-        location: 'TEST-EVENTLOG'
-      });
+      const stores = TestStoreInitializer.initializeStores();
+      messageStore = stores.messageStore;
+      dataStore = stores.dataStore;
+      eventLog = stores.eventLog;
 
       dwn = await Dwn.create({ didResolver, messageStore, dataStore, eventLog });
     });

--- a/tests/handlers/protocols-query.spec.ts
+++ b/tests/handlers/protocols-query.spec.ts
@@ -1,14 +1,18 @@
+import type {
+  DataStore,
+  EventLog,
+  MessageStore
+} from '../../src/index.js';
+
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
 
-import { DataStoreLevel } from '../../src/store/data-store-level.js';
 import { DidKeyResolver } from '../../src/did/did-key-resolver.js';
-import { EventLogLevel } from '../../src/event-log/event-log-level.js';
 import { GeneralJwsSigner } from '../../src/jose/jws/general/signer.js';
 import { Message } from '../../src/core/message.js';
-import { MessageStoreLevel } from '../../src/store/message-store-level.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
+import { TestStoreInitializer } from '../test-store-initializer.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
 
 import { DidResolver, Dwn, DwnErrorCode, Encoder, Jws } from '../../src/index.js';
@@ -17,29 +21,22 @@ chai.use(chaiAsPromised);
 
 describe('ProtocolsQueryHandler.handle()', () => {
   let didResolver: DidResolver;
-  let messageStore: MessageStoreLevel;
-  let dataStore: DataStoreLevel;
-  let eventLog: EventLogLevel;
+  let messageStore: MessageStore;
+  let dataStore: DataStore;
+  let eventLog: EventLog;
   let dwn: Dwn;
 
   describe('functional tests', () => {
+
+    // important to follow the `before` and `after` pattern to initialize and clean the stores in tests
+    // so that different test suites can reuse the same backend store for testing
     before(async () => {
       didResolver = new DidResolver([new DidKeyResolver()]);
 
-      // important to follow this pattern to initialize and clean the message and data store in tests
-      // so that different suites can reuse the same block store and index location for testing
-      messageStore = new MessageStoreLevel({
-        blockstoreLocation : 'TEST-MESSAGESTORE',
-        indexLocation      : 'TEST-INDEX'
-      });
-
-      dataStore = new DataStoreLevel({
-        blockstoreLocation: 'TEST-DATASTORE'
-      });
-
-      eventLog = new EventLogLevel({
-        location: 'TEST-EVENTLOG'
-      });
+      const stores = TestStoreInitializer.initializeStores();
+      messageStore = stores.messageStore;
+      dataStore = stores.dataStore;
+      eventLog = stores.eventLog;
 
       dwn = await Dwn.create({ didResolver, messageStore, dataStore, eventLog });
     });

--- a/tests/handlers/records-delete.spec.ts
+++ b/tests/handlers/records-delete.spec.ts
@@ -1,46 +1,43 @@
+import type {
+  DataStore,
+  EventLog,
+  MessageStore
+} from '../../src/index.js';
+
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
 
 import { ArrayUtility } from '../../src/utils/array.js';
-import { Cid } from '../../src/utils/cid.js';
-import { DataStoreLevel } from '../../src/store/data-store-level.js';
 import { DidKeyResolver } from '../../src/did/did-key-resolver.js';
-import { EventLogLevel } from '../../src/event-log/event-log-level.js';
 import { Message } from '../../src/core/message.js';
-import { MessageStoreLevel } from '../../src/store/message-store-level.js';
 import { RecordsDeleteHandler } from '../../src/handlers/records-delete.js';
+import { stubInterface } from 'ts-sinon';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
+import { TestStoreInitializer } from '../test-store-initializer.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
-import { DidResolver, Dwn, Encoder, Jws, RecordsDelete, RecordsWrite } from '../../src/index.js';
+import { DataStream, DidResolver, Dwn, Encoder, Jws, RecordsDelete, RecordsRead, RecordsWrite } from '../../src/index.js';
 
 chai.use(chaiAsPromised);
 
 describe('RecordsDeleteHandler.handle()', () => {
   let didResolver: DidResolver;
-  let messageStore: MessageStoreLevel;
-  let dataStore: DataStoreLevel;
-  let eventLog: EventLogLevel;
+  let messageStore: MessageStore;
+  let dataStore: DataStore;
+  let eventLog: EventLog;
   let dwn: Dwn;
 
   describe('functional tests', () => {
+
+    // important to follow the `before` and `after` pattern to initialize and clean the stores in tests
+    // so that different test suites can reuse the same backend store for testing
     before(async () => {
       didResolver = new DidResolver([new DidKeyResolver()]);
 
-      // important to follow this pattern to initialize and clean the message and data store in tests
-      // so that different suites can reuse the same block store and index location for testing
-      messageStore = new MessageStoreLevel({
-        blockstoreLocation : 'TEST-MESSAGESTORE',
-        indexLocation      : 'TEST-INDEX'
-      });
-
-      dataStore = new DataStoreLevel({
-        blockstoreLocation: 'TEST-DATASTORE'
-      });
-
-      eventLog = new EventLogLevel({
-        location: 'TEST-EVENTLOG'
-      });
+      const stores = TestStoreInitializer.initializeStores();
+      messageStore = stores.messageStore;
+      dataStore = stores.dataStore;
+      eventLog = stores.eventLog;
 
       dwn = await Dwn.create({ didResolver, messageStore, dataStore, eventLog });
     });
@@ -100,6 +97,76 @@ describe('RecordsDeleteHandler.handle()', () => {
       expect(recordsDelete2Reply.status.code).to.equal(404);
     });
 
+    it('should not affect other records or tenants with the same data', async () => {
+      const alice = await DidKeyResolver.generate();
+      const bob = await DidKeyResolver.generate();
+      const data = Encoder.stringToBytes('test');
+
+      // alice writes a records with data
+      const aliceWriteData = await TestDataGenerator.generateRecordsWrite({ author: alice, data });
+      const aliceWriteReply = await dwn.processMessage(alice.did, aliceWriteData.message, aliceWriteData.dataStream);
+      expect(aliceWriteReply.status.code).to.equal(202);
+
+      // alice writes another record with the same data
+      const aliceAssociateData = await TestDataGenerator.generateRecordsWrite({ author: alice, data });
+      const aliceAssociateReply = await dwn.processMessage(alice.did, aliceAssociateData.message, aliceAssociateData.dataStream);
+      expect(aliceAssociateReply.status.code).to.equal(202);
+
+      // bob writes a records with same data
+      const bobWriteData = await TestDataGenerator.generateRecordsWrite({ author: bob, data });
+      const bobWriteReply = await dwn.processMessage(bob.did, bobWriteData.message, bobWriteData.dataStream);
+      expect(bobWriteReply.status.code).to.equal(202);
+
+      // bob writes another record with the same data
+      const bobAssociateData = await TestDataGenerator.generateRecordsWrite({ author: bob, data });
+      const bobAssociateReply = await dwn.processMessage(bob.did, bobAssociateData.message, bobAssociateData.dataStream);
+      expect(bobAssociateReply.status.code).to.equal(202);
+
+      // alice deletes one of the two records
+      const aliceDeleteWriteData = await TestDataGenerator.generateRecordsDelete({
+        author   : alice,
+        recordId : aliceWriteData.message.recordId
+      });
+      const aliceDeleteWriteReply = await dwn.processMessage(alice.did, aliceDeleteWriteData.message);
+      expect(aliceDeleteWriteReply.status.code).to.equal(202);
+
+      // verify the other record with the same data is unaffected
+      const aliceRead1 = await RecordsRead.create({
+        recordId                    : aliceAssociateData.message.recordId,
+        authorizationSignatureInput : Jws.createSignatureInput(alice)
+      });
+
+      const aliceRead1Reply = await dwn.handleRecordsRead(alice.did, aliceRead1.message);
+      expect(aliceRead1Reply.status.code).to.equal(200);
+
+      const aliceDataFetched = await DataStream.toBytes(aliceRead1Reply.record!.data!);
+      expect(ArrayUtility.byteArraysEqual(aliceDataFetched, data)).to.be.true;
+
+      // alice deletes the other record
+      const aliceDeleteAssociateData = await TestDataGenerator.generateRecordsDelete({
+        author   : alice,
+        recordId : aliceAssociateData.message.recordId
+      });
+      const aliceDeleteAssociateReply = await dwn.processMessage(alice.did, aliceDeleteAssociateData.message);
+      expect(aliceDeleteAssociateReply.status.code).to.equal(202);
+
+      // verify that alice can no longer fetch the 2nd record
+      const aliceRead2Reply = await dwn.handleRecordsRead(alice.did, aliceRead1.message);
+      expect(aliceRead2Reply.status.code).to.equal(404);
+
+      // verify that bob can still fetch record with the same data
+      const bobRead1 = await RecordsRead.create({
+        recordId                    : bobAssociateData.message.recordId,
+        authorizationSignatureInput : Jws.createSignatureInput(bob)
+      });
+
+      const bobRead1Reply = await dwn.handleRecordsRead(bob.did, bobRead1.message);
+      expect(bobRead1Reply.status.code).to.equal(200);
+
+      const bobDataFetched = await DataStream.toBytes(bobRead1Reply.record!.data!);
+      expect(ArrayUtility.byteArraysEqual(bobDataFetched, data)).to.be.true;
+    });
+
     it('should return 404 if deleting a non-existent record', async () => {
       const alice = await DidKeyResolver.generate();
 
@@ -155,12 +222,7 @@ describe('RecordsDeleteHandler.handle()', () => {
     it('should be able to delete then rewrite the same data', async () => {
       const alice = await DidKeyResolver.generate();
       const data = Encoder.stringToBytes('test');
-      const dataCid = await Cid.computeDagPbCidFromBytes(data);
       const encodedData = Encoder.bytesToBase64Url(data);
-
-      const blockstoreForData = await dataStore.blockstore.partition('data');
-      const blockstoreOfAlice = await blockstoreForData.partition(alice.did);
-      const blockstoreOfAliceOfDataCid = await blockstoreOfAlice.partition(dataCid);
 
       // alice writes a record
       const aliceWriteData = await TestDataGenerator.generateRecordsWrite({
@@ -179,8 +241,6 @@ describe('RecordsDeleteHandler.handle()', () => {
       expect(aliceQueryWriteAfterAliceWriteReply.entries?.length).to.equal(1);
       expect(aliceQueryWriteAfterAliceWriteReply.entries![0].encodedData).to.equal(encodedData);
 
-      await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfAliceOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
-
       // alice deleting the record
       const aliceDeleteWriteData = await TestDataGenerator.generateRecordsDelete({
         author   : alice,
@@ -196,8 +256,6 @@ describe('RecordsDeleteHandler.handle()', () => {
       const aliceQueryWriteAfterAliceDeleteReply = await dwn.processMessage(alice.did, aliceQueryWriteAfterAliceDeleteData.message);
       expect(aliceQueryWriteAfterAliceDeleteReply.status.code).to.equal(200);
       expect(aliceQueryWriteAfterAliceDeleteReply.entries?.length).to.equal(0);
-
-      await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfAliceOfDataCid.db.keys())).to.eventually.eql([ ]);
 
       // alice writes a new record with the same data
       const aliceRewriteData = await TestDataGenerator.generateRecordsWrite({
@@ -215,72 +273,6 @@ describe('RecordsDeleteHandler.handle()', () => {
       expect(aliceQueryWriteAfterAliceRewriteReply.status.code).to.equal(200);
       expect(aliceQueryWriteAfterAliceRewriteReply.entries?.length).to.equal(1);
       expect(aliceQueryWriteAfterAliceRewriteReply.entries![0].encodedData).to.equal(encodedData);
-
-      await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfAliceOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
-    });
-
-    it('should only delete data after all messages referencing it are deleted', async () => {
-      const alice = await DidKeyResolver.generate();
-      const bob = await DidKeyResolver.generate();
-      const data = Encoder.stringToBytes('test');
-      const dataCid = await Cid.computeDagPbCidFromBytes(data);
-
-      const blockstoreForData = await dataStore.blockstore.partition('data');
-      const blockstoreOfAlice = await blockstoreForData.partition(alice.did);
-      const blockstoreOfAliceOfDataCid = await blockstoreOfAlice.partition(dataCid);
-
-      const blockstoreOfBob = await blockstoreForData.partition(bob.did);
-      const blockstoreOfBobOfDataCid = await blockstoreOfBob.partition(dataCid);
-
-      // alice writes a records with data
-      const aliceWriteData = await TestDataGenerator.generateRecordsWrite({ author: alice, data });
-      const aliceWriteReply = await dwn.processMessage(alice.did, aliceWriteData.message, aliceWriteData.dataStream);
-      expect(aliceWriteReply.status.code).to.equal(202);
-
-      await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfAliceOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
-
-      // alice writes another record with the same data
-      const aliceAssociateData = await TestDataGenerator.generateRecordsWrite({ author: alice, data });
-      const aliceAssociateReply = await dwn.processMessage(alice.did, aliceAssociateData.message, aliceAssociateData.dataStream);
-      expect(aliceAssociateReply.status.code).to.equal(202);
-
-      await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfAliceOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
-
-      // bob writes a records with same data
-      const bobWriteData = await TestDataGenerator.generateRecordsWrite({ author: bob, data });
-      const bobWriteReply = await dwn.processMessage(bob.did, bobWriteData.message, bobWriteData.dataStream);
-      expect(bobWriteReply.status.code).to.equal(202);
-
-      await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfBobOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
-
-      // bob writes another record with the same data
-      const bobAssociateData = await TestDataGenerator.generateRecordsWrite({ author: bob, data });
-      const bobAssociateReply = await dwn.processMessage(bob.did, bobAssociateData.message, bobAssociateData.dataStream);
-      expect(bobAssociateReply.status.code).to.equal(202);
-
-      await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfBobOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
-
-      // alice deletes one of the two records
-      const aliceDeleteWriteData = await TestDataGenerator.generateRecordsDelete({
-        author   : alice,
-        recordId : aliceWriteData.message.recordId
-      });
-      const aliceDeleteWriteReply = await dwn.processMessage(alice.did, aliceDeleteWriteData.message);
-      expect(aliceDeleteWriteReply.status.code).to.equal(202);
-
-      await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfAliceOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
-
-      // alice deletes the other record
-      const aliceDeleteAssociateData = await TestDataGenerator.generateRecordsDelete({
-        author   : alice,
-        recordId : aliceAssociateData.message.recordId
-      });
-      const aliceDeleteAssociateReply = await dwn.processMessage(alice.did, aliceDeleteAssociateData.message);
-      expect(aliceDeleteAssociateReply.status.code).to.equal(202);
-
-      // verify that data is deleted in alice's blockstore, but remains in bob's blockstore
-      await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfAliceOfDataCid.db.keys())).to.eventually.eql([ ]);
-      await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfBobOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
     });
 
     describe('event log', () => {
@@ -359,8 +351,8 @@ describe('RecordsDeleteHandler.handle()', () => {
     // intentionally not supplying the public key so a different public key is generated to simulate invalid signature
     const mismatchingPersona = await TestDataGenerator.generatePersona({ did: author.did, keyId: author.keyId });
     const didResolver = TestStubGenerator.createDidResolverStub(mismatchingPersona);
-    const messageStore = sinon.createStubInstance(MessageStoreLevel);
-    const dataStore = sinon.createStubInstance(DataStoreLevel);
+    const messageStore = stubInterface<MessageStore>();
+    const dataStore = stubInterface<DataStore>();
 
     const recordsDeleteHandler = new RecordsDeleteHandler(didResolver, messageStore, dataStore, eventLog);
     const reply = await recordsDeleteHandler.handle({ tenant, message });
@@ -372,8 +364,8 @@ describe('RecordsDeleteHandler.handle()', () => {
     const tenant = author.did;
 
     // setting up a stub method resolver & message store
-    const messageStore = sinon.createStubInstance(MessageStoreLevel);
-    const dataStore = sinon.createStubInstance(DataStoreLevel);
+    const messageStore = stubInterface<MessageStore>();
+    const dataStore = stubInterface<DataStore>();
 
     const recordsDeleteHandler = new RecordsDeleteHandler(didResolver, messageStore, dataStore, eventLog);
 

--- a/tests/handlers/records-query.spec.ts
+++ b/tests/handlers/records-query.spec.ts
@@ -1,3 +1,4 @@
+import type { DataStore, EventLog, MessageStore } from '../../src/index.js';
 import type { DerivedPrivateJwk, EncryptionInput, RecordsWriteMessage } from '../../src/index.js';
 import type { RecordsQueryReplyEntry, RecordsWriteDescriptor } from '../../src/types/records-types.js';
 
@@ -7,18 +8,17 @@ import sinon from 'sinon';
 import chai, { expect } from 'chai';
 
 import { ArrayUtility } from '../../src/utils/array.js';
-import { DataStoreLevel } from '../../src/store/data-store-level.js';
 import { DidKeyResolver } from '../../src/did/did-key-resolver.js';
 import { DwnConstant } from '../../src/core/dwn-constant.js';
 import { DwnErrorCode } from '../../src/index.js';
 import { Encoder } from '../../src/utils/encoder.js';
 import { Encryption } from '../../src/index.js';
-import { EventLogLevel } from '../../src/event-log/event-log-level.js';
 import { Jws } from '../../src/utils/jws.js';
 import { Message } from '../../src/core/message.js';
-import { MessageStoreLevel } from '../../src/store/message-store-level.js';
 import { RecordsQueryHandler } from '../../src/handlers/records-query.js';
+import { stubInterface } from 'ts-sinon';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
+import { TestStoreInitializer } from '../test-store-initializer.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
 import { toTemporalInstant } from '@js-temporal/polyfill';
 
@@ -35,28 +35,20 @@ function createDateString(d: Date): string {
 describe('RecordsQueryHandler.handle()', () => {
   describe('functional tests', () => {
     let didResolver: DidResolver;
-    let messageStore: MessageStoreLevel;
-    let dataStore: DataStoreLevel;
-    let eventLog: EventLogLevel;
+    let messageStore: MessageStore;
+    let dataStore: DataStore;
+    let eventLog: EventLog;
     let dwn: Dwn;
 
+    // important to follow the `before` and `after` pattern to initialize and clean the stores in tests
+    // so that different test suites can reuse the same backend store for testing
     before(async () => {
       didResolver = new DidResolver([new DidKeyResolver()]);
 
-      // important to follow this pattern to initialize and clean the message and data store in tests
-      // so that different suites can reuse the same block store and index location for testing
-      messageStore = new MessageStoreLevel({
-        blockstoreLocation : 'TEST-MESSAGESTORE',
-        indexLocation      : 'TEST-INDEX'
-      });
-
-      dataStore = new DataStoreLevel({
-        blockstoreLocation: 'TEST-DATASTORE'
-      });
-
-      eventLog = new EventLogLevel({
-        location: 'TEST-EVENTLOG'
-      });
+      const stores = TestStoreInitializer.initializeStores();
+      messageStore = stores.messageStore;
+      dataStore = stores.dataStore;
+      eventLog = stores.eventLog;
 
       dwn = await Dwn.create({ didResolver, messageStore, dataStore, eventLog });
     });
@@ -877,8 +869,8 @@ describe('RecordsQueryHandler.handle()', () => {
     // intentionally not supplying the public key so a different public key is generated to simulate invalid signature
     const mismatchingPersona = await TestDataGenerator.generatePersona({ did: author!.did, keyId: author!.keyId });
     const didResolver = TestStubGenerator.createDidResolverStub(mismatchingPersona);
-    const messageStore = sinon.createStubInstance(MessageStoreLevel);
-    const dataStore = sinon.createStubInstance(DataStoreLevel);
+    const messageStore = stubInterface<MessageStore>();
+    const dataStore = stubInterface<DataStore>();
 
     const recordsQueryHandler = new RecordsQueryHandler(didResolver, messageStore, dataStore);
     const reply = await recordsQueryHandler.handle({ tenant, message });
@@ -892,8 +884,8 @@ describe('RecordsQueryHandler.handle()', () => {
 
     // setting up a stub method resolver & message store
     const didResolver = TestStubGenerator.createDidResolverStub(author!);
-    const messageStore = sinon.createStubInstance(MessageStoreLevel);
-    const dataStore = sinon.createStubInstance(DataStoreLevel);
+    const messageStore = stubInterface<MessageStore>();
+    const dataStore = stubInterface<DataStore>();
     const recordsQueryHandler = new RecordsQueryHandler(didResolver, messageStore, dataStore);
 
     // stub the `parse()` function to throw an error

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -2,6 +2,7 @@ import type { EncryptionInput } from '../../src/interfaces/records-write.js';
 import type { GenerateFromRecordsWriteOut } from '../utils/test-data-generator.js';
 import type { QueryResultEntry } from '../../src/types/message-types.js';
 import type { RecordsWriteMessage } from '../../src/types/records-types.js';
+import type { DataStore, EventLog, MessageStore } from '../../src/index.js';
 
 import chaiAsPromised from 'chai-as-promised';
 import credentialIssuanceProtocolDefinition from '../vectors/protocol-definitions/credential-issuance.json' assert { type: 'json' };
@@ -16,25 +17,24 @@ import chai, { expect } from 'chai';
 import { ArrayUtility } from '../../src/utils/array.js';
 import { base64url } from 'multiformats/bases/base64';
 import { Cid } from '../../src/utils/cid.js';
-import { DataStoreLevel } from '../../src/store/data-store-level.js';
 import { DataStream } from '../../src/utils/data-stream.js';
 import { DidKeyResolver } from '../../src/did/did-key-resolver.js';
 import { DidResolver } from '../../src/did/did-resolver.js';
 import { Dwn } from '../../src/dwn.js';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
 import { Encoder } from '../../src/utils/encoder.js';
-import { EventLogLevel } from '../../src/event-log/event-log-level.js';
 import { GeneralJwsSigner } from '../../src/jose/jws/general/signer.js';
 import { getCurrentTimeInHighPrecision } from '../../src/utils/time.js';
 import { Jws } from '../../src/utils/jws.js';
 import { KeyDerivationScheme } from '../../src/index.js';
 import { Message } from '../../src/core/message.js';
-import { MessageStoreLevel } from '../../src/store/message-store-level.js';
 import { ProtocolActor } from '../../src/types/protocols-types.js';
 import { RecordsRead } from '../../src/interfaces/records-read.js';
 import { RecordsWrite } from '../../src/interfaces/records-write.js';
 import { RecordsWriteHandler } from '../../src/handlers/records-write.js';
+import { stubInterface } from 'ts-sinon';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
+import { TestStoreInitializer } from '../test-store-initializer.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
 
 import { Encryption, EncryptionAlgorithm } from '../../src/utils/encryption.js';
@@ -43,29 +43,22 @@ chai.use(chaiAsPromised);
 
 describe('RecordsWriteHandler.handle()', () => {
   let didResolver: DidResolver;
-  let messageStore: MessageStoreLevel;
-  let dataStore: DataStoreLevel;
-  let eventLog: EventLogLevel;
+  let messageStore: MessageStore;
+  let dataStore: DataStore;
+  let eventLog: EventLog;
   let dwn: Dwn;
 
   describe('functional tests', () => {
+
+    // important to follow the `before` and `after` pattern to initialize and clean the stores in tests
+    // so that different test suites can reuse the same backend store for testing
     before(async () => {
       didResolver = new DidResolver([new DidKeyResolver()]);
 
-      // important to follow this pattern to initialize and clean the message and data store in tests
-      // so that different suites can reuse the same block store and index location for testing
-      messageStore = new MessageStoreLevel({
-        blockstoreLocation : 'TEST-MESSAGESTORE',
-        indexLocation      : 'TEST-INDEX'
-      });
-
-      dataStore = new DataStoreLevel({
-        blockstoreLocation: 'TEST-DATASTORE'
-      });
-
-      eventLog = new EventLogLevel({
-        location: 'TEST-EVENTLOG'
-      });
+      const stores = TestStoreInitializer.initializeStores();
+      messageStore = stores.messageStore;
+      dataStore = stores.dataStore;
+      eventLog = stores.eventLog;
 
       dwn = await Dwn.create({ didResolver, messageStore, dataStore, eventLog });
     });
@@ -379,12 +372,10 @@ describe('RecordsWriteHandler.handle()', () => {
     describe('initial write & subsequent write tests', () => {
       describe('createFrom()', () => {
         it('should accept a published RecordsWrite using createFrom() without specifying `data` or `datePublished`', async () => {
-          const dataForCid = await dataStore.blockstore.partition('data');
-
           const data = Encoder.stringToBytes('test');
-          const dataCid = await Cid.computeDagPbCidFromBytes(data);
           const encodedData = Encoder.bytesToBase64Url(data);
 
+          // new record
           const { message, author, recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({
             published: false,
             data,
@@ -397,8 +388,7 @@ describe('RecordsWriteHandler.handle()', () => {
           const reply = await dwn.processMessage(tenant, message, dataStream);
           expect(reply.status.code).to.equal(202);
 
-          expect(ArrayUtility.fromAsyncGenerator(dataForCid.db.keys())).to.eventually.eql([ dataCid ]);
-
+          // changing the `published` property
           const newWrite = await RecordsWrite.createFrom({
             unsignedRecordsWriteMessage : recordsWrite.message,
             published                   : true,
@@ -407,8 +397,6 @@ describe('RecordsWriteHandler.handle()', () => {
 
           const newWriteReply = await dwn.processMessage(tenant, newWrite.message);
           expect(newWriteReply.status.code).to.equal(202);
-
-          expect(ArrayUtility.fromAsyncGenerator(dataForCid.db.keys())).to.eventually.eql([ dataCid ]);
 
           // verify the new record state can be queried
           const recordsQueryMessageData = await TestDataGenerator.generateRecordsQuery({
@@ -423,8 +411,6 @@ describe('RecordsWriteHandler.handle()', () => {
 
           // very importantly verify the original data is still returned
           expect(recordsQueryReply.entries![0].encodedData).to.equal(encodedData);
-
-          expect(ArrayUtility.fromAsyncGenerator(dataForCid.db.keys())).to.eventually.eql([ dataCid ]);
         });
 
         it('should inherit parent published state when using createFrom() to create RecordsWrite', async () => {
@@ -1584,8 +1570,6 @@ describe('RecordsWriteHandler.handle()', () => {
         const alice = await DidKeyResolver.generate();
         const bob = await DidKeyResolver.generate();
 
-        const dataForCid = await dataStore.blockstore.partition('data');
-
         // alice writes a private record
         const dataString = 'private data';
         const dataSize = dataString.length;
@@ -1599,8 +1583,6 @@ describe('RecordsWriteHandler.handle()', () => {
 
         const reply = await dwn.processMessage(alice.did, message, dataStream);
         expect(reply.status.code).to.equal(202);
-
-        expect(ArrayUtility.fromAsyncGenerator(dataForCid.db.keys())).to.eventually.eql([ dataCid ]);
 
         const protocolDefinition = socialMediaProtocolDefinition;
         const protocol = protocolDefinition.protocol;
@@ -1668,138 +1650,12 @@ describe('RecordsWriteHandler.handle()', () => {
     });
 
     describe('reference counting tests', () => {
-      it('should only write the data once even if written by multiple messages', async () => {
-        const alice = await DidKeyResolver.generate();
-        const data = Encoder.stringToBytes('test');
-        const dataCid = await Cid.computeDagPbCidFromBytes(data);
-        const encodedData = Encoder.bytesToBase64Url(data);
-
-        const blockstoreForData = await dataStore.blockstore.partition('data');
-        const blockstoreOfGivenTenant = await blockstoreForData.partition(alice.did);
-        const blockstoreOfGivenDataCid = await blockstoreOfGivenTenant.partition(dataCid);
-
-        const aliceWrite1Data = await TestDataGenerator.generateRecordsWrite({
-          author: alice,
-          data
-        });
-        const aliceWrite1Reply = await dwn.processMessage(alice.did, aliceWrite1Data.message, aliceWrite1Data.dataStream);
-        expect(aliceWrite1Reply.status.code).to.equal(202);
-
-        const aliceQueryWrite1AfterAliceWrite1Data = await TestDataGenerator.generateRecordsQuery({
-          author : alice,
-          filter : { recordId: aliceWrite1Data.message.recordId }
-        });
-        const aliceQueryWrite1AfterAliceWrite1Reply = await dwn.processMessage(alice.did, aliceQueryWrite1AfterAliceWrite1Data.message);
-        expect(aliceQueryWrite1AfterAliceWrite1Reply.status.code).to.equal(200);
-        expect(aliceQueryWrite1AfterAliceWrite1Reply.entries?.length).to.equal(1);
-        expect(aliceQueryWrite1AfterAliceWrite1Reply.entries![0].encodedData).to.equal(encodedData);
-
-        await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfGivenDataCid.db.keys())).to.eventually.eql([ dataCid ]);
-
-        const aliceWrite2Data = await TestDataGenerator.generateRecordsWrite({
-          author: alice,
-          data
-        });
-        const aliceWrite2Reply = await dwn.processMessage(alice.did, aliceWrite2Data.message, aliceWrite2Data.dataStream);
-        expect(aliceWrite2Reply.status.code).to.equal(202);
-
-        const aliceQueryWrite1AfterAliceWrite2Data = await TestDataGenerator.generateRecordsQuery({
-          author : alice,
-          filter : { recordId: aliceWrite1Data.message.recordId }
-        });
-        const aliceQueryWrite1AfterAliceWrite2Reply = await dwn.processMessage(alice.did, aliceQueryWrite1AfterAliceWrite2Data.message);
-        expect(aliceQueryWrite1AfterAliceWrite2Reply.status.code).to.equal(200);
-        expect(aliceQueryWrite1AfterAliceWrite2Reply.entries?.length).to.equal(1);
-        expect(aliceQueryWrite1AfterAliceWrite2Reply.entries![0].encodedData).to.equal(encodedData);
-
-        const aliceQueryWrite2AfterAliceWrite2Data = await TestDataGenerator.generateRecordsQuery({
-          author : alice,
-          filter : { recordId: aliceWrite2Data.message.recordId }
-        });
-        const aliceQueryWrite2AfterAliceWrite2Reply = await dwn.processMessage(alice.did, aliceQueryWrite2AfterAliceWrite2Data.message);
-        expect(aliceQueryWrite2AfterAliceWrite2Reply.status.code).to.equal(200);
-        expect(aliceQueryWrite2AfterAliceWrite2Reply.entries?.length).to.equal(1);
-        expect(aliceQueryWrite2AfterAliceWrite2Reply.entries![0].encodedData).to.equal(encodedData);
-
-        await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfGivenDataCid.db.keys())).to.eventually.eql([ dataCid ]);
-      });
-
-      it('should duplicate same data if written to different tenants', async () => {
-        const alice = await DidKeyResolver.generate();
-        const bob = await DidKeyResolver.generate();
-
-        const data = Encoder.stringToBytes('test');
-        const dataCid = await Cid.computeDagPbCidFromBytes(data);
-        const encodedData = Encoder.bytesToBase64Url(data);
-
-        const blockstoreForData = await dataStore.blockstore.partition('data');
-        const blockstoreOfAlice = await blockstoreForData.partition(alice.did);
-        const blockstoreOfAliceOfDataCid = await blockstoreOfAlice.partition(dataCid);
-
-        const blockstoreOfBob = await blockstoreForData.partition(bob.did);
-        const blockstoreOfBobOfDataCid = await blockstoreOfBob.partition(dataCid);
-
-        // write data to alice's DWN
-        const aliceWriteData = await TestDataGenerator.generateRecordsWrite({
-          author: alice,
-          data
-        });
-        const aliceWriteReply = await dwn.processMessage(alice.did, aliceWriteData.message, aliceWriteData.dataStream);
-        expect(aliceWriteReply.status.code).to.equal(202);
-
-        const aliceQueryWriteAfterAliceWriteData = await TestDataGenerator.generateRecordsQuery({
-          author : alice,
-          filter : { recordId: aliceWriteData.message.recordId }
-        });
-        const aliceQueryWriteAfterAliceWriteReply = await dwn.processMessage(alice.did, aliceQueryWriteAfterAliceWriteData.message);
-        expect(aliceQueryWriteAfterAliceWriteReply.status.code).to.equal(200);
-        expect(aliceQueryWriteAfterAliceWriteReply.entries?.length).to.equal(1);
-        expect(aliceQueryWriteAfterAliceWriteReply.entries![0].encodedData).to.equal(encodedData);
-
-        // write same data to bob's DWN
-        const bobWriteData = await TestDataGenerator.generateRecordsWrite({
-          author: bob,
-          data
-        });
-        const bobWriteReply = await dwn.processMessage(bob.did, bobWriteData.message, bobWriteData.dataStream);
-        expect(bobWriteReply.status.code).to.equal(202);
-
-        const aliceQueryWriteAfterBobWriteData = await TestDataGenerator.generateRecordsQuery({
-          author : alice,
-          filter : { recordId: aliceWriteData.message.recordId }
-        });
-        const aliceQueryWriteAfterBobWriteReply = await dwn.processMessage(alice.did, aliceQueryWriteAfterBobWriteData.message);
-        expect(aliceQueryWriteAfterBobWriteReply.status.code).to.equal(200);
-        expect(aliceQueryWriteAfterBobWriteReply.entries?.length).to.equal(1);
-        expect(aliceQueryWriteAfterBobWriteReply.entries![0].encodedData).to.equal(encodedData);
-
-        const bobQueryWriteAfterBobWriteData = await TestDataGenerator.generateRecordsQuery({
-          author : bob,
-          filter : { recordId: bobWriteData.message.recordId }
-        });
-        const bobQueryWriteAfterBobWriteReply = await dwn.processMessage(bob.did, bobQueryWriteAfterBobWriteData.message);
-        expect(bobQueryWriteAfterBobWriteReply.status.code).to.equal(200);
-        expect(bobQueryWriteAfterBobWriteReply.entries?.length).to.equal(1);
-        expect(bobQueryWriteAfterBobWriteReply.entries![0].encodedData).to.equal(encodedData);
-
-        // verify that both alice and bob's blockstore have reference to the same data CID
-        await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfAliceOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
-        await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfBobOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
-      });
-
       it('should not allow referencing data across tenants', async () => {
         const alice = await DidKeyResolver.generate();
         const bob = await DidKeyResolver.generate();
         const data = Encoder.stringToBytes('test');
         const dataCid = await Cid.computeDagPbCidFromBytes(data);
         const encodedData = Encoder.bytesToBase64Url(data);
-
-        const blockstoreForData = await dataStore.blockstore.partition('data');
-        const blockstoreOfAlice = await blockstoreForData.partition(alice.did);
-        const blockstoreOfAliceOfDataCid = await blockstoreOfAlice.partition(dataCid);
-
-        const blockstoreOfBob = await blockstoreForData.partition(bob.did);
-        const blockstoreOfBobOfDataCid = await blockstoreOfBob.partition(dataCid);
 
         // alice writes data to her DWN
         const aliceWriteData = await TestDataGenerator.generateRecordsWrite({
@@ -1817,8 +1673,6 @@ describe('RecordsWriteHandler.handle()', () => {
         expect(aliceQueryWriteAfterAliceWriteReply.status.code).to.equal(200);
         expect(aliceQueryWriteAfterAliceWriteReply.entries?.length).to.equal(1);
         expect(aliceQueryWriteAfterAliceWriteReply.entries![0].encodedData).to.equal(encodedData);
-
-        await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfAliceOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
 
         // bob learns of the CID of data of alice and tries to gain unauthorized access by referencing it in his own DWN
         const bobAssociateData = await TestDataGenerator.generateRecordsWrite({
@@ -1847,10 +1701,6 @@ describe('RecordsWriteHandler.handle()', () => {
         const bobQueryAssociateAfterBobAssociateReply = await dwn.processMessage(bob.did, bobQueryAssociateAfterBobAssociateData.message);
         expect(bobQueryAssociateAfterBobAssociateReply.status.code).to.equal(200);
         expect(bobQueryAssociateAfterBobAssociateReply.entries?.length).to.equal(0);
-
-        // verify that bob's blockstore does not contain alice's data
-        await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfAliceOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
-        await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfBobOfDataCid.db.keys())).to.eventually.eql([ ]);
       });
     });
   });
@@ -1869,8 +1719,8 @@ describe('RecordsWriteHandler.handle()', () => {
 
       const tenant = author.did;
       const didResolver = TestStubGenerator.createDidResolverStub(author);
-      const messageStore = sinon.createStubInstance(MessageStoreLevel);
-      const dataStore = sinon.createStubInstance(DataStoreLevel);
+      const messageStore = stubInterface<MessageStore>();
+      const dataStore = stubInterface<DataStore>();
 
       const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStore, dataStore, eventLog);
       const reply = await recordsWriteHandler.handle({ tenant, message, dataStream: dataStream! });
@@ -1893,8 +1743,8 @@ describe('RecordsWriteHandler.handle()', () => {
 
       const tenant = author.did;
       const didResolver = sinon.createStubInstance(DidResolver);
-      const messageStore = sinon.createStubInstance(MessageStoreLevel);
-      const dataStore = sinon.createStubInstance(DataStoreLevel);
+      const messageStore = stubInterface<MessageStore>();
+      const dataStore = stubInterface<DataStore>();
 
       const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStore, dataStore, eventLog);
       const reply = await recordsWriteHandler.handle({ tenant, message, dataStream: dataStream! });
@@ -1911,8 +1761,8 @@ describe('RecordsWriteHandler.handle()', () => {
       // intentionally not supplying the public key so a different public key is generated to simulate invalid signature
       const mismatchingPersona = await TestDataGenerator.generatePersona({ did: author.did, keyId: author.keyId });
       const didResolver = TestStubGenerator.createDidResolverStub(mismatchingPersona);
-      const messageStore = sinon.createStubInstance(MessageStoreLevel);
-      const dataStore = sinon.createStubInstance(DataStoreLevel);
+      const messageStore = stubInterface<MessageStore>();
+      const dataStore = stubInterface<DataStore>();
 
       const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStore, dataStore, eventLog);
       const reply = await recordsWriteHandler.handle({ tenant, message, dataStream: dataStream! });
@@ -1926,8 +1776,8 @@ describe('RecordsWriteHandler.handle()', () => {
 
       // setting up a stub DID resolver & message store
       const didResolver = TestStubGenerator.createDidResolverStub(author);
-      const messageStore = sinon.createStubInstance(MessageStoreLevel);
-      const dataStore = sinon.createStubInstance(DataStoreLevel);
+      const messageStore = stubInterface<MessageStore>();
+      const dataStore = stubInterface<DataStore>();
 
       const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStore, dataStore, eventLog);
 
@@ -1959,8 +1809,8 @@ describe('RecordsWriteHandler.handle()', () => {
       message.authorization = authorizationSigner.getJws();
 
       const didResolver = TestStubGenerator.createDidResolverStub(author);
-      const messageStore = sinon.createStubInstance(MessageStoreLevel);
-      const dataStore = sinon.createStubInstance(DataStoreLevel);
+      const messageStore = stubInterface<MessageStore>();
+      const dataStore = stubInterface<DataStore>();
 
       const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStore, dataStore, eventLog);
       const reply = await recordsWriteHandler.handle({ tenant, message, dataStream: dataStream! });
@@ -2020,10 +1870,10 @@ describe('RecordsWriteHandler.handle()', () => {
 
     const didResolverStub = TestStubGenerator.createDidResolverStub(author);
 
-    const messageStoreStub = sinon.createStubInstance(MessageStoreLevel);
+    const messageStoreStub = stubInterface<MessageStore>();
     messageStoreStub.query.resolves([]);
 
-    const dataStoreStub = sinon.createStubInstance(DataStoreLevel);
+    const dataStoreStub = stubInterface<DataStore>();
 
     const recordsWriteHandler = new RecordsWriteHandler(didResolverStub, messageStoreStub, dataStoreStub, eventLog);
 

--- a/tests/interfaces/records-write.spec.ts
+++ b/tests/interfaces/records-write.spec.ts
@@ -1,13 +1,13 @@
 import type { EncryptionInput } from '../../src/interfaces/records-write.js';
+import type { MessageStore } from '../../src/types/message-store.js';
 import type { RecordsWriteMessage } from '../../src/types/records-types.js';
 
 import chaiAsPromised from 'chai-as-promised';
-import sinon from 'sinon';
 import chai, { expect } from 'chai';
 
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
-import { MessageStoreLevel } from '../../src/store/message-store-level.js';
 import { RecordsWrite } from '../../src/interfaces/records-write.js';
+import { stubInterface } from 'ts-sinon';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { getCurrentTimeInHighPrecision, sleep } from '../../src/utils/time.js';
 import { Jws, KeyDerivationScheme } from '../../src/index.js';
@@ -37,7 +37,7 @@ describe('RecordsWrite', () => {
       expect(message.descriptor.dateCreated).to.equal(options.dateCreated);
       expect(message.recordId).to.equal(options.recordId);
 
-      const messageStoreStub = sinon.createStubInstance(MessageStoreLevel);
+      const messageStoreStub = stubInterface<MessageStore>();
 
       await recordsWrite.authorize(alice.did, messageStoreStub);
     });

--- a/tests/store/data-store-level.spec.ts
+++ b/tests/store/data-store-level.spec.ts
@@ -11,7 +11,7 @@ chai.use(chaiAsPromised);
 
 let store: DataStoreLevel;
 
-describe('DataStore Test Suite', () => {
+describe('DataStoreLevel Test Suite', () => {
   before(async () => {
     store = new DataStoreLevel({ blockstoreLocation: 'TEST-DATASTORE' });
     await store.open();
@@ -49,6 +49,35 @@ describe('DataStore Test Suite', () => {
 
         dataSizeInBytes *= 10;
       }
+    });
+
+    it('should duplicate same data if written to different tenants', async () => {
+      const alice = await TestDataGenerator.randomCborSha256Cid();
+      const bob = await TestDataGenerator.randomCborSha256Cid();
+
+      const dataBytes = TestDataGenerator.randomBytes(100);
+      const dataCid = await Cid.computeDagPbCidFromBytes(dataBytes);
+
+      const blockstoreForData = await store.blockstore.partition('data');
+      const blockstoreOfAlice = await blockstoreForData.partition(alice);
+      const blockstoreOfAliceOfDataCid = await blockstoreOfAlice.partition(dataCid);
+
+      const blockstoreOfBob = await blockstoreForData.partition(bob);
+      const blockstoreOfBobOfDataCid = await blockstoreOfBob.partition(dataCid);
+
+      // write data to alice's DWN
+      const dataStream1 = DataStream.fromBytes(dataBytes);
+      const messageCid1 = await TestDataGenerator.randomCborSha256Cid();
+      await store.put(alice, messageCid1, dataCid, dataStream1);
+
+      // write same data to bob's DWN
+      const dataStream2 = DataStream.fromBytes(dataBytes);
+      const messageCid2 = await TestDataGenerator.randomCborSha256Cid();
+      await store.put(bob, messageCid2, dataCid, dataStream2);
+
+      // verify that both alice and bob's blockstore have their own reference to data CID
+      await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfAliceOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
+      await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfBobOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
     });
   });
 
@@ -159,6 +188,56 @@ describe('DataStore Test Suite', () => {
 
       const keysAfterDelete = await ArrayUtility.fromAsyncGenerator(store.blockstore.db.keys());
       expect(keysAfterDelete.length).to.equal(0);
+    });
+
+    it('should only delete data after all messages referencing it are deleted', async () => {
+      const alice = await TestDataGenerator.randomCborSha256Cid();
+      const bob = await TestDataGenerator.randomCborSha256Cid();
+
+      const dataBytes = TestDataGenerator.randomBytes(100);
+      const dataCid = await Cid.computeDagPbCidFromBytes(dataBytes);
+
+      const blockstoreForData = await store.blockstore.partition('data');
+      const blockstoreOfAlice = await blockstoreForData.partition(alice);
+      const blockstoreOfAliceOfDataCid = await blockstoreOfAlice.partition(dataCid);
+
+      const blockstoreOfBob = await blockstoreForData.partition(bob);
+      const blockstoreOfBobOfDataCid = await blockstoreOfBob.partition(dataCid);
+
+      // alice writes a records with data
+      const dataStream1 = DataStream.fromBytes(dataBytes);
+      const messageCid1 = await TestDataGenerator.randomCborSha256Cid();
+      await store.put(alice, messageCid1, dataCid, dataStream1);
+      await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfAliceOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
+
+      // alice writes a different record with same data again
+      const dataStream2 = DataStream.fromBytes(dataBytes);
+      const messageCid2 = await TestDataGenerator.randomCborSha256Cid();
+      await store.put(alice, messageCid2, dataCid, dataStream2);
+      await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfAliceOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
+
+      // bob writes a records with same data
+      const dataStream3 = DataStream.fromBytes(dataBytes);
+      const messageCid3 = await TestDataGenerator.randomCborSha256Cid();
+      await store.put(bob, messageCid3, dataCid, dataStream3);
+      await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfBobOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
+
+      // bob writes a different record with same data again
+      const dataStream4 = DataStream.fromBytes(dataBytes);
+      const messageCid4 = await TestDataGenerator.randomCborSha256Cid();
+      await store.put(bob, messageCid4, dataCid, dataStream4);
+      await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfBobOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
+
+      // alice deletes one of the two records
+      await store.delete(alice, messageCid1, dataCid);
+      await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfAliceOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
+
+      // alice deletes the other record
+      await store.delete(alice, messageCid2, dataCid);
+
+      // verify that data is deleted in alice's blockstore, but remains in bob's blockstore
+      await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfAliceOfDataCid.db.keys())).to.eventually.eql([ ]);
+      await expect(ArrayUtility.fromAsyncGenerator(blockstoreOfBobOfDataCid.db.keys())).to.eventually.eql([ dataCid ]);
     });
   });
 });

--- a/tests/store/message-store-level.spec.ts
+++ b/tests/store/message-store-level.spec.ts
@@ -1,0 +1,48 @@
+import type { MessageStore } from '../../src/index.js';
+import type { CreateLevelDatabaseOptions, LevelDatabase } from '../../src/store/level-wrapper.js';
+
+import { createLevelDatabase } from '../../src/store/level-wrapper.js';
+import { expect } from 'chai';
+import { MessageStoreLevel } from '../../src/store/message-store-level.js';
+import { TestStoreInitializer } from '../test-store-initializer.js';
+
+let messageStore: MessageStore;
+
+describe('MessageStoreLevel Test Suite', () => {
+  // important to follow the `before` and `after` pattern to initialize and clean the stores in tests
+  // so that different test suites can reuse the same backend store for testing
+  before(async () => {
+    const stores = TestStoreInitializer.initializeStores();
+    messageStore = stores.messageStore;
+    await messageStore.open();
+  });
+
+  beforeEach(async () => {
+    await messageStore.clear(); // clean up before each test rather than after so that a test does not depend on other tests to do the clean up
+  });
+
+  after(async () => {
+    await messageStore.close();
+  });
+
+  describe('createLevelDatabase', function () {
+    it('should be called if provided', async () => {
+      // need to close the message store instance first before creating a new one with the same name below
+      await messageStore.close();
+
+      const locations = new Set;
+
+      messageStore = new MessageStoreLevel({
+        blockstoreLocation : 'TEST-MESSAGESTORE',
+        indexLocation      : 'TEST-INDEX',
+        createLevelDatabase<V>(location: string, options?: CreateLevelDatabaseOptions<V>): Promise<LevelDatabase<V>> {
+          locations.add(location);
+          return createLevelDatabase(location, options);
+        }
+      });
+      await messageStore.open();
+
+      expect(locations).to.eql(new Set([ 'TEST-MESSAGESTORE', 'TEST-INDEX' ]));
+    });
+  });
+});

--- a/tests/store/message-store.spec.ts
+++ b/tests/store/message-store.spec.ts
@@ -1,22 +1,22 @@
+import type { MessageStore } from '../../src/index.js';
 import type { RecordsWriteMessage } from '../../src/types/records-types.js';
-import type { CreateLevelDatabaseOptions, LevelDatabase } from '../../src/store/level-wrapper.js';
 
-import { createLevelDatabase } from '../../src/store/level-wrapper.js';
 import { DidKeyResolver } from '../../src/index.js';
 import { expect } from 'chai';
 import { Message } from '../../src/core/message.js';
-import { MessageStoreLevel } from '../../src/store/message-store-level.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
+import { TestStoreInitializer } from '../test-store-initializer.js';
 
-let messageStore: MessageStoreLevel;
+let messageStore: MessageStore;
 
-describe('MessageStoreLevel Tests', () => {
+describe('Generic MessageStore Test Suite', () => {
   describe('put', function () {
+
+    // important to follow the `before` and `after` pattern to initialize and clean the stores in tests
+    // so that different test suites can reuse the same backend store for testing
     before(async () => {
-      messageStore = new MessageStoreLevel({
-        blockstoreLocation : 'TEST-MESSAGESTORE',
-        indexLocation      : 'TEST-INDEX'
-      });
+      const stores = TestStoreInitializer.initializeStores();
+      messageStore = stores.messageStore;
       await messageStore.open();
     });
 
@@ -122,24 +122,6 @@ describe('MessageStoreLevel Tests', () => {
 
       const results = await messageStore.query(alice.did, { schema });
       expect(results.length).to.equal(0);
-    });
-  });
-
-  describe('createLevelDatabase', function () {
-    it('should be called if provided', async () => {
-      const locations = new Set;
-
-      const messageStore = new MessageStoreLevel({
-        blockstoreLocation : 'TEST-MESSAGESTORE',
-        indexLocation      : 'TEST-INDEX',
-        createLevelDatabase<V>(location: string, options?: CreateLevelDatabaseOptions<V>): Promise<LevelDatabase<V>> {
-          locations.add(location);
-          return createLevelDatabase(location, options);
-        }
-      });
-      await messageStore.open();
-
-      expect(locations).to.eql(new Set([ 'TEST-MESSAGESTORE', 'TEST-INDEX' ]));
     });
   });
 });

--- a/tests/test-store-initializer.ts
+++ b/tests/test-store-initializer.ts
@@ -1,0 +1,31 @@
+import type { DataStore, EventLog, MessageStore } from '../src/index.js';
+import { DataStoreLevel, EventLogLevel, MessageStoreLevel } from '../src/index.js';
+
+/**
+ * Class that initializes store implementations for testing.
+ * This is intended to be extended as the single point of configuration
+ * that allows different store implementations to be swapped in
+ * to test compatibility with default/built-in store implementations.
+ */
+export class TestStoreInitializer {
+
+  /**
+   * Initializes and return the stores used for running the test suite.
+   */
+  public static initializeStores(): { messageStore: MessageStore, dataStore: DataStore, eventLog: EventLog } {
+    const messageStore = new MessageStoreLevel({
+      blockstoreLocation : 'TEST-MESSAGESTORE',
+      indexLocation      : 'TEST-INDEX'
+    });
+
+    const dataStore = new DataStoreLevel({
+      blockstoreLocation: 'TEST-DATASTORE'
+    });
+
+    const eventLog = new EventLogLevel({
+      location: 'TEST-EVENTLOG'
+    });
+
+    return { messageStore, dataStore, eventLog };
+  }
+}


### PR DESCRIPTION
1. Made tests independent of specific store implementations
   Still need more changes to make testing external implementation truly seamless, but at least the story is much better than before.
1. Moved store implementation specific tests into their own dedicated suites.