### PR TITLE
Move level store exports to index.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,8 +219,7 @@ const result = await window.web5.dwn.processMessage({
 ### Custom Tenant Gating
 By default, all DIDs are allowed as tenants. A custom tenant gate implementation can be provided when initializing the DWN.
 ```ts
-import { Dwn, TenantGate } from '@tbd54566975/dwn-sdk-js';
-import { DataStoreLevel, EventLogLevel, MessageStoreLevel } from '@tbd54566975/dwn-sdk-js/stores';
+import { Dwn, TenantGate, DataStoreLevel, EventLogLevel, MessageStoreLevel } from '@tbd54566975/dwn-sdk-js';
 
 class CustomTenantGate implements TenantGate {
   public async isTenant(did): Promise<void> {

--- a/build/create-browser-bundle.cjs
+++ b/build/create-browser-bundle.cjs
@@ -11,10 +11,3 @@ esbuild.build({
   const serializedMetafile = JSON.stringify(result.metafile, null, 4);
   fs.writeFileSync(`${__dirname}/../bundle-metadata.json`, serializedMetafile, { encoding: 'utf8' });
 });
-
-esbuild.build({
-  ...browserConfig,
-  entryPoints : ['./src/index-stores.ts'],
-  outfile     : 'dist/bundles/level-stores.js',
-  sourcemap   : false,
-});

--- a/build/create-cjs-bundle.cjs
+++ b/build/create-cjs-bundle.cjs
@@ -37,12 +37,3 @@ const indexConfig = {
 };
 
 esbuild.buildSync(indexConfig);
-
-
-const storesConfig = {
-  ...baseConfig,
-  entryPoints : ['./dist/esm/src/index-stores.js'],
-  outfile     : './dist/cjs/index-stores.js',
-};
-
-esbuild.buildSync(storesConfig);

--- a/package.json
+++ b/package.json
@@ -54,11 +54,6 @@
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/src/index.d.ts"
     },
-    "./stores": {
-      "import": "./dist/esm/src/index-stores.js",
-      "require": "./dist/cjs/index-stores.js",
-      "types": "./dist/types/src/index-stores.d.ts"
-    },
     "./tests": {
       "import": "./dist/esm/tests/test-suite.js",
       "types": "./dist/types/tests/test-suite.d.ts"

--- a/src/index-stores.ts
+++ b/src/index-stores.ts
@@ -1,4 +1,0 @@
-// Exporting LevelDB implementations of DWN stores separately because it is not compatible with all environments (e.g. React-Native)
-export { DataStoreLevel } from './store/data-store-level.js';
-export { EventLogLevel } from './event-log/event-log-level.js';
-export { MessageStoreLevel } from './store/message-store-level.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,3 +48,6 @@ export { RecordsRead, RecordsReadOptions } from './interfaces/records-read.js';
 export { SnapshotsCreate, SnapshotsCreateOptions } from './interfaces/snapshots-create.js';
 export { Secp256k1 } from './utils/secp256k1.js';
 export { SignatureInput } from './types/jws-types.js';
+export { DataStoreLevel } from './store/data-store-level.js';
+export { EventLogLevel } from './event-log/event-log-level.js';
+export { MessageStoreLevel } from './store/message-store-level.js';

--- a/tests/test-stores.ts
+++ b/tests/test-stores.ts
@@ -1,5 +1,5 @@
 import type { DataStore, EventLog, MessageStore } from '../src/index.js';
-import { DataStoreLevel, EventLogLevel, MessageStoreLevel } from '../src/index-stores.js';
+import { DataStoreLevel, EventLogLevel, MessageStoreLevel } from '../src/index.js';
 
 /**
  * Class that manages store implementations for testing.


### PR DESCRIPTION
React Native currently cannot import `MessageStoreLevel`, `DataStoreLevel`, or `EventLogLevel`, as they are in a named export called `./stores`. 

React Native currently does not support named exports (but it is coming in a future update), so we have to manually import those classes from the `dist/esm/src/index-stores` directory. Example: https://github.com/TBD54566975/web5-wallet/pull/52#discussion_r1291668116

This is not ideal, but really causes issues when other packages use the `./stores` import. For example, in @frankhinek's agent refactor PR, we're using the `/stores` named export here: https://github.com/TBD54566975/web5-js/pull/168/files#r1298468034. React Native is not able to do this, causing the `@web5/agent` package to also be incompatible with React Native.

We have a couple of options here:
1. Move the `MessageStoreLevel`, `DataStoreLevel`, and `EventLogLevel` exports back into the primary `dwn-sdk-js` package (what this PR is doing).
2. Create a separate package just for the stores.

Perhaps there are more options than this, and I'd be open to other suggestions!