### PR TITLE
Export Sort and Pagination types.

### DIFF
--- a/src/core/dwn-constant.ts
+++ b/src/core/dwn-constant.ts
@@ -1,7 +1,9 @@
 export class DwnConstant {
   /**
-   * The maximum size in bytes of raw data that will be returned as `encodedData`.
-   * this is also the maximum size that we will store within MessageStore.
+   * The maximum size of raw data that will be returned as `encodedData`.
+   *
+   * We chose 30k, as after encoding it would give plenty of headroom up to the 65k limit in most SQL variants.
+   * We currently encode using base64url which is a 33% increase in size.
    */
-  public static readonly maxDataSizeAllowedToBeEncoded = 42_000;
+  public static readonly maxDataSizeAllowedToBeEncoded = 30_000;
 }

--- a/src/core/dwn-constant.ts
+++ b/src/core/dwn-constant.ts
@@ -3,5 +3,5 @@ export class DwnConstant {
    * The maximum size in bytes of raw data that will be returned as `encodedData`.
    * this is also the maximum size that we will store within MessageStore.
    */
-  public static readonly maxDataSizeAllowedToBeEncoded = 50_000;
+  public static readonly maxDataSizeAllowedToBeEncoded = 42_000;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,13 @@ export type { DwnServiceEndpoint, ServiceEndpoint, DidDocument, DidResolutionRes
 export type { EventLog, Event, GetEventsOptions } from './types/event-log.js';
 export type { EventsGetMessage, EventsGetReply } from './types/event-types.js';
 export type { HooksWriteMessage } from './types/hooks-types.js';
-export type { GenericMessage, Filter } from './types/message-types.js';
+export type { Filter, GenericMessage, MessageSort, Pagination } from './types/message-types.js';
 export type { MessagesGetMessage, MessagesGetReply } from './types/messages-types.js';
 export type { PermissionConditions, PermissionScope, PermissionsGrantDescriptor, PermissionsGrantMessage, PermissionsRequestDescriptor, PermissionsRequestMessage, PermissionsRevokeDescriptor, PermissionsRevokeMessage } from './types/permissions-types.js';
 export type { ProtocolsConfigureDescriptor, ProtocolDefinition, ProtocolTypes, ProtocolRuleSet, ProtocolsQueryFilter, ProtocolsConfigureMessage, ProtocolsQueryMessage } from './types/protocols-types.js';
 export type { EncryptionProperty, RecordsDeleteMessage, RecordsQueryMessage, RecordsQueryReply, RecordsQueryReplyEntry, RecordsReadReply, RecordsWriteDescriptor, RecordsWriteMessage } from './types/records-types.js';
 export type { SnapshotsCreateDescriptor, SnapshotsCreateMessage, SnapshotDefinition, SnapshotScope, SnapshotScopeType } from './types/snapshots-types.js';
+export { SortOrder } from './types/message-types.js';
 export { AllowAllTenantGate, TenantGate } from './core/tenant-gate.js';
 export { Cid } from './utils/cid.js';
 export { DateSort, RecordsQuery, RecordsQueryOptions } from './interfaces/records-query.js';


### PR DESCRIPTION
Exporting Filter, Sort and Pagination types for consumption by external MessageStores.

Lower max maxDataSizeAllowedToBeEncoded. We are currently checking this against the dataSize, which is the binary data size. However when we store it we are base64 encoding the data, which has an approximate increase of 33%, this was causing some issues going right above the limit in SQL.

Upon some rough calculations of the 65k limit for most SQL - 33% reduction, I rounded down to the nice number of 42_000.