### PR TITLE
#434 - fixed bug that allowed creation of protocol record with parentId but missing contextId

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.51%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.32%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.81%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.51%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.51%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.33%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.81%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.51%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/json-schemas/interface-methods/records-write.json
+++ b/json-schemas/interface-methods/records-write.json
@@ -152,6 +152,11 @@
         "messageTimestamp",
         "dataFormat"
       ],
+      "dependencies": {
+        "parentId": [
+          "protocol"
+        ]
+      },
       "allOf": [
         {
           "$comment": "rule defining `published` and `datePublished` relationship",

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -166,6 +166,10 @@ export class RecordsWrite extends Message<RecordsWriteMessage> {
       throw new Error('`dataCid` and `dataSize` must both be defined or undefined at the same time');
     }
 
+    if (options.parentId !== undefined && options.contextId === undefined) {
+      throw new Error('`contextId` must also be given when `parentId` is specified');
+    }
+
     const dataCid = options.dataCid ?? await Cid.computeDagPbCidFromBytes(options.data!);
     const dataSize = options.dataSize ?? options.data!.length;
 

--- a/src/types/data-store.ts
+++ b/src/types/data-store.ts
@@ -31,7 +31,7 @@ export interface DataStore {
   get(tenant: string, messageCid: string, dataCid: string): Promise<GetResult | undefined>;
 
   /**
-   * Associates existing data.
+   * Associates dataCid of existing data with the given messageCid.
    * The returned dataCid and returned dataSize will be verified against the given dataCid (and inferred dataSize).
    * @param tenant The tenant in which the data must exist under for the association to occur.
    * @param messageCid CID of the message that references the data.

--- a/tests/interfaces/records-write.spec.ts
+++ b/tests/interfaces/records-write.spec.ts
@@ -1,6 +1,6 @@
-import type { EncryptionInput } from '../../src/interfaces/records-write.js';
 import type { MessageStore } from '../../src/types/message-store.js';
 import type { RecordsWriteMessage } from '../../src/types/records-types.js';
+import type { EncryptionInput, RecordsWriteOptions } from '../../src/interfaces/records-write.js';
 
 import chaiAsPromised from 'chai-as-promised';
 import chai, { expect } from 'chai';
@@ -173,6 +173,26 @@ describe('RecordsWrite', () => {
       const createPromise2 = RecordsWrite.create(options2);
 
       await expect(createPromise2).to.be.rejectedWith('`protocol` and `protocolPath` must both be defined or undefined at the same time');
+    });
+
+    it('#434 - should required `contextId` when `parent` is specified', async () => {
+      const alice = await TestDataGenerator.generatePersona();
+
+      const options: RecordsWriteOptions = {
+        schema                      : 'http://any-schema.com',
+        protocol                    : 'http://example.com',
+        protocolPath                : 'foo/bar',
+        parentId                    : await TestDataGenerator.randomCborSha256Cid(),
+        dataCid                     : await TestDataGenerator.randomCborSha256Cid(),
+        dataSize                    : 123,
+        dataFormat                  : 'application/json',
+        recordId                    : await TestDataGenerator.randomCborSha256Cid(),
+        authorizationSignatureInput : Jws.createSignatureInput(alice)
+      };
+
+      const createPromise = RecordsWrite.create(options);
+
+      await expect(createPromise).to.be.rejectedWith('`contextId` must also be given when `parentId` is specified');
     });
 
     it('should throw if attempting to use `protocols` key derivation encryption scheme on non-protocol-based record', async () => {

--- a/tests/validation/json-schemas/records/records-write.spec.ts
+++ b/tests/validation/json-schemas/records/records-write.spec.ts
@@ -259,6 +259,36 @@ describe('RecordsWrite schema definition', () => {
     }).throws('must have required property \'contextId\'');
   });
 
+  it('#434 - should throw if `parentId` is defined without other protocol related properties', () => {
+    const invalidMessage = {
+      recordId   : 'anyRecordId',
+      // contextId  : 'anyContextId', // intentionally missing
+      descriptor : {
+        interface        : 'Records',
+        method           : 'Write',
+        // protocol         : 'http://foo.bar', // intentionally missing
+        // protocolPath     : 'foo/bar', // intentionally missing
+        parentId         : 'anyParentId',
+        dataCid          : 'anyCid',
+        dataFormat       : 'application/json',
+        dataSize         : 123,
+        dateCreated      : '2022-12-19T10:20:30.123456Z',
+        messageTimestamp : '2022-12-19T10:20:30.123456Z'
+      },
+      authorization: {
+        payload    : 'anyPayload',
+        signatures : [{
+          protected : 'anyProtectedHeader',
+          signature : 'anySignature'
+        }]
+      }
+    };
+
+    expect(() => {
+      Message.validateJsonSchema(invalidMessage);
+    }).throws('must have property protocol when property parentId is present');
+  });
+
   it('should throw if `protocol` is defined but `protocolPath` is missing', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',


### PR DESCRIPTION
Discovered by Tyler Amirault in Slack:

https://discord.com/channels/937858703112155166/969272658501976117/1128421823223185579