### PR TITLE
Fix number equality filter bug in IndexLevel

### DIFF
--- a/src/store/index-level.ts
+++ b/src/store/index-level.ts
@@ -159,7 +159,7 @@ export class IndexLevel {
    * @returns IDs of data that matches the exact property and value.
    */
   private async findExactMatches(propertyName: string, propertyValue: unknown, options?: IndexLevelOptions): Promise<string[]> {
-    const propertyValuePrefix = this.join(propertyName, this.encodeValue(propertyValue));
+    const propertyValuePrefix = this.join(propertyName, this.encodeValue(propertyValue), '');
 
     const iteratorOptions: LevelWrapperIteratorOptions<string> = {
       gt: propertyValuePrefix

--- a/tests/store/index-level.spec.ts
+++ b/tests/store/index-level.spec.ts
@@ -265,6 +265,31 @@ describe('Index Level', () => {
       expect(resp.length).to.equal(1);
       expect(resp).to.include(id1);
     });
+
+    it('should return records that match provided number equality filter', async () => {
+      await index.put('a', { digit: 1000 });
+      await index.put('b', { digit: 100 });
+      await index.put('c', { digit: 10 });
+
+      const resp = await index.query({
+        digit: 100
+      });
+
+      expect(resp.length).to.equal(1);
+      expect(resp.at(0)).to.equal('b');
+    });
+
+    it ('should not return records that do not match provided number equality filter', async() => {
+      await index.put('a', { digit: 1000 });
+      await index.put('b', { digit: 100 });
+      await index.put('c', { digit: 10 });
+
+      const resp = await index.query({
+        digit: 1
+      });
+
+      expect(resp.length).to.equal(0);
+    });
   });
 
   describe('delete', () => {


### PR DESCRIPTION
When querying IndexLevel using the `EqualFilter` with a number, there was an bug where values that didn't match that filter were getting returned. 

This bug was due to the way that LevelDB iterators work. 

Previously, the code to find exact matches was using a LevelDB iterator to seek to the first value that had the prefix of: `<propertyName>\x00<propertyValue>`. It would then use that iterator to take all values until it no longer started with that prefix.

This was problematic, as when the caller is querying via a number, not all digits that start with a given digit are equal to one another. For example, `digit\x0010` has the same prefix as `digit\x00100`, even though one has the value of `10`, while the other has a value of `100`. 

To fix, we need to add the delimiter used to separate the various parts of the key, to the end of the digit. This means we're now searching for the prefix `<propertyName>\x00<propertyValu>\x00`. This ensures that digits that begin with the same characters are no longer incorrectly returned with the results.

--- 

This was discovered as a part of the following issue:
https://github.com/TBD54566975/dwn-sdk-js/issues/458

There still exists an issue with range filters, which I'll hopefully get fixed up with a follow-up PR!