### PR TITLE
Added support for unauthenticated queries for published ProtocolsConfigures

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.49%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.43%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.63%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.49%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.49%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.42%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.63%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.49%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.48%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.42%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.58%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.48%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.49%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.44%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.61%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.49%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.49%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.44%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.61%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.49%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.49%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.43%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.63%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.49%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.49%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.42%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.63%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.49%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.49%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.43%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.63%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.49%25-brightgreen.svg?style=flat)
 
 ## Introduction
 

--- a/json-schemas/interface-methods/protocol-definition.json
+++ b/json-schemas/interface-methods/protocol-definition.json
@@ -11,6 +11,9 @@
     "protocol": {
       "type": "string"
     },
+    "published": {
+      "type": "boolean"
+    },
     "types": {
       "type": "object",
       "patternProperties": {

--- a/json-schemas/interface-methods/protocol-definition.json
+++ b/json-schemas/interface-methods/protocol-definition.json
@@ -4,6 +4,8 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "protocol",
+    "published",
     "types",
     "structure"
   ],

--- a/json-schemas/interface-methods/protocols-query.json
+++ b/json-schemas/interface-methods/protocols-query.json
@@ -4,7 +4,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "authorization",
     "descriptor"
   ],
   "properties": {

--- a/src/handlers/protocols-configure.ts
+++ b/src/handlers/protocols-configure.ts
@@ -84,12 +84,12 @@ export class ProtocolsConfigureHandler implements MethodHandler {
     return messageReply;
   };
 
-  private static constructProtocolsConfigureIndexes(protocolsConfigure: ProtocolsConfigure): Record<string, string> {
+  private static constructProtocolsConfigureIndexes(protocolsConfigure: ProtocolsConfigure): { [key: string]: string | boolean } {
     // strip out `definition` as it is not indexable
     const { definition, ...propertiesToIndex } = protocolsConfigure.message.descriptor;
     const { author } = protocolsConfigure;
 
-    const indexes: Record<string, any> = {
+    const indexes: { [key: string]: string | boolean } = {
       ...propertiesToIndex,
       author    : author!,
       protocol  : definition.protocol, // retain protocol url from `definition`,

--- a/src/handlers/protocols-configure.ts
+++ b/src/handlers/protocols-configure.ts
@@ -89,10 +89,11 @@ export class ProtocolsConfigureHandler implements MethodHandler {
     const { definition, ...propertiesToIndex } = protocolsConfigure.message.descriptor;
     const { author } = protocolsConfigure;
 
-    const indexes = {
+    const indexes: Record<string, any> = {
       ...propertiesToIndex,
-      protocol : definition.protocol, // retain protocol url from `definition`
-      author   : author!
+      author    : author!,
+      protocol  : definition.protocol, // retain protocol url from `definition`,
+      published : definition.published
     };
 
     return indexes;

--- a/src/handlers/protocols-query.ts
+++ b/src/handlers/protocols-query.ts
@@ -34,7 +34,7 @@ export class ProtocolsQueryHandler implements MethodHandler {
       };
     }
 
-    // author is authenticated but still needs to be authorized
+    // authentication & authorization
     try {
       await authenticate(message.authorization, this.didResolver);
       await protocolsQuery.authorize(tenant, this.messageStore);

--- a/src/handlers/protocols-query.ts
+++ b/src/handlers/protocols-query.ts
@@ -25,8 +25,8 @@ export class ProtocolsQueryHandler implements MethodHandler {
       return messageReplyFromError(e, 400);
     }
 
+    // if this is an anonymous query, query only published ProtocolsConfigures
     if (protocolsQuery.author === undefined) {
-      // this is an anonymous query, query only published ProtocolsConfigures
       const entries: ProtocolsConfigureMessage[] = await this.fetchPublishedProtocolsConfigure(tenant, protocolsQuery);
       return {
         status: { code: 200, detail: 'OK' },

--- a/src/interfaces/protocols-configure.ts
+++ b/src/interfaces/protocols-configure.ts
@@ -1,4 +1,4 @@
-import type { SignatureInput } from '../types/jws-types.js';
+import type { GeneralJws, SignatureInput } from '../types/jws-types.js';
 import type { ProtocolDefinition, ProtocolsConfigureDescriptor, ProtocolsConfigureMessage } from '../types/protocols-types.js';
 
 import { getCurrentTimeInHighPrecision } from '../utils/time.js';
@@ -32,7 +32,12 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
       definition       : ProtocolsConfigure.normalizeDefinition(options.definition)
     };
 
-    const authorization = await Message.signAsAuthorization(descriptor, options.authorizationSignatureInput, options.permissionsGrantId);
+    // only generate the `authorization` property if signature input is given
+    let authorization: GeneralJws | undefined;
+    if (options.authorizationSignatureInput !== undefined) {
+      authorization = await Message.signAsAuthorization(descriptor, options.authorizationSignatureInput, options.permissionsGrantId);
+    }
+
     const message = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/protocols-configure.ts
+++ b/src/interfaces/protocols-configure.ts
@@ -1,4 +1,4 @@
-import type { GeneralJws, SignatureInput } from '../types/jws-types.js';
+import type { SignatureInput } from '../types/jws-types.js';
 import type { ProtocolDefinition, ProtocolsConfigureDescriptor, ProtocolsConfigureMessage } from '../types/protocols-types.js';
 
 import { getCurrentTimeInHighPrecision } from '../utils/time.js';
@@ -32,12 +32,7 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
       definition       : ProtocolsConfigure.normalizeDefinition(options.definition)
     };
 
-    // only generate the `authorization` property if signature input is given
-    let authorization: GeneralJws | undefined;
-    if (options.authorizationSignatureInput !== undefined) {
-      authorization = await Message.signAsAuthorization(descriptor, options.authorizationSignatureInput, options.permissionsGrantId);
-    }
-
+    const authorization = await Message.signAsAuthorization(descriptor, options.authorizationSignatureInput, options.permissionsGrantId);
     const message = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/protocols-query.ts
+++ b/src/interfaces/protocols-query.ts
@@ -19,9 +19,6 @@ export type ProtocolsQueryOptions = {
 };
 
 export class ProtocolsQuery extends Message<ProtocolsQueryMessage> {
-  // JSON Schema guarantees presence of `authorization` which contains author DID
-  readonly author!: string;
-
 
   public static async parse(message: ProtocolsQueryMessage): Promise<ProtocolsQuery> {
     if (message.authorization !== undefined) {
@@ -77,7 +74,7 @@ export class ProtocolsQuery extends Message<ProtocolsQueryMessage> {
     if (this.author === tenant) {
       return;
     } else if (this.authorizationPayload?.permissionsGrantId) {
-      await GrantAuthorization.authorizeGenericMessage(tenant, this, this.author, messageStore);
+      await GrantAuthorization.authorizeGenericMessage(tenant, this, this.author!, messageStore);
     } else {
       throw new DwnError(
         DwnErrorCode.ProtocolsQueryUnauthorized,

--- a/src/store/message-store-level.ts
+++ b/src/store/message-store-level.ts
@@ -104,7 +104,7 @@ export class MessageStoreLevel implements MessageStore {
   async put(
     tenant: string,
     message: GenericMessage,
-    indexes: Record<string, string>,
+    indexes: { [key: string]: string | boolean },
     options?: MessageStoreOptions
   ): Promise<void> {
     options?.signal?.throwIfAborted();

--- a/src/types/message-store.ts
+++ b/src/types/message-store.ts
@@ -22,7 +22,7 @@ export interface MessageStore {
   put(
     tenant: string,
     message: GenericMessage,
-    indexes: { [key: string]: string },
+    indexes: { [key: string]: string | boolean },
     options?: MessageStoreOptions
   ): Promise<void>;
 

--- a/src/types/protocols-types.ts
+++ b/src/types/protocols-types.ts
@@ -11,6 +11,10 @@ export type ProtocolsConfigureDescriptor = {
 
 export type ProtocolDefinition = {
   protocol: string;
+  /**
+   * Denotes if this Protocol Definition can be returned by unauthenticated `ProtocolsQuery`.
+   */
+  published: boolean;
   types: ProtocolTypes;
   structure: {
     [key: string]: ProtocolRuleSet;

--- a/tests/handlers/records-read.spec.ts
+++ b/tests/handlers/records-read.spec.ts
@@ -1,6 +1,6 @@
 import type { DerivedPrivateJwk } from '../../src/utils/hd-key.js';
 import type { EncryptionInput } from '../../src/interfaces/records-write.js';
-import type { DataStore, EventLog, MessageStore, ProtocolsConfigureMessage } from '../../src/index.js';
+import type { DataStore, EventLog, MessageStore } from '../../src/index.js';
 
 import chaiAsPromised from 'chai-as-promised';
 import emailProtocolDefinition from '../vectors/protocol-definitions/email.json' assert { type: 'json' };
@@ -563,16 +563,6 @@ export function testRecordsReadHandler(): void {
 
           const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message, protocolsConfig.dataStream);
           expect(protocolsConfigureReply.status.code).to.equal(202);
-
-          // // Bob queries for Alice's email protocol definition to get the public encryption key declared
-          // const protocolsQuery = await TestDataGenerator.generateProtocolsQuery({
-          //   filter: { protocol: emailProtocolDefinition.protocol }
-          // });
-          // const protocolsQueryReply = await dwn.processMessage(alice.did, protocolsQuery.message);
-          // const fetchedProtocolDefinition = (protocolsQueryReply.entries![0] as ProtocolsConfigureMessage).descriptor.definition;
-
-          // Bob verifies that the email protocol definition is authored by Alice
-          // const publicEncryptionKey = fetchedProtocolDefinition.descriptor
 
           // encrypt bob's message
           const bobMessageBytes = Encoder.stringToBytes('message from bob');

--- a/tests/handlers/records-read.spec.ts
+++ b/tests/handlers/records-read.spec.ts
@@ -1,6 +1,6 @@
 import type { DerivedPrivateJwk } from '../../src/utils/hd-key.js';
 import type { EncryptionInput } from '../../src/interfaces/records-write.js';
-import type { DataStore, EventLog, MessageStore } from '../../src/index.js';
+import type { DataStore, EventLog, MessageStore, ProtocolsConfigureMessage } from '../../src/index.js';
 
 import chaiAsPromised from 'chai-as-promised';
 import emailProtocolDefinition from '../vectors/protocol-definitions/email.json' assert { type: 'json' };
@@ -547,14 +547,14 @@ export function testRecordsReadHandler(): void {
         });
 
         it('should only be able to decrypt record with a correct derived private key  - `protocols` derivation scheme', async () => {
-        // scenario, Bob writes into Alice's DWN an encrypted "email", alice is able to decrypt it
+          // scenario: Bob writes into Alice's DWN an encrypted "email", alice is able to decrypt it
 
           // creating Alice and Bob persona and setting up a stub DID resolver
           const alice = await TestDataGenerator.generatePersona();
           const bob = await TestDataGenerator.generatePersona();
           TestStubGenerator.stubDidResolver(didResolver, [alice, bob]);
 
-          // configure protocol
+          // Alice configures email protocol
           const protocolDefinition = emailProtocolDefinition;
           const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
             author: alice,
@@ -563,6 +563,16 @@ export function testRecordsReadHandler(): void {
 
           const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message, protocolsConfig.dataStream);
           expect(protocolsConfigureReply.status.code).to.equal(202);
+
+          // // Bob queries for Alice's email protocol definition to get the public encryption key declared
+          // const protocolsQuery = await TestDataGenerator.generateProtocolsQuery({
+          //   filter: { protocol: emailProtocolDefinition.protocol }
+          // });
+          // const protocolsQueryReply = await dwn.processMessage(alice.did, protocolsQuery.message);
+          // const fetchedProtocolDefinition = (protocolsQueryReply.entries![0] as ProtocolsConfigureMessage).descriptor.definition;
+
+          // Bob verifies that the email protocol definition is authored by Alice
+          // const publicEncryptionKey = fetchedProtocolDefinition.descriptor
 
           // encrypt bob's message
           const bobMessageBytes = Encoder.stringToBytes('message from bob');

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -64,6 +64,11 @@ export type Persona = {
 };
 
 export type GenerateProtocolsConfigureInput = {
+  /**
+   * Denotes if the Protocol Definition can be returned by unauthenticated `ProtocolsQuery`.
+   * Only takes effect if `protocolDefinition` is not explicitly set. Defaults to false if not specified.
+   */
+  published?: boolean;
   author?: Persona;
   messageTimestamp?: string;
   protocolDefinition?: ProtocolDefinition;
@@ -299,6 +304,7 @@ export class TestDataGenerator {
 
       definition = {
         protocol  : TestDataGenerator.randomString(20),
+        published : input?.published ?? false,
         types     : {},
         structure : {}
       };

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -7,8 +7,9 @@ import type { ProtocolDefinition, ProtocolsConfigureMessage } from '../../../../
 describe('ProtocolsConfigure schema definition', () => {
   it('should throw if unknown actor is encountered in action rule', async () => {
     const protocolDefinition: ProtocolDefinition = {
-      protocol : 'email',
-      types    : {
+      protocol  : 'email',
+      published : true,
+      types     : {
         email: {
           schema      : 'email',
           dataFormats : ['text/plain']

--- a/tests/vectors/protocol-definitions/credential-issuance.json
+++ b/tests/vectors/protocol-definitions/credential-issuance.json
@@ -1,13 +1,18 @@
 {
   "protocol": "http://credential-issuance-protocol.xyz",
+  "published": true,
   "types": {
     "credentialApplication": {
       "schema": "https://identity.foundation/credential-manifest/schemas/credential-application",
-      "dataFormats": ["application/json"]
+      "dataFormats": [
+        "application/json"
+      ]
     },
     "credentialResponse": {
       "schema": "https://identity.foundation/credential-manifest/schemas/credential-response",
-      "dataFormats": ["application/json"]
+      "dataFormats": [
+        "application/json"
+      ]
     }
   },
   "structure": {

--- a/tests/vectors/protocol-definitions/dex.json
+++ b/tests/vectors/protocol-definitions/dex.json
@@ -1,17 +1,24 @@
 {
   "protocol": "http://dex.xyz",
+  "published": true,
   "types": {
     "ask": {
       "schema": "https://tbd/website/tbdex/ask",
-      "dataFormats": ["application/json"]
+      "dataFormats": [
+        "application/json"
+      ]
     },
     "offer": {
       "schema": "https://tbd/website/tbdex/offer",
-      "dataFormats": ["application/json"]
+      "dataFormats": [
+        "application/json"
+      ]
     },
     "fulfillment": {
       "schema": "https://tbd/website/tbdex/fulfillment",
-      "dataFormats": ["application/json"]
+      "dataFormats": [
+        "application/json"
+      ]
     }
   },
   "structure": {

--- a/tests/vectors/protocol-definitions/email.json
+++ b/tests/vectors/protocol-definitions/email.json
@@ -1,9 +1,12 @@
 {
   "protocol": "http://email-protocol.xyz",
+  "published": true,
   "types": {
     "email": {
       "schema": "email",
-      "dataFormats": ["text/plain"]
+      "dataFormats": [
+        "text/plain"
+      ]
     }
   },
   "structure": {

--- a/tests/vectors/protocol-definitions/message.json
+++ b/tests/vectors/protocol-definitions/message.json
@@ -1,9 +1,12 @@
 {
   "protocol": "http://message-protocol.xyz",
+  "published": true,
   "types": {
     "message": {
       "schema": "http://message.me",
-      "dataFormats": ["text/plain"]
+      "dataFormats": [
+        "text/plain"
+      ]
     }
   },
   "structure": {

--- a/tests/vectors/protocol-definitions/minimal.json
+++ b/tests/vectors/protocol-definitions/minimal.json
@@ -1,5 +1,6 @@
 {
   "protocol": "http://minimal.xyz",
+  "published": false,
   "types": {
     "foo": {}
   },
@@ -7,4 +8,3 @@
     "foo": {}
   }
 }
-  

--- a/tests/vectors/protocol-definitions/private-protocol.json
+++ b/tests/vectors/protocol-definitions/private-protocol.json
@@ -1,9 +1,12 @@
 {
   "protocol": "http://private-protocol.xyz",
+  "published": false,
   "types": {
     "privateNote": {
       "schema": "private-note",
-      "dataFormats": ["text/plain"]
+      "dataFormats": [
+        "text/plain"
+      ]
     }
   },
   "structure": {

--- a/tests/vectors/protocol-definitions/social-media.json
+++ b/tests/vectors/protocol-definitions/social-media.json
@@ -1,21 +1,30 @@
 {
   "protocol": "http://social-media.xyz",
+  "published": true,
   "types": {
     "message": {
       "schema": "messageSchema",
-      "dataFormats": ["text/plain"]
+      "dataFormats": [
+        "text/plain"
+      ]
     },
     "reply": {
       "schema": "replySchema",
-      "dataFormats": ["text/plain"]
+      "dataFormats": [
+        "text/plain"
+      ]
     },
     "image": {
       "schema": "imageSchema",
-      "dataFormats": ["image/jpeg"]
+      "dataFormats": [
+        "image/jpeg"
+      ]
     },
     "caption": {
       "schema": "captionSchema",
-      "dataFormats": ["text/plain"]
+      "dataFormats": [
+        "text/plain"
+      ]
     }
   },
   "structure": {


### PR DESCRIPTION
1. Added concept of published ProtocolsConfigures
1. Added support for unauthenticated queries for published ProtocolsConfigures
1. Retain `authorization` property when returning results for `ProtocolsQuery`
1. Refactored `RecordsQuery` handler for cleaner auth logic (should be helpful for adding permission auth)