### PR TITLE
Added support for multi-implementation test suite runs in one external repository

### DIFF
--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -1,5 +1,6 @@
 import type { EncryptionInput } from '../../src/interfaces/records-write.js';
 import type { GenerateFromRecordsWriteOut } from '../utils/test-data-generator.js';
+import type { ProtocolActionRule } from '../../src/types/protocols-types.js';
 import type { QueryResultEntry } from '../../src/types/message-types.js';
 import type { RecordsWriteMessage } from '../../src/types/records-types.js';
 import type { DataStore, EventLog, MessageStore } from '../../src/index.js';
@@ -1291,11 +1292,11 @@ export function testRecordsWriteHandler(): void {
           const alice = await DidKeyResolver.generate();
           const issuer = await DidKeyResolver.generate();
 
-          // create an invalid ancestor path that is longer than possible
-          const invalidProtocolDefinition = { ...credentialIssuanceProtocolDefinition };
+          // clone then create an invalid ancestor path that is longer than possible
+          const invalidProtocolDefinition = JSON.parse(JSON.stringify(credentialIssuanceProtocolDefinition));
           const actionRuleIndex =
           invalidProtocolDefinition.structure.credentialApplication.credentialResponse.$actions
-            .findIndex((actionRule) => actionRule.who === ProtocolActor.Recipient);
+            .findIndex((actionRule: ProtocolActionRule) => actionRule.who === ProtocolActor.Recipient);
           invalidProtocolDefinition.structure.credentialApplication.credentialResponse
             .$actions[actionRuleIndex].of
             = 'credentialResponse';

--- a/tests/test-suite.ts
+++ b/tests/test-suite.ts
@@ -25,7 +25,9 @@ export class TestSuite {
    */
   public static runStoreDependentTests(overrides?: { messageStore?: MessageStore, dataStore?: DataStore, eventLog?: EventLog }): void {
 
-    TestStores.override(overrides);
+    before(async () => {
+      TestStores.override(overrides);
+    });
 
     testDwnClass();
     testMessageStore();


### PR DESCRIPTION
@amika-sq reported the need to run the exported test suites multiple times, however this is not currently supported because
1. Any number of times the custom store overrides will all take place immediately before test suite is run regardless how many time it is supposed to run, resulting in only the last override taking effect for all test suite runs.
2. A test is modifying a protocol definition used across test suite runs, causing 3 tests dependent on the protocol definition to always fail  in subsequent test suite runs.