### PR TITLE
cjs compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/dwn-sdk-js",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     {
       "name": "Moe Jangda",
       "url": "https://github.com/mistermoe"
+    },
+    {
+      "name": "Liran Cohen",
+      "url": "https://github.com/LiranCohen"
     }
   ],
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A reference implementation of https://identity.foundation/decentralized-web-node/spec/",
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "module": "ESNext", // Required for enabling JavaScript import assertion support
     "declaration": true,
     "declarationMap": true,
-    
     "declarationDir": "dist/types",
     "outDir": "dist/esm",
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "module": "ESNext", // Required for enabling JavaScript import assertion support
     "declaration": true,
     "declarationMap": true,
+    
     "declarationDir": "dist/types",
     "outDir": "dist/esm",
     "sourceMap": true,


### PR DESCRIPTION
This PR removes use of es6 `#` private fields (which were introduced in a recent commit) to regain cjs compatibility. we're retaining cjs due to electron's lack of esm support.