### PR TITLE
Sleep for 2ms to avoid time-sensitive test failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.58%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.44%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.95%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.58%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.58%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.45%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.97%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.58%25-brightgreen.svg?style=flat)
 
 
 - [Introduction](#introduction)

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -16,3 +16,11 @@ export function sleep(durationInMillisecond: number): Promise<void> {
 export function getCurrentTimeInHighPrecision(): string {
   return Temporal.Now.instant().toString({ smallestUnit: 'microseconds' });
 }
+
+/**
+ * We must sleep for at least 2ms to avoid timestamp collisions during testing.
+ * https://github.com/TBD54566975/dwn-sdk-js/issues/481
+ */
+export async function minimalSleep(): Promise<void> {
+  await sleep(2);
+}

--- a/tests/core/message.spec.ts
+++ b/tests/core/message.spec.ts
@@ -1,10 +1,10 @@
 import type { RecordsWriteMessageWithOptionalEncodedData } from '../../src/store/storage-controller.js';
 
 import { expect } from 'chai';
+import { getCurrentTimeInHighPrecision } from '../../src/utils/time.js';
 import { Message } from '../../src/core/message.js';
 import { RecordsRead } from '../../src/index.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
-import { getCurrentTimeInHighPrecision, sleep } from '../../src/utils/time.js';
 
 describe('Message', () => {
   describe('getAuthor()', () => {
@@ -45,9 +45,9 @@ describe('Message', () => {
   describe('getNewestMessage', () => {
     it('should return the newest message', async () => {
       const a = (await TestDataGenerator.generateRecordsWrite()).message;
-      await sleep(2); // need to sleep for at least two millisecond else some messages get generated with the same time
+      await TestDataGenerator.minimalSleep();
       const b = (await TestDataGenerator.generateRecordsWrite()).message;
-      await sleep(2);
+      await TestDataGenerator.minimalSleep();
       const c = (await TestDataGenerator.generateRecordsWrite()).message; // c is the newest since its created last
 
       const newestMessage = await Message.getNewestMessage([b, c, a]);
@@ -58,9 +58,9 @@ describe('Message', () => {
   describe('getOldestMessage', () => {
     it('should return the newest message', async () => {
       const a = (await TestDataGenerator.generateRecordsWrite()).message;
-      await sleep(2); // need to sleep for at least two millisecond else some messages get generated with the same time
+      await TestDataGenerator.minimalSleep();
       const b = (await TestDataGenerator.generateRecordsWrite()).message;
-      await sleep(2);
+      await TestDataGenerator.minimalSleep();
       const c = (await TestDataGenerator.generateRecordsWrite()).message; // c is the newest since its created last
 
       const newestMessage = await Message.getOldestMessage([b, c, a]);

--- a/tests/core/message.spec.ts
+++ b/tests/core/message.spec.ts
@@ -1,10 +1,10 @@
 import type { RecordsWriteMessageWithOptionalEncodedData } from '../../src/store/storage-controller.js';
 
 import { expect } from 'chai';
-import { getCurrentTimeInHighPrecision } from '../../src/utils/time.js';
 import { Message } from '../../src/core/message.js';
 import { RecordsRead } from '../../src/index.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
+import { getCurrentTimeInHighPrecision, minimalSleep } from '../../src/utils/time.js';
 
 describe('Message', () => {
   describe('getAuthor()', () => {
@@ -45,9 +45,9 @@ describe('Message', () => {
   describe('getNewestMessage', () => {
     it('should return the newest message', async () => {
       const a = (await TestDataGenerator.generateRecordsWrite()).message;
-      await TestDataGenerator.minimalSleep();
+      await minimalSleep();
       const b = (await TestDataGenerator.generateRecordsWrite()).message;
-      await TestDataGenerator.minimalSleep();
+      await minimalSleep();
       const c = (await TestDataGenerator.generateRecordsWrite()).message; // c is the newest since its created last
 
       const newestMessage = await Message.getNewestMessage([b, c, a]);
@@ -58,9 +58,9 @@ describe('Message', () => {
   describe('getOldestMessage', () => {
     it('should return the newest message', async () => {
       const a = (await TestDataGenerator.generateRecordsWrite()).message;
-      await TestDataGenerator.minimalSleep();
+      await minimalSleep();
       const b = (await TestDataGenerator.generateRecordsWrite()).message;
-      await TestDataGenerator.minimalSleep();
+      await minimalSleep();
       const c = (await TestDataGenerator.generateRecordsWrite()).message; // c is the newest since its created last
 
       const newestMessage = await Message.getOldestMessage([b, c, a]);

--- a/tests/core/message.spec.ts
+++ b/tests/core/message.spec.ts
@@ -45,9 +45,9 @@ describe('Message', () => {
   describe('getNewestMessage', () => {
     it('should return the newest message', async () => {
       const a = (await TestDataGenerator.generateRecordsWrite()).message;
-      await sleep(1); // need to sleep for at least one millisecond else some messages get generated with the same time
+      await sleep(2); // need to sleep for at least two millisecond else some messages get generated with the same time
       const b = (await TestDataGenerator.generateRecordsWrite()).message;
-      await sleep(1);
+      await sleep(2);
       const c = (await TestDataGenerator.generateRecordsWrite()).message; // c is the newest since its created last
 
       const newestMessage = await Message.getNewestMessage([b, c, a]);
@@ -58,9 +58,9 @@ describe('Message', () => {
   describe('getOldestMessage', () => {
     it('should return the newest message', async () => {
       const a = (await TestDataGenerator.generateRecordsWrite()).message;
-      await sleep(1); // need to sleep for at least one millisecond else some messages get generated with the same time
+      await sleep(2); // need to sleep for at least two millisecond else some messages get generated with the same time
       const b = (await TestDataGenerator.generateRecordsWrite()).message;
-      await sleep(1);
+      await sleep(2);
       const c = (await TestDataGenerator.generateRecordsWrite()).message; // c is the newest since its created last
 
       const newestMessage = await Message.getOldestMessage([b, c, a]);

--- a/tests/handlers/permissions-revoke.spec.ts
+++ b/tests/handlers/permissions-revoke.spec.ts
@@ -255,7 +255,7 @@ describe('PermissionsRevokeHandler.handle()', () => {
         permissionsGrantId : await Message.getCid(permissionsGrant.message),
       });
 
-      await sleep(2);
+      await TestDataGenerator.minimalSleep();
 
       // Revoke the grant using a later timestamp than the pre-created revoke
       const { permissionsRevoke: permissionsRevoke2 } = await TestDataGenerator.generatePermissionsRevoke({

--- a/tests/handlers/permissions-revoke.spec.ts
+++ b/tests/handlers/permissions-revoke.spec.ts
@@ -11,7 +11,7 @@ import { Message } from '../../src/core/message.js';
 import { MessageStoreLevel } from '../../src/store/message-store-level.js';
 import { PermissionsRevoke } from '../../src/interfaces/permissions-revoke.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
-import { getCurrentTimeInHighPrecision, sleep } from '../../src/utils/time.js';
+import { getCurrentTimeInHighPrecision, minimalSleep, sleep } from '../../src/utils/time.js';
 
 describe('PermissionsRevokeHandler.handle()', () => {
   let didResolver: DidResolver;
@@ -255,7 +255,7 @@ describe('PermissionsRevokeHandler.handle()', () => {
         permissionsGrantId : await Message.getCid(permissionsGrant.message),
       });
 
-      await TestDataGenerator.minimalSleep();
+      await minimalSleep();
 
       // Revoke the grant using a later timestamp than the pre-created revoke
       const { permissionsRevoke: permissionsRevoke2 } = await TestDataGenerator.generatePermissionsRevoke({

--- a/tests/handlers/permissions-revoke.spec.ts
+++ b/tests/handlers/permissions-revoke.spec.ts
@@ -255,7 +255,7 @@ describe('PermissionsRevokeHandler.handle()', () => {
         permissionsGrantId : await Message.getCid(permissionsGrant.message),
       });
 
-      await sleep(1);
+      await sleep(2);
 
       // Revoke the grant using a later timestamp than the pre-created revoke
       const { permissionsRevoke: permissionsRevoke2 } = await TestDataGenerator.generatePermissionsRevoke({

--- a/tests/handlers/protocols-configure.spec.ts
+++ b/tests/handlers/protocols-configure.spec.ts
@@ -115,7 +115,7 @@ export function testProtocolsConfigureHandler(): void {
           author: alice,
           protocolDefinition,
         });
-        await sleep(1);
+        await sleep(2);
         const middleProtocolsConfigure = await TestDataGenerator.generateProtocolsConfigure({
           author: alice,
           protocolDefinition,
@@ -299,7 +299,7 @@ export function testProtocolsConfigureHandler(): void {
         it('should delete older ProtocolsConfigure events when one is overwritten', async () => {
           const alice = await DidKeyResolver.generate();
           const oldestWrite = await TestDataGenerator.generateProtocolsConfigure({ author: alice, protocolDefinition: minimalProtocolDefinition });
-          await sleep(1);
+          await sleep(2);
           const newestWrite = await TestDataGenerator.generateProtocolsConfigure({ author: alice, protocolDefinition: minimalProtocolDefinition });
 
           let reply = await dwn.processMessage(alice.did, oldestWrite.message, oldestWrite.dataStream);

--- a/tests/handlers/protocols-configure.spec.ts
+++ b/tests/handlers/protocols-configure.spec.ts
@@ -16,6 +16,7 @@ import { DidKeyResolver } from '../../src/did/did-key-resolver.js';
 import { GeneralJwsSigner } from '../../src/jose/jws/general/signer.js';
 import { lexicographicalCompare } from '../../src/utils/string.js';
 import { Message } from '../../src/core/message.js';
+import { minimalSleep } from '../../src/utils/time.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestStores } from '../test-stores.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
@@ -114,7 +115,7 @@ export function testProtocolsConfigureHandler(): void {
           author: alice,
           protocolDefinition,
         });
-        await TestDataGenerator.minimalSleep();
+        await minimalSleep();
         const middleProtocolsConfigure = await TestDataGenerator.generateProtocolsConfigure({
           author: alice,
           protocolDefinition,
@@ -298,7 +299,7 @@ export function testProtocolsConfigureHandler(): void {
         it('should delete older ProtocolsConfigure events when one is overwritten', async () => {
           const alice = await DidKeyResolver.generate();
           const oldestWrite = await TestDataGenerator.generateProtocolsConfigure({ author: alice, protocolDefinition: minimalProtocolDefinition });
-          await TestDataGenerator.minimalSleep();
+          await minimalSleep();
           const newestWrite = await TestDataGenerator.generateProtocolsConfigure({ author: alice, protocolDefinition: minimalProtocolDefinition });
 
           let reply = await dwn.processMessage(alice.did, oldestWrite.message, oldestWrite.dataStream);

--- a/tests/handlers/protocols-configure.spec.ts
+++ b/tests/handlers/protocols-configure.spec.ts
@@ -16,7 +16,6 @@ import { DidKeyResolver } from '../../src/did/did-key-resolver.js';
 import { GeneralJwsSigner } from '../../src/jose/jws/general/signer.js';
 import { lexicographicalCompare } from '../../src/utils/string.js';
 import { Message } from '../../src/core/message.js';
-import { sleep } from '../../src/utils/time.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestStores } from '../test-stores.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
@@ -115,7 +114,7 @@ export function testProtocolsConfigureHandler(): void {
           author: alice,
           protocolDefinition,
         });
-        await sleep(2);
+        await TestDataGenerator.minimalSleep();
         const middleProtocolsConfigure = await TestDataGenerator.generateProtocolsConfigure({
           author: alice,
           protocolDefinition,
@@ -299,7 +298,7 @@ export function testProtocolsConfigureHandler(): void {
         it('should delete older ProtocolsConfigure events when one is overwritten', async () => {
           const alice = await DidKeyResolver.generate();
           const oldestWrite = await TestDataGenerator.generateProtocolsConfigure({ author: alice, protocolDefinition: minimalProtocolDefinition });
-          await sleep(2);
+          await TestDataGenerator.minimalSleep();
           const newestWrite = await TestDataGenerator.generateProtocolsConfigure({ author: alice, protocolDefinition: minimalProtocolDefinition });
 
           let reply = await dwn.processMessage(alice.did, oldestWrite.message, oldestWrite.dataStream);

--- a/tests/handlers/protocols-query.spec.ts
+++ b/tests/handlers/protocols-query.spec.ts
@@ -273,7 +273,7 @@ export function testProtocolsQueryHandler(): void {
 
           // Set up timestamps
           const protocolsQueryTimestamp = getCurrentTimeInHighPrecision();
-          await sleep(1);
+          await sleep(2);
           const dateGranted = getCurrentTimeInHighPrecision();
 
           // Alice gives Bob a PermissionsGrant with scope ProtocolsConfigure

--- a/tests/handlers/records-delete.spec.ts
+++ b/tests/handlers/records-delete.spec.ts
@@ -12,7 +12,6 @@ import { ArrayUtility } from '../../src/utils/array.js';
 import { DidKeyResolver } from '../../src/did/did-key-resolver.js';
 import { Message } from '../../src/core/message.js';
 import { RecordsDeleteHandler } from '../../src/handlers/records-delete.js';
-import { sleep } from '../../src/utils/time.js';
 import { stubInterface } from 'ts-sinon';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestStores } from '../test-stores.js';
@@ -196,7 +195,7 @@ export function testRecordsDeleteHandler(): void {
           recordId                    : initialWriteData.message.recordId,
           authorizationSignatureInput : Jws.createSignatureInput(alice)
         });
-        await sleep(2);
+        await TestDataGenerator.minimalSleep();
         const subsequentWriteData = await TestDataGenerator.generateFromRecordsWrite({
           existingWrite : initialWriteData.recordsWrite,
           author        : alice

--- a/tests/handlers/records-delete.spec.ts
+++ b/tests/handlers/records-delete.spec.ts
@@ -11,6 +11,7 @@ import chai, { expect } from 'chai';
 import { ArrayUtility } from '../../src/utils/array.js';
 import { DidKeyResolver } from '../../src/did/did-key-resolver.js';
 import { Message } from '../../src/core/message.js';
+import { minimalSleep } from '../../src/utils/time.js';
 import { RecordsDeleteHandler } from '../../src/handlers/records-delete.js';
 import { stubInterface } from 'ts-sinon';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
@@ -195,7 +196,7 @@ export function testRecordsDeleteHandler(): void {
           recordId                    : initialWriteData.message.recordId,
           authorizationSignatureInput : Jws.createSignatureInput(alice)
         });
-        await TestDataGenerator.minimalSleep();
+        await minimalSleep();
         const subsequentWriteData = await TestDataGenerator.generateFromRecordsWrite({
           existingWrite : initialWriteData.recordsWrite,
           author        : alice

--- a/tests/handlers/records-delete.spec.ts
+++ b/tests/handlers/records-delete.spec.ts
@@ -196,7 +196,7 @@ export function testRecordsDeleteHandler(): void {
           recordId                    : initialWriteData.message.recordId,
           authorizationSignatureInput : Jws.createSignatureInput(alice)
         });
-        await sleep(1);
+        await sleep(2);
         const subsequentWriteData = await TestDataGenerator.generateFromRecordsWrite({
           existingWrite : initialWriteData.recordsWrite,
           author        : alice

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -37,6 +37,7 @@ import type { PrivateJwk, PublicJwk } from '../../src/types/jose-types.js';
 import * as cbor from '@ipld/dag-cbor';
 import { CID } from 'multiformats/cid';
 import { DataStream } from '../../src/utils/data-stream.js';
+import { getCurrentTimeInHighPrecision } from '../../src/utils/time.js';
 import { PermissionsGrant } from '../../src/interfaces/permissions-grant.js';
 import { PermissionsRequest } from '../../src/interfaces/permissions-request.js';
 import { PermissionsRevoke } from '../../src/interfaces/permissions-revoke.js';
@@ -44,7 +45,6 @@ import { removeUndefinedProperties } from '../../src/utils/object.js';
 import { Secp256k1 } from '../../src/utils/secp256k1.js';
 import { sha256 } from 'multiformats/hashes/sha2';
 import { Temporal } from '@js-temporal/polyfill';
-import { getCurrentTimeInHighPrecision, sleep } from '../../src/utils/time.js';
 
 import {
   DidKeyResolver,
@@ -820,13 +820,5 @@ export class TestDataGenerator {
       },
       didDocumentMetadata: {}
     };
-  }
-
-  /**
-   * We must sleep for at least 2ms to avoid timestamp collisions during testing.
-   * https://github.com/TBD54566975/dwn-sdk-js/issues/481
-   */
-  public static async minimalSleep(): Promise<void> {
-    await sleep(2);
   }
 }

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -37,7 +37,6 @@ import type { PrivateJwk, PublicJwk } from '../../src/types/jose-types.js';
 import * as cbor from '@ipld/dag-cbor';
 import { CID } from 'multiformats/cid';
 import { DataStream } from '../../src/utils/data-stream.js';
-import { getCurrentTimeInHighPrecision } from '../../src/utils/time.js';
 import { PermissionsGrant } from '../../src/interfaces/permissions-grant.js';
 import { PermissionsRequest } from '../../src/interfaces/permissions-request.js';
 import { PermissionsRevoke } from '../../src/interfaces/permissions-revoke.js';
@@ -45,6 +44,7 @@ import { removeUndefinedProperties } from '../../src/utils/object.js';
 import { Secp256k1 } from '../../src/utils/secp256k1.js';
 import { sha256 } from 'multiformats/hashes/sha2';
 import { Temporal } from '@js-temporal/polyfill';
+import { getCurrentTimeInHighPrecision, sleep } from '../../src/utils/time.js';
 
 import {
   DidKeyResolver,
@@ -820,5 +820,13 @@ export class TestDataGenerator {
       },
       didDocumentMetadata: {}
     };
+  }
+
+  /**
+   * We must sleep for at least 2ms to avoid timestamp collisions during testing.
+   * https://github.com/TBD54566975/dwn-sdk-js/issues/481
+   */
+  public static async minimalSleep(): Promise<void> {
+    await sleep(2);
   }
 }


### PR DESCRIPTION
Experienced this issue and tracked it down:
https://github.com/TBD54566975/dwn-sdk-js/issues/481

This might be some sort of precision bug within Temporal itself, I'm not really sure how various NodeJS systems handle time precision.

But in these cases there simply needs to be a gap in time for the testing logic, increasing the gap by an additional millisecond will make sure these tests are accurate.