### PR TITLE
offline did resolution in tests were not working

### DIFF
--- a/src/did/did-ion-resolver.ts
+++ b/src/did/did-ion-resolver.ts
@@ -1,22 +1,27 @@
-import type { DidMethodResolver, DidResolutionResult } from './did-resolver.js';
-
 import crossFetch from 'cross-fetch';
-// supports fetch in: node, browsers, and browser extensions.
-// uses native fetch if available in environment or falls back to a ponyfill.
-// 'cross-fetch' is a ponyfill that uses `XMLHTTPRequest` under the hood.
-// `XMLHTTPRequest` cannot be used in browser extension background service workers.
-// browser extensions get even more strict with `fetch` in that it cannot be referenced
-// indirectly.
-const fetch = globalThis.fetch ?? crossFetch;
+import type { DidMethodResolver, DidResolutionResult } from './did-resolver.js';
 
 /**
  * Resolver for ION DIDs.
  */
 export class DidIonResolver implements DidMethodResolver {
+
+  // since we are not always using global fetch, we set our fetch method within the constructor.
+  private fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
   /**
    * @param resolutionEndpoint optional custom URL to send DID resolution request to
    */
-  constructor (private resolutionEndpoint: string = 'https://discover.did.msidentity.com/1.0/identifiers/') { }
+  constructor (private resolutionEndpoint: string = 'https://discover.did.msidentity.com/1.0/identifiers/') {
+
+    // supports fetch in: node, browsers, and browser extensions.
+    // uses native fetch if available in environment or falls back to a ponyfill.
+    // 'cross-fetch' is a ponyfill that uses `XMLHTTPRequest` under the hood.
+    // `XMLHTTPRequest` cannot be used in browser extension background service workers.
+    // browser extensions get even more strict with `fetch` in that it cannot be referenced
+    // indirectly.
+    this.fetch = globalThis.fetch ?? crossFetch;
+  }
 
   method(): string {
     return 'ion';
@@ -26,7 +31,7 @@ export class DidIonResolver implements DidMethodResolver {
     // using `URL` constructor to handle both existence and absence of trailing slash '/' in resolution endpoint
     // appending './' to DID so 'did' in 'did:ion:abc' doesn't get interpreted as a URL scheme (e.g. like 'http') due to the colon
     const resolutionUrl = new URL('./' + did, this.resolutionEndpoint).toString();
-    const response = await fetch(resolutionUrl);
+    const response = await this.fetch(resolutionUrl);
 
     if (response.status !== 200) {
       throw new Error(`unable to resolve ${did}, got http status ${response.status}`);

--- a/src/did/did-ion-resolver.ts
+++ b/src/did/did-ion-resolver.ts
@@ -6,22 +6,19 @@ import type { DidMethodResolver, DidResolutionResult } from './did-resolver.js';
  */
 export class DidIonResolver implements DidMethodResolver {
 
-  // since we are not always using global fetch, we set our fetch method within the constructor.
-  private fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+  // supports fetch in: node, browsers, and browser extensions.
+  // uses native fetch if available in environment or falls back to a ponyfill.
+  // 'cross-fetch' is a ponyfill that uses `XMLHTTPRequest` under the hood.
+  // `XMLHTTPRequest` cannot be used in browser extension background service workers.
+  // browser extensions get even more strict with `fetch` in that it cannot be referenced
+  // indirectly.
+  // member field allows for test stubbing
+  private fetch = globalThis.fetch ?? crossFetch;
 
   /**
    * @param resolutionEndpoint optional custom URL to send DID resolution request to
    */
-  constructor (private resolutionEndpoint: string = 'https://discover.did.msidentity.com/1.0/identifiers/') {
-
-    // supports fetch in: node, browsers, and browser extensions.
-    // uses native fetch if available in environment or falls back to a ponyfill.
-    // 'cross-fetch' is a ponyfill that uses `XMLHTTPRequest` under the hood.
-    // `XMLHTTPRequest` cannot be used in browser extension background service workers.
-    // browser extensions get even more strict with `fetch` in that it cannot be referenced
-    // indirectly.
-    this.fetch = globalThis.fetch ?? crossFetch;
-  }
+  constructor (private resolutionEndpoint: string = 'https://discover.did.msidentity.com/1.0/identifiers/') { }
 
   method(): string {
     return 'ion';

--- a/tests/did/did-ion-resolver.spec.ts
+++ b/tests/did/did-ion-resolver.spec.ts
@@ -36,9 +36,10 @@ describe('DidIonResolver', () => {
     const did = 'did:ion:EiClkZMDxPKqC9c-umQfTkR8vvZ9JPhl_xLDI9Nfk38w5w';
     const didIonResolver = new DidIonResolver();
 
+    let resolverStub;
     // stub network call if network is not available
     if (!networkAvailable) {
-      sinon.stub(globalThis as any, 'fetch').resolves({
+      resolverStub = sinon.stub(didIonResolver as any, 'fetch').resolves({
         status : 200,
         json   : async () => Promise.resolve({
           didDocument         : { id: did },
@@ -48,6 +49,9 @@ describe('DidIonResolver', () => {
     }
 
     const resolutionDocument = await didIonResolver.resolve(did);
+    if (resolverStub) {
+      resolverStub.restore();
+    }
     expect(resolutionDocument.didDocument?.id).to.equal(did);
     expect(resolutionDocument.didDocumentMetadata.canonicalId).to.equal(did);
   });
@@ -56,12 +60,16 @@ describe('DidIonResolver', () => {
     const did = 'did:ion:SomethingThatCannotBeResolved';
     const didIonResolver = new DidIonResolver();
 
+    let resolverStub;
     // stub network call if network is not available
     if (!networkAvailable) {
-      sinon.stub(globalThis as any, 'fetch').resolves({ status: 404 });
+      resolverStub = sinon.stub(didIonResolver as any, 'fetch').resolves({ status: 404 });
     }
 
     const resolutionPromise = didIonResolver.resolve(did);
+    if (resolverStub) {
+      resolverStub.restore();
+    }
     await expect(resolutionPromise).to.be.rejectedWith('unable to resolve');
   });
 });


### PR DESCRIPTION
Refactored to include the fetch method within the DidIonResolver class.

Now sinon can stub out fetch when the network is unavailable.