### PR TITLE
Replace eccrypto with eciesjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.31%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.26%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.68%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.31%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.32%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.26%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.68%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.32%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "ajv": "8.12.0",
         "blockstore-core": "4.2.0",
         "cross-fetch": "3.1.6",
-        "eccrypto": "1.1.6",
+        "eciesjs": "0.4.0",
         "flat": "5.0.2",
         "interface-blockstore": "5.2.3",
         "interface-store": "5.1.2",
@@ -39,7 +39,6 @@
       "devDependencies": {
         "@types/chai": "4.3.0",
         "@types/chai-as-promised": "7.1.5",
-        "@types/eccrypto": "1.1.3",
         "@types/flat": "^5.0.2",
         "@types/karma": "^6.3.3",
         "@types/lodash": "4.14.179",
@@ -697,6 +696,17 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz",
+      "integrity": "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==",
+      "dependencies": {
+        "@noble/hashes": "1.3.1"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/ed25519": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.0.0.tgz",
@@ -707,6 +717,17 @@
           "url": "https://paulmillr.com/funding/"
         }
       ]
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@noble/secp256k1": {
       "version": "2.0.0",
@@ -902,22 +923,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/eccrypto": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/eccrypto/-/eccrypto-1.1.3.tgz",
-      "integrity": "sha512-3O0qER6JMYReqVbcQTGmXeMHdw3O+rVps63tlo5g5zoB3altJS8yzSvboSivwVWeYO9o5jSATu7P0UIqYZPgow==",
-      "dev": true,
-      "dependencies": {
-        "@types/expect": "^1.20.4",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/expect": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/@types/expect/-/expect-1.20.4.tgz",
-      "integrity": "sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==",
-      "dev": true
     },
     "node_modules/@types/flat": {
       "version": "5.0.2",
@@ -1264,6 +1269,8 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
       "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+      "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1444,24 +1451,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "optional": true,
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bip66": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/bl": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
@@ -1601,7 +1590,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -1743,7 +1732,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/builtin-status-codes": {
       "version": "3.0.0",
@@ -1982,7 +1971,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -2132,7 +2121,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -2145,7 +2134,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -2453,53 +2442,12 @@
         "url": "https://bevry.me/fund"
       }
     },
-    "node_modules/drbg.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-      "integrity": "sha512-F4wZ06PvqxYLFEZKkFxTDcns9oFNk34hvmJSEwdzsxVQ8YI5YaxtACgQatkYgv2VI2CFkUd2Y+xosPQnHv809g==",
-      "optional": true,
+    "node_modules/eciesjs": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.0.tgz",
+      "integrity": "sha512-z4dEeaH16xxYVgtxJ8YVwpifH4Keg4gyp5F451mnDNwbAN3MgL5jcoEQGpqJrapv/zW8KwDnXG21Dw5B0hqvmw==",
       "dependencies": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/eccrypto": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/eccrypto/-/eccrypto-1.1.6.tgz",
-      "integrity": "sha512-d78ivVEzu7Tn0ZphUUaL43+jVPKTMPFGtmgtz1D0LrFn7cY3K8CdrvibuLz2AAkHBLKZtR8DMbB2ukRYFk987A==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "acorn": "7.1.1",
-        "elliptic": "6.5.4",
-        "es6-promise": "4.2.8",
-        "nan": "2.14.0"
-      },
-      "optionalDependencies": {
-        "secp256k1": "3.7.1"
-      }
-    },
-    "node_modules/eccrypto/node_modules/secp256k1": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
-      "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "bip66": "^1.1.5",
-        "bn.js": "^4.11.8",
-        "create-hash": "^1.2.0",
-        "drbg.js": "^1.0.1",
-        "elliptic": "^6.4.1",
-        "nan": "^2.14.0",
-        "safe-buffer": "^5.1.2"
-      },
-      "engines": {
-        "node": ">=4.0.0"
+        "@noble/curves": "^1.1.0"
       }
     },
     "node_modules/ee-first": {
@@ -2589,11 +2537,6 @@
       "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
       "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
       "dev": true
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "node_modules/esbuild": {
       "version": "0.16.17",
@@ -2940,7 +2883,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -3030,12 +2973,6 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "optional": true
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -3493,7 +3430,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
       "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
@@ -3507,7 +3444,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -3521,7 +3458,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4858,7 +4795,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -5165,11 +5102,6 @@
       "engines": {
         "node": ">=8.0.0"
       }
-    },
-    "node_modules/nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "node_modules/nanoid": {
       "version": "3.3.3",
@@ -6114,7 +6046,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -6280,7 +6212,7 @@
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "ajv": "8.12.0",
     "blockstore-core": "4.2.0",
     "cross-fetch": "3.1.6",
-    "eccrypto": "1.1.6",
+    "eciesjs": "0.4.0",
     "flat": "5.0.2",
     "interface-blockstore": "5.2.3",
     "interface-store": "5.1.2",
@@ -91,7 +91,6 @@
   "devDependencies": {
     "@types/chai": "4.3.0",
     "@types/chai-as-promised": "7.1.5",
-    "@types/eccrypto": "1.1.3",
     "@types/flat": "^5.0.2",
     "@types/karma": "^6.3.3",
     "@types/lodash": "4.14.179",


### PR DESCRIPTION
This PR replaces the problematic and poorly maintained [eccrypto](https://github.com/bitchan/eccrypto) library with [eciesjs](https://github.com/ecies/js).

> **Note**
> Although not unexpected, it is worth emphasizing that this is a breaking change in the sense that any data previously encrypted with `Encryption.eciesSecp256k1Encrypt()` cannot be decrypted `Encryption.eciesSecp256k1Decrypt()` after this PR has been merged.  However, given the issues discovered recently with record encryption, this seems to be an acceptable at this time.

- `eccrypto` has not been updated since March 2021 whereas `eciesjs` is being actively maintained by a responsive maintainer.
- `eccrypto` depends on 5 packages ([acorn](https://www.npmjs.com/package/acorn), [elliptic](https://www.npmjs.com/package/elliptic), [es6-promise](https://www.npmjs.com/package/es6-promise), [nan](https://www.npmjs.com/package/nan), and [secp256k1](https://www.npmjs.com/package/secp256k1)) whereas `eciesjs` has only 1 dependency ([@noble/curves](https://www.npmjs.com/package/@noble/curves)), which has been audited by an independent security firm.
- The `eciesjs` maintainer also provides ECIES implementations in [Python](https://github.com/ecies/py), [Go](https://github.com/ecies/go), [Rust](https://github.com/ecies/rs), and [WASM](https://github.com/ecies/rs-wasm).  Basic interop is tested.
- Closes #291 
- The "secp256k1 unavailable, reverting to browser version" will be gone 😄 

Future work:
- We should consider adding a second, non-NIST option for ECIES, such as XChaCha20-Poly1305 for the symmetric cipher and authentication tag algorithm.