### PR TITLE
Remove sleep() from db.open()

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-96.91%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.49%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.51%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-96.91%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.11%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.49%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.76%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.11%25-brightgreen.svg?style=flat)
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.11%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.47%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.75%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.11%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-96.91%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.49%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.51%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-96.91%25-brightgreen.svg?style=flat)
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.11%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.49%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.76%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.11%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.11%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-94.48%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-93.76%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.11%25-brightgreen.svg?style=flat)
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/src/store/level-wrapper.ts
+++ b/src/store/level-wrapper.ts
@@ -60,7 +60,7 @@ export class LevelWrapper<V> {
     // If db is still opening, wait until the 'open' event is emitted
     case 'opening':
       return new Promise((resolve) => {
-        this.db.once('open', () => resolve());
+        this.db.once('open', resolve);
       });
 
     // If db is closing, wait until it is closed then await `db.open()`

--- a/src/store/level-wrapper.ts
+++ b/src/store/level-wrapper.ts
@@ -47,6 +47,11 @@ export class LevelWrapper<V> {
   async open(): Promise<void> {
     await this.createLevelDatabase();
 
+    // `db.open()` is automatically called by the database constructor. We may need to call it explicitly
+    // in order to explicitly catch an error that would otherwise not surface until another method
+    // like `db.get()` is called.  Once `db.open()` has then been called, any read & write
+    // operations will again be queued internally until opening has finished.
+
     // Create an event handler that resolves the Promise when 'open' event is emitted
     // or if db.status is already === 'open'.
     return new Promise(async (resolve) => {


### PR DESCRIPTION
Addresses #483.

Currently, when we open our `LevelWrapper` db, we `sleep(200)` repeatedly until it is open. Per the [abstract-level documentation](https://github.com/Level/abstract-level#events), the `db` emits events for `open`, `opening`, `closed`, and `closing`. So we simply need to wrap the event emitter in a promise and await that promise..