### PR TITLE
Temporarily disable protocol any and context rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.65%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.64%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-94.04%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.65%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.1%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.46%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.75%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.1%25-brightgreen.svg?style=flat)
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/json-schemas/interface-methods/protocol-rule-set.json
+++ b/json-schemas/interface-methods/protocol-rule-set.json
@@ -68,8 +68,6 @@
                   "inGroup": {
                     "type": "string",
                     "enum": [
-                      "any",
-                      "context",
                       "ancestors"
                     ]
                   }

--- a/tests/handlers/records-read.spec.ts
+++ b/tests/handlers/records-read.spec.ts
@@ -314,7 +314,7 @@ export function testRecordsReadHandler(): void {
             expect(imposterReadReply.status.detail).to.include(DwnErrorCode.ProtocolAuthorizationActionNotAllowed);
           });
 
-          it('should allow read with `context` recipient rule', async () => {
+          xit('should allow read with `context` recipient rule', async () => {
             // scenario: Alice creates a groupChat and sends a message to the groupChat.
             //           Bob tries and fails to read the message. Then Alice invites with Bob to the groupChat.
             //           Now, Bob is able to send a message to the groupChat because he recieved an invite.
@@ -389,7 +389,7 @@ export function testRecordsReadHandler(): void {
             expect(readReply2.status.code).to.equal(200);
           });
 
-          it('should allow read with `any` recipient rule', async () => {
+          xit('should allow read with `any` recipient rule', async () => {
             // scenario: Bob tries to read a chat message to Alice's DWN, but fails because Alice has not added him as a friend.
             //           Alice adds Bob as a friend, then Bob is able to read a chat message.
 
@@ -499,7 +499,7 @@ export function testRecordsReadHandler(): void {
             expect(imposterReadReply.status.detail).to.include(DwnErrorCode.ProtocolAuthorizationActionNotAllowed);
           });
 
-          it('should allow read with `context` author rule', async () => {
+          xit('should allow read with `context` author rule', async () => {
             // scenario: Alice starts a groupChat. Bob tries and fails to read a groupChat/chat.
             //           Bob joins the groupChat, then he is able to read a groupChat/chat.
 
@@ -573,7 +573,7 @@ export function testRecordsReadHandler(): void {
             expect(readReply2.status.code).to.equal(200);
           });
 
-          it('should allow read with `any` author rule', async () => {
+          xit('should allow read with `any` author rule', async () => {
             // scenario: Alice writes a `reward` to the contribution-reward protocol. Bob tries and fails to read the reward.
             //           He makes a contribution, then he is able to read the reward
 

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -947,7 +947,7 @@ export function testRecordsWriteHandler(): void {
               .to.equal(base64url.baseEncode(encodedCredentialResponse));
           });
 
-          it('should allow write with `context` recipient rule', async () => {
+          xit('should allow write with `context` recipient rule', async () => {
             // scenario: Alice creates a groupChat. Bob tries and fails to write a message.
             //           Then invites with Bob to the groupChat. Now, Bob is able to send a
             //           message to the groupChat because he recieved an invite.
@@ -1015,7 +1015,7 @@ export function testRecordsWriteHandler(): void {
             expect(messageReply.status.code).to.equal(202);
           });
 
-          it('should allow write with `any` recipient rule', async () => {
+          xit('should allow write with `any` recipient rule', async () => {
             // scenario: Bob tries to write a chat message to Alice's DWN, but fails because Alice has not added him as a friend.
             //           Alice adds Bob as a friend, then Bob is able to write a chat message.
 
@@ -1146,7 +1146,7 @@ export function testRecordsWriteHandler(): void {
               .to.equal(base64url.baseEncode(encodedCaption));
           });
 
-          it('should allow write with `context` author rule', async () => {
+          xit('should allow write with `context` author rule', async () => {
             // scenario: Alice starts a groupChat. Bob tries and fails to write a groupChat/chat.
             //           Bob joins the groupChat, then he is able to write a groupChat/chat.
 
@@ -1212,7 +1212,7 @@ export function testRecordsWriteHandler(): void {
             expect(bobsChatReply2.status.code).to.equal(202);
           });
 
-          it('should allow write with `any` author rule', async () => {
+          xit('should allow write with `any` author rule', async () => {
             // scenario: Alice hosts a Q&A Forum and where anyone who has previously asked a question
             //           may provide an answer to other questions.
             //           Alice writes a question. Bob asks tries to write an to answer her question, but cannot.


### PR DESCRIPTION
We are working on another way to address these use cases with a new protocol concept called `roles`. In the meantime, it's best we disable the `any` and `context`. I'll rip out / update the code implementing of these protocol rules in a later PR. This PR is minimal for expediency.