### PR TITLE
add protocolPath to json schema validation  in records query filter

### DIFF
--- a/json-schemas/interface-methods/records-query.json
+++ b/json-schemas/interface-methods/records-query.json
@@ -43,6 +43,9 @@
             "protocol": {
               "type": "string"
             },
+            "protocolPath": {
+              "type": "string"
+            },
             "attester": {
               "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/did"
             },


### PR DESCRIPTION
ProtocolPath should be a filter property:
 https://github.com/TBD54566975/dwn-sdk-js/blob/fe7e4912bf105a1f9b912584cf4bcd05a751d8d5/src/types/records-types.ts#L103
But fails due to schema validation: 

```sh
Error: /descriptor/filter: must NOT have additional properties
    at validateJsonSchema (file:///Users/akmb2/workspace/github.com/zion/simple-web5-chat/node_modules/@tbd54566975/dwn-sdk-js/dist/esm/src/schema-validator.js:25:11)
    at Message.validateJsonSchema (file:///Users/akmb2/workspace/github.com/zion/simple-web5-chat/node_modules/@tbd54566975/dwn-sdk-js/dist/esm/src/core/message.js:58:9)
    at RecordsQuery.<anonymous> (file:///Users/akmb2/workspace/github.com/zion/simple-web5-chat/node_modules/@tbd54566975/dwn-sdk-js/dist/esm/src/interfaces/records-query.js:55:21)
    at Generator.next (<anonymous>)
    at fulfilled (file:///Users/akmb2/workspace/github.com/zion/simple-web5-chat/node_modules/@tbd54566975/dwn-sdk-js/dist/esm/src/interfaces/records-query.js:4:58)
```

Here's an example invocation: 

```sh
    return this.web5.dwn.records.query({
      message: {
        filter: {
          protocol: definition,
          contextId: contextID,
          protocolPath: protocolPath,
          schema: <schema>
        },
        dateSort: "createdAscending",
      },
    });
```

This PR adds property protocolPath to json schema.
