### PR TITLE
Remove extraneous TimestampedMessage type

### DIFF
--- a/src/core/message.ts
+++ b/src/core/message.ts
@@ -1,6 +1,6 @@
 import type { GeneralJws } from '../types/jws-types.js';
 import type { SignatureInput } from '../types/jws-types.js';
-import type { BaseAuthorizationPayload, Descriptor, GenericMessage, TimestampedMessage } from '../types/message-types.js';
+import type { BaseAuthorizationPayload, Descriptor, GenericMessage } from '../types/message-types.js';
 
 import { Cid } from '../utils/cid.js';
 import { GeneralJwsSigner } from '../jose/jws/general/signer.js';
@@ -156,8 +156,8 @@ export abstract class Message<M extends GenericMessage> {
   /**
    * @returns newest message in the array. `undefined` if given array is empty.
    */
-  public static async getNewestMessage(messages: TimestampedMessage[]): Promise<TimestampedMessage | undefined> {
-    let currentNewestMessage: TimestampedMessage | undefined = undefined;
+  public static async getNewestMessage(messages: GenericMessage[]): Promise<GenericMessage | undefined> {
+    let currentNewestMessage: GenericMessage | undefined = undefined;
     for (const message of messages) {
       if (currentNewestMessage === undefined || await Message.isNewer(message, currentNewestMessage)) {
         currentNewestMessage = message;
@@ -170,8 +170,8 @@ export abstract class Message<M extends GenericMessage> {
   /**
    * @returns oldest message in the array. `undefined` if given array is empty.
    */
-  public static async getOldestMessage(messages: TimestampedMessage[]): Promise<TimestampedMessage | undefined> {
-    let currentOldestMessage: TimestampedMessage | undefined = undefined;
+  public static async getOldestMessage(messages: GenericMessage[]): Promise<GenericMessage | undefined> {
+    let currentOldestMessage: GenericMessage | undefined = undefined;
     for (const message of messages) {
       if (currentOldestMessage === undefined || await Message.isOlder(message, currentOldestMessage)) {
         currentOldestMessage = message;
@@ -185,7 +185,7 @@ export abstract class Message<M extends GenericMessage> {
    * Checks if first message is newer than second message.
    * @returns `true` if `a` is newer than `b`; `false` otherwise
    */
-  public static async isNewer(a: TimestampedMessage, b: TimestampedMessage): Promise<boolean> {
+  public static async isNewer(a: GenericMessage, b: GenericMessage): Promise<boolean> {
     const aIsNewer = (await Message.compareMessageTimestamp(a, b) > 0);
     return aIsNewer;
   }
@@ -194,7 +194,7 @@ export abstract class Message<M extends GenericMessage> {
    * Checks if first message is older than second message.
    * @returns `true` if `a` is older than `b`; `false` otherwise
    */
-  public static async isOlder(a: TimestampedMessage, b: TimestampedMessage): Promise<boolean> {
+  public static async isOlder(a: GenericMessage, b: GenericMessage): Promise<boolean> {
     const aIsOlder = (await Message.compareMessageTimestamp(a, b) < 0);
     return aIsOlder;
   }
@@ -203,7 +203,7 @@ export abstract class Message<M extends GenericMessage> {
    * Compares the `messageTimestamp` of the given messages with a fallback to message CID according to the spec.
    * @returns 1 if `a` is larger/newer than `b`; -1 if `a` is smaller/older than `b`; 0 otherwise (same age)
    */
-  public static async compareMessageTimestamp(a: TimestampedMessage, b: TimestampedMessage): Promise<number> {
+  public static async compareMessageTimestamp(a: GenericMessage, b: GenericMessage): Promise<number> {
     if (a.descriptor.messageTimestamp > b.descriptor.messageTimestamp) {
       return 1;
     } else if (a.descriptor.messageTimestamp < b.descriptor.messageTimestamp) {

--- a/src/handlers/records-delete.ts
+++ b/src/handlers/records-delete.ts
@@ -1,8 +1,8 @@
 import type { EventLog } from '../types/event-log.js';
 import type { GenericMessageReply } from '../core/message-reply.js';
 import type { MethodHandler } from '../types/method-handler.js';
+import type { DataStore, DidResolver, MessageStore } from '../index.js';
 import type { RecordsDeleteMessage, RecordsWriteMessage } from '../types/records-types.js';
-import type { DataStore, DidResolver, GenericMessage, MessageStore, RecordsWrite } from '../index.js';
 
 import { authenticate } from '../core/auth.js';
 import { messageReplyFromError } from '../core/message-reply.js';

--- a/src/handlers/records-delete.ts
+++ b/src/handlers/records-delete.ts
@@ -1,9 +1,8 @@
 import type { EventLog } from '../types/event-log.js';
 import type { GenericMessageReply } from '../core/message-reply.js';
 import type { MethodHandler } from '../types/method-handler.js';
-import type { RecordsDeleteMessage } from '../types/records-types.js';
-import type { TimestampedMessage } from '../types/message-types.js';
-import type { DataStore, DidResolver, MessageStore } from '../index.js';
+import type { RecordsDeleteMessage, RecordsWriteMessage } from '../types/records-types.js';
+import type { DataStore, DidResolver, GenericMessage, MessageStore, RecordsWrite } from '../index.js';
 
 import { authenticate } from '../core/auth.js';
 import { messageReplyFromError } from '../core/message-reply.js';
@@ -40,7 +39,7 @@ export class RecordsDeleteHandler implements MethodHandler {
       interface : DwnInterfaceName.Records,
       recordId  : message.descriptor.recordId
     };
-    const existingMessages = await this.messageStore.query(tenant, query) as TimestampedMessage[];
+    const existingMessages = await this.messageStore.query(tenant, query) as (RecordsWriteMessage | RecordsDeleteMessage)[];
 
     // find which message is the newest, and if the incoming message is the newest
     const newestExistingMessage = await Message.getNewestMessage(existingMessages);

--- a/src/store/storage-controller.ts
+++ b/src/store/storage-controller.ts
@@ -1,8 +1,8 @@
 import type { DataStore } from '../types/data-store.js';
 import type { EventLog } from '../types/event-log.js';
+import type { GenericMessage } from '../types/message-types.js';
 import type { MessageStore } from '../types/message-store.js';
 import type { RecordsWriteMessage } from '../types/records-types.js';
-import type { GenericMessage, TimestampedMessage } from '../types/message-types.js';
 
 import { constructRecordsWriteIndexes } from '../handlers/records-write.js';
 import { DwnConstant } from '../core/dwn-constant.js';
@@ -40,8 +40,8 @@ export class StorageController {
    */
   public static async deleteAllOlderMessagesButKeepInitialWrite(
     tenant: string,
-    existingMessages: TimestampedMessage[],
-    comparedToMessage: TimestampedMessage,
+    existingMessages: GenericMessage[],
+    comparedToMessage: GenericMessage,
     messageStore: MessageStore,
     dataStore: DataStore,
     eventLog: EventLog

--- a/src/types/message-types.ts
+++ b/src/types/message-types.ts
@@ -27,15 +27,6 @@ export type Descriptor = {
 };
 
 /**
- * Messages that have `messageTimestamp` in their `descriptor` property.
- */
-export type TimestampedMessage = GenericMessage & {
-  descriptor: {
-    messageTimestamp: string;
-  }
-};
-
-/**
  * Message returned in a query result.
  * NOTE: the message structure is a modified version of the message received, the most notable differences are:
  * 1. does not contain `authorization`


### PR DESCRIPTION
Previous `TimestampedMessage` referred to messages with `dateModified` in the descriptor. We removed `dateModified` and now all messages use `messageTimestamp`. So we can use type `GenericMessage` instead of `TimestampedMessage`.