### PR TITLE
Make EventLogLevelConfig.location optional

### DIFF
--- a/src/event-log/event-log-level.ts
+++ b/src/event-log/event-log-level.ts
@@ -11,7 +11,7 @@ type EventLogLevelConfig = {
    *  LevelDB will store its files, or in browsers, the name of the
    * {@link https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase IDBDatabase} to be opened.
   */
-  location: string,
+  location?: string,
   createLevelDatabase?: typeof createLevelDatabase,
 };
 
@@ -30,7 +30,11 @@ export class EventLogLevel implements EventLog {
       ...config,
     };
 
-    this.db = new LevelWrapper<string>({ ...this.config, valueEncoding: 'utf8' });
+    this.db = new LevelWrapper<string>({
+      location            : this.config.location!,
+      createLevelDatabase : this.config.createLevelDatabase,
+      valueEncoding       : 'utf8',
+    });
     this.ulidFactory = monotonicFactory();
   }
 


### PR DESCRIPTION
`EventLogLevelConfig` is used when constructing an `EventLogLevel` instance. 

Currently, the `location` property in the config is required. This means that the default location used in the `EventLogLevel` constructor of `'EVENTLOG'` is never actually used.

Other stores, like `MessageStoreLevel` and `DataStoreLevel` have their config locations optional, and then will use the non-null assertion operator to use default values if there wasn't a location defined ([MessageStoreLevel code here](https://github.com/TBD54566975/dwn-sdk-js/blob/main/src/store/message-store-level.ts#L38-L55) and [DataStoreLevel code here](https://github.com/TBD54566975/dwn-sdk-js/blob/main/src/store/data-store-level.ts#L29-L40)).

This PR makes the `EventLogLevelConfig.location` property optional to match the other stores, using `EVENTLOG` if a location wasn't specified by the caller.