### PR TITLE
#439 - Turned `authorization` property from a JWS into a container object

### DIFF
--- a/build/compile-validators.js
+++ b/build/compile-validators.js
@@ -17,6 +17,7 @@ import Ajv from 'ajv';
 import mkdirp from 'mkdirp';
 import standaloneCode from 'ajv/dist/standalone/index.js';
 
+import Authorization from '../json-schemas/authorization.json' assert { type: 'json' };
 import BaseAuthorizationPayload from '../json-schemas/authorization-payloads/base-authorization-payload.json' assert { type: 'json' };
 import Definitions from '../json-schemas/definitions.json' assert { type: 'json' };
 import EventsGet from '../json-schemas/events/events-get.json' assert { type: 'json' };
@@ -40,11 +41,12 @@ import RecordsFilter from '../json-schemas/interface-methods/records-filter.json
 import RecordsQuery from '../json-schemas/interface-methods/records-query.json' assert { type: 'json' };
 import RecordsRead from '../json-schemas/interface-methods/records-read.json' assert { type: 'json' };
 import RecordsWrite from '../json-schemas/interface-methods/records-write.json' assert { type: 'json' };
-import RecordsWriteAuthorizationPayload from '../json-schemas/authorization-payloads/records-write-authorization-payload.json' assert { type: 'json' };
+import RecordsWriteAuthorSignaturePayload from '../json-schemas/authorization-payloads/records-write-authorization-payload.json' assert { type: 'json' };
 import RecordsWriteUnidentified from '../json-schemas/interface-methods/records-write-unidentified.json' assert { type: 'json' };
 import SnapshotsCreate from '../json-schemas/interface-methods/snapshots-create.json' assert { type: 'json' };
 
 const schemas = {
+  Authorization,
   RecordsDelete,
   RecordsQuery,
   RecordsWrite,
@@ -70,7 +72,7 @@ const schemas = {
   PublicJwk,
   SnapshotsCreate,
   BaseAuthorizationPayload,
-  RecordsWriteAuthorizationPayload
+  RecordsWriteAuthorSignaturePayload
 };
 
 const ajv = new Ajv({ code: { source: true, esm: true } });

--- a/json-schemas/authorization.json
+++ b/json-schemas/authorization.json
@@ -1,0 +1,11 @@
+{
+  "$id": "https://identity.foundation/dwn/json-schemas/authorization.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "author": {
+      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+    }
+  }
+}

--- a/json-schemas/events/events-get.json
+++ b/json-schemas/events/events-get.json
@@ -9,7 +9,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+      "$ref": "https://identity.foundation/dwn/json-schemas/authorization.json"
     },
     "descriptor": {
       "type": "object",

--- a/json-schemas/hooks/hooks-write.json
+++ b/json-schemas/hooks/hooks-write.json
@@ -9,7 +9,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+      "$ref": "https://identity.foundation/dwn/json-schemas/authorization.json"
     },
     "descriptor": {
       "type": "object",

--- a/json-schemas/interface-methods/messages-get.json
+++ b/json-schemas/interface-methods/messages-get.json
@@ -9,7 +9,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+      "$ref": "https://identity.foundation/dwn/json-schemas/authorization.json"
     },
     "descriptor": {
       "type": "object",

--- a/json-schemas/interface-methods/permissions-grant.json
+++ b/json-schemas/interface-methods/permissions-grant.json
@@ -9,7 +9,7 @@
   "additionalProperties": false,
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+      "$ref": "https://identity.foundation/dwn/json-schemas/authorization.json"
     },
     "delegationChain": {
       "description": "the parent grant",

--- a/json-schemas/interface-methods/permissions-request.json
+++ b/json-schemas/interface-methods/permissions-request.json
@@ -9,7 +9,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+      "$ref": "https://identity.foundation/dwn/json-schemas/authorization.json"
     },
     "descriptor": {
       "type": "object",

--- a/json-schemas/interface-methods/permissions-revoke.json
+++ b/json-schemas/interface-methods/permissions-revoke.json
@@ -9,7 +9,7 @@
   "additionalProperties": false,
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+      "$ref": "https://identity.foundation/dwn/json-schemas/authorization.json"
     },
     "descriptor": {
       "type": "object",

--- a/json-schemas/interface-methods/protocols-configure.json
+++ b/json-schemas/interface-methods/protocols-configure.json
@@ -9,7 +9,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+      "$ref": "https://identity.foundation/dwn/json-schemas/authorization.json"
     },
     "descriptor": {
       "type": "object",

--- a/json-schemas/interface-methods/protocols-query.json
+++ b/json-schemas/interface-methods/protocols-query.json
@@ -8,7 +8,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+      "$ref": "https://identity.foundation/dwn/json-schemas/authorization.json"
     },
     "descriptor": {
       "type": "object",

--- a/json-schemas/interface-methods/records-delete.json
+++ b/json-schemas/interface-methods/records-delete.json
@@ -9,7 +9,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+      "$ref": "https://identity.foundation/dwn/json-schemas/authorization.json"
     },
     "descriptor": {
       "type": "object",

--- a/json-schemas/interface-methods/records-query.json
+++ b/json-schemas/interface-methods/records-query.json
@@ -8,7 +8,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+      "$ref": "https://identity.foundation/dwn/json-schemas/authorization.json"
     },
     "descriptor": {
       "type": "object",
@@ -44,7 +44,7 @@
           "properties": {
             "limit": {
               "type": "number",
-              "minimum": 1 
+              "minimum": 1
             },
             "messageCid": {
               "type": "string"

--- a/json-schemas/interface-methods/records-read.json
+++ b/json-schemas/interface-methods/records-read.json
@@ -8,7 +8,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+      "$ref": "https://identity.foundation/dwn/json-schemas/authorization.json"
     },
     "descriptor": {
       "type": "object",

--- a/json-schemas/interface-methods/records-write-unidentified.json
+++ b/json-schemas/interface-methods/records-write-unidentified.json
@@ -17,7 +17,7 @@
       "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
     },
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+      "$ref": "https://identity.foundation/dwn/json-schemas/authorization.json"
     },
     "encryption": {
       "type": "object",

--- a/json-schemas/interface-methods/snapshots-create.json
+++ b/json-schemas/interface-methods/snapshots-create.json
@@ -9,7 +9,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+      "$ref": "https://identity.foundation/dwn/json-schemas/authorization.json"
     },
     "descriptor": {
       "type": "object",

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -1,8 +1,7 @@
 import type { CID } from 'multiformats';
 import type { DidResolver } from '../did/did-resolver.js';
-import type { GeneralJws } from '../types/jws-types.js';
-import type { GenericMessage } from '../types/message-types.js';
 import type { Message } from './message.js';
+import type { AuthorizationModel, GenericMessage } from '../types/message-types.js';
 
 import { Cid } from '../utils/cid.js';
 import { GeneralJwsVerifier } from '../jose/jws/general/verifier.js';
@@ -38,12 +37,12 @@ export async function validateAuthorizationIntegrity(
     throw new DwnError(DwnErrorCode.AuthorizationMissing, 'Property `authorization` is missing.');
   }
 
-  if (message.authorization.signatures.length !== 1) {
+  if (message.authorization.author.signatures.length !== 1) {
     throw new Error('expected no more than 1 signature for authorization');
   }
 
   // validate payload integrity
-  const payloadJson = Jws.decodePlainObjectPayload(message.authorization);
+  const payloadJson = Jws.decodePlainObjectPayload(message.authorization.author);
 
   validateJsonSchema(jsonSchemaKey, payloadJson);
 
@@ -62,12 +61,12 @@ export async function validateAuthorizationIntegrity(
  * Validates the signature(s) of the given JWS.
  * @throws {Error} if fails authentication
  */
-export async function authenticate(jws: GeneralJws | undefined, didResolver: DidResolver): Promise<void> {
-  if (jws === undefined) {
+export async function authenticate(authorizationModel: AuthorizationModel | undefined, didResolver: DidResolver): Promise<void> {
+  if (authorizationModel === undefined) {
     throw new DwnError(DwnErrorCode.AuthenticateJwsMissing, 'Missing JWS.');
   }
 
-  const verifier = new GeneralJwsVerifier(jws);
+  const verifier = new GeneralJwsVerifier(authorizationModel.author);
   await verifier.verify(didResolver);
 }
 

--- a/src/interfaces/events-get.ts
+++ b/src/interfaces/events-get.ts
@@ -31,7 +31,7 @@ export class EventsGet extends Message<EventsGetMessage> {
       descriptor.watermark = options.watermark;
     }
 
-    const authorization = await Message.signAsAuthorization(descriptor, options.authorizationSigner);
+    const authorization = await Message.signAuthorizationAsAuthor(descriptor, options.authorizationSigner);
     const message = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/hooks-write.ts
+++ b/src/interfaces/hooks-write.ts
@@ -43,7 +43,7 @@ export class HooksWrite extends Message<HooksWriteMessage> {
     // Error: `undefined` is not supported by the IPLD Data Model and cannot be encoded
     removeUndefinedProperties(descriptor);
 
-    const authorization = await Message.signAsAuthorization(descriptor, options.authorizationSigner);
+    const authorization = await Message.signAuthorizationAsAuthor(descriptor, options.authorizationSigner);
     const message = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/messages-get.ts
+++ b/src/interfaces/messages-get.ts
@@ -30,7 +30,7 @@ export class MessagesGet extends Message<MessagesGetMessage> {
       messageTimestamp : options?.messageTimestamp ?? getCurrentTimeInHighPrecision(),
     };
 
-    const authorization = await Message.signAsAuthorization(descriptor, options.authorizationSigner);
+    const authorization = await Message.signAuthorizationAsAuthor(descriptor, options.authorizationSigner);
     const message = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/permissions-grant.ts
+++ b/src/interfaces/permissions-grant.ts
@@ -60,7 +60,7 @@ export class PermissionsGrant extends Message<PermissionsGrantMessage> {
     // Error: `undefined` is not supported by the IPLD Data Model and cannot be encoded
     removeUndefinedProperties(descriptor);
 
-    const authorization = await Message.signAsAuthorization(descriptor, options.authorizationSigner);
+    const authorization = await Message.signAuthorizationAsAuthor(descriptor, options.authorizationSigner);
     const message: PermissionsGrantMessage = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/permissions-request.ts
+++ b/src/interfaces/permissions-request.ts
@@ -43,7 +43,7 @@ export class PermissionsRequest extends Message<PermissionsRequestMessage> {
     // Error: `undefined` is not supported by the IPLD Data Model and cannot be encoded
     removeUndefinedProperties(descriptor);
 
-    const auth = await Message.signAsAuthorization(descriptor, options.authorizationSigner);
+    const auth = await Message.signAuthorizationAsAuthor(descriptor, options.authorizationSigner);
     const message: PermissionsRequestMessage = { descriptor, authorization: auth };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/permissions-revoke.ts
+++ b/src/interfaces/permissions-revoke.ts
@@ -27,7 +27,7 @@ export class PermissionsRevoke extends Message<PermissionsRevokeMessage> {
       permissionsGrantId : options.permissionsGrantId,
     };
 
-    const authorization = await Message.signAsAuthorization(descriptor, options.authorizationSigner);
+    const authorization = await Message.signAuthorizationAsAuthor(descriptor, options.authorizationSigner);
     const message: PermissionsRevokeMessage = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/protocols-configure.ts
+++ b/src/interfaces/protocols-configure.ts
@@ -34,7 +34,7 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
       definition       : ProtocolsConfigure.normalizeDefinition(options.definition)
     };
 
-    const authorization = await Message.signAsAuthorization(
+    const authorization = await Message.signAuthorizationAsAuthor(
       descriptor,
       options.authorizationSigner,
       { permissionsGrantId: options.permissionsGrantId }

--- a/src/interfaces/protocols-query.ts
+++ b/src/interfaces/protocols-query.ts
@@ -1,4 +1,4 @@
-import type { GeneralJws } from '../types/jws-types.js';
+import type { AuthorizationModel } from '../types/message-types.js';
 import type { MessageStore } from '../types/message-store.js';
 import type { Signer } from '../types/signer.js';
 import type { ProtocolsQueryDescriptor, ProtocolsQueryFilter, ProtocolsQueryMessage } from '../types/protocols-types.js';
@@ -46,9 +46,9 @@ export class ProtocolsQuery extends Message<ProtocolsQueryMessage> {
     removeUndefinedProperties(descriptor);
 
     // only generate the `authorization` property if signature input is given
-    let authorization: GeneralJws | undefined;
+    let authorization: AuthorizationModel | undefined;
     if (options.authorizationSigner !== undefined) {
-      authorization = await Message.signAsAuthorization(
+      authorization = await Message.signAuthorizationAsAuthor(
         descriptor,
         options.authorizationSigner,
         { permissionsGrantId: options.permissionsGrantId }

--- a/src/interfaces/records-delete.ts
+++ b/src/interfaces/records-delete.ts
@@ -38,7 +38,7 @@ export class RecordsDelete extends Message<RecordsDeleteMessage> {
       messageTimestamp : options.messageTimestamp ?? currentTime
     };
 
-    const authorization = await Message.signAsAuthorization(descriptor, options.authorizationSigner);
+    const authorization = await Message.signAuthorizationAsAuthor(descriptor, options.authorizationSigner);
     const message: RecordsDeleteMessage = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/records-query.ts
+++ b/src/interfaces/records-query.ts
@@ -58,7 +58,7 @@ export class RecordsQuery extends Message<RecordsQueryMessage> {
 
     // only generate the `authorization` property if signature input is given
     const authorizationSigner = options.authorizationSigner;
-    const authorization = authorizationSigner ? await Message.signAsAuthorization(descriptor, authorizationSigner) : undefined;
+    const authorization = authorizationSigner ? await Message.signAuthorizationAsAuthor(descriptor, authorizationSigner) : undefined;
     const message = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/records-read.ts
+++ b/src/interfaces/records-read.ts
@@ -59,7 +59,7 @@ export class RecordsRead extends Message<RecordsReadMessage> {
     // only generate the `authorization` property if signature input is given
     let authorization = undefined;
     if (authorizationSigner !== undefined) {
-      authorization = await Message.signAsAuthorization(descriptor, authorizationSigner, { permissionsGrantId, protocolRole });
+      authorization = await Message.signAuthorizationAsAuthor(descriptor, authorizationSigner, { permissionsGrantId, protocolRole });
     }
     const message: RecordsReadMessage = { descriptor, authorization };
 

--- a/src/interfaces/snapshots-create.ts
+++ b/src/interfaces/snapshots-create.ts
@@ -32,7 +32,7 @@ export class SnapshotsCreate extends Message<SnapshotsCreateMessage> {
       definitionCid
     };
 
-    const authorization = await Message.signAsAuthorization(descriptor, options.authorizationSigner);
+    const authorization = await Message.signAuthorizationAsAuthor(descriptor, options.authorizationSigner);
     const message = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/types/message-types.ts
+++ b/src/types/message-types.ts
@@ -4,8 +4,15 @@ import type { GeneralJws } from './jws-types.js';
  * Intersection type for all concrete message types.
  */
 export type GenericMessage = {
-  descriptor: Descriptor
-  authorization?: GeneralJws;
+  descriptor: Descriptor;
+  authorization?: AuthorizationModel;
+};
+
+/**
+ * The data model for the `authorization` property in a DWN message.
+ */
+export type AuthorizationModel = {
+  author: GeneralJws;
 };
 
 /**

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -5,7 +5,7 @@ import type { GenericMessageReply } from '../core/message-reply.js';
 import type { KeyDerivationScheme } from '../utils/hd-key.js';
 import type { PublicJwk } from './jose-types.js';
 import type { Readable } from 'readable-stream';
-import type { BaseAuthorizationPayload, GenericMessage, Pagination } from './message-types.js';
+import type { AuthorizationModel, BaseAuthorizationPayload, GenericMessage, Pagination } from './message-types.js';
 import type { DwnInterfaceName, DwnMethodName } from '../core/message.js';
 
 export type RecordsWriteDescriptor = {
@@ -123,7 +123,7 @@ export type RecordsWriteAttestationPayload = {
   descriptorCid: string;
 };
 
-export type RecordsWriteAuthorizationPayload = BaseAuthorizationPayload & {
+export type RecordsWriteAuthorSignaturePayload = BaseAuthorizationPayload & {
   recordId: string;
   contextId?: string;
   attestationCid?: string;
@@ -140,7 +140,7 @@ export type RecordsQueryReply = GenericMessageReply & {
 };
 
 export type RecordsReadMessage = {
-  authorization?: GeneralJws;
+  authorization?: AuthorizationModel;
   descriptor: RecordsReadDescriptor;
 };
 
@@ -149,7 +149,7 @@ export type RecordsReadReply = GenericMessageReply & {
     recordId: string,
     contextId?: string;
     descriptor: RecordsWriteDescriptor;
-    // authorization: GeneralJws; // intentionally omitted
+    // authorization: AuthorizationModel; // intentionally omitted
     attestation?: GeneralJws;
     encryption?: EncryptionProperty;
     data: Readable;

--- a/src/utils/jws.ts
+++ b/src/utils/jws.ts
@@ -78,8 +78,8 @@ export class Jws {
    * Creates a Signer[] from the given Personas.
    */
   public static createSigners(keyMaterials: KeyMaterial[]): Signer[] {
-    const signatureInputs = keyMaterials.map((keyMaterial) => Jws.createSigner(keyMaterial));
-    return signatureInputs;
+    const signers = keyMaterials.map((keyMaterial) => Jws.createSigner(keyMaterial));
+    return signers;
   }
 
   /**

--- a/tests/handlers/permissions-grant.spec.ts
+++ b/tests/handlers/permissions-grant.spec.ts
@@ -169,7 +169,7 @@ export function testPermissionsGrantHandler(): void {
             schema    : 'some-schema',
             protocol  : 'some-protocol'
           };
-          schemaAndProtocolGrant.message.authorization = await Message.signAsAuthorization(
+          schemaAndProtocolGrant.message.authorization = await Message.signAuthorizationAsAuthor(
             schemaAndProtocolGrant.message.descriptor,
             Jws.createSigner(alice)
           );
@@ -187,7 +187,7 @@ export function testPermissionsGrantHandler(): void {
             schema    : 'some-schema',
             contextId : 'some-context-id'
           };
-          schemaAndContextIdGrant.message.authorization = await Message.signAsAuthorization(
+          schemaAndContextIdGrant.message.authorization = await Message.signAuthorizationAsAuthor(
             schemaAndContextIdGrant.message.descriptor,
             Jws.createSigner(alice)
           );
@@ -205,7 +205,7 @@ export function testPermissionsGrantHandler(): void {
             schema       : 'some-schema',
             protocolPath : 'some-protocol-path'
           };
-          schemaAndProtocolPathGrant.message.authorization = await Message.signAsAuthorization(
+          schemaAndProtocolPathGrant.message.authorization = await Message.signAuthorizationAsAuthor(
             schemaAndProtocolPathGrant.message.descriptor,
             Jws.createSigner(alice)
           );
@@ -237,7 +237,7 @@ export function testPermissionsGrantHandler(): void {
             contextId    : 'some-context-id',
             protocolPath : 'some-protocol-path',
           };
-          contextIdAndProtocolPathGrant.message.authorization = await Message.signAsAuthorization(
+          contextIdAndProtocolPathGrant.message.authorization = await Message.signAuthorizationAsAuthor(
             contextIdAndProtocolPathGrant.message.descriptor,
             Jws.createSigner(alice)
           );

--- a/tests/handlers/protocols-configure.spec.ts
+++ b/tests/handlers/protocols-configure.spec.ts
@@ -80,13 +80,13 @@ export function testProtocolsConfigureHandler(): void {
 
         // intentionally create more than one signature, which is not allowed
         const extraRandomPersona = await TestDataGenerator.generatePersona();
-        const signatureInput1 = Jws.createSigner(author);
-        const signatureInput2 = Jws.createSigner(extraRandomPersona);
+        const signer1 = Jws.createSigner(author);
+        const signer2 = Jws.createSigner(extraRandomPersona);
 
         const authorizationPayloadBytes = Encoder.objectToBytes(protocolsConfigure.authorizationPayload!);
 
-        const jwsBuilder = await GeneralJwsBuilder.create(authorizationPayloadBytes, [signatureInput1, signatureInput2]);
-        message.authorization = jwsBuilder.getJws();
+        const jwsBuilder = await GeneralJwsBuilder.create(authorizationPayloadBytes, [signer1, signer2]);
+        message.authorization = { author: jwsBuilder.getJws() };
 
         TestStubGenerator.stubDidResolver(didResolver, [author]);
 
@@ -231,7 +231,7 @@ export function testProtocolsConfigureHandler(): void {
         protocolsConfig.message.descriptor.definition.protocol = 'example.com/';
 
         // Re-create auth because we altered the descriptor after signing
-        protocolsConfig.message.authorization = await Message.signAsAuthorization(
+        protocolsConfig.message.authorization = await Message.signAuthorizationAsAuthor(
           protocolsConfig.message.descriptor,
           Jws.createSigner(alice)
         );
@@ -255,7 +255,7 @@ export function testProtocolsConfigureHandler(): void {
         protocolsConfig.message.descriptor.definition.types.ask.schema = 'ask';
 
         // Re-create auth because we altered the descriptor after signing
-        protocolsConfig.message.authorization = await Message.signAsAuthorization(
+        protocolsConfig.message.authorization = await Message.signAuthorizationAsAuthor(
           protocolsConfig.message.descriptor,
           Jws.createSigner(alice)
         );

--- a/tests/handlers/protocols-query.spec.ts
+++ b/tests/handlers/protocols-query.spec.ts
@@ -149,7 +149,7 @@ export function testProtocolsQueryHandler(): void {
       protocolsQuery.message.descriptor.filter!.protocol = 'example.com/';
 
       // Re-create auth because we altered the descriptor after signing
-      protocolsQuery.message.authorization = await Message.signAsAuthorization(
+      protocolsQuery.message.authorization = await Message.signAuthorizationAsAuthor(
         protocolsQuery.message.descriptor,
         Jws.createSigner(alice)
       );
@@ -169,9 +169,9 @@ export function testProtocolsQueryHandler(): void {
         const authorizationPayload = { ...protocolsQuery.authorizationPayload };
         authorizationPayload.descriptorCid = incorrectDescriptorCid;
         const authorizationPayloadBytes = Encoder.objectToBytes(authorizationPayload);
-        const signatureInput = Jws.createSigner(author);
-        const jwsBuilder = await GeneralJwsBuilder.create(authorizationPayloadBytes, [signatureInput]);
-        message.authorization = jwsBuilder.getJws();
+        const signer = Jws.createSigner(author);
+        const jwsBuilder = await GeneralJwsBuilder.create(authorizationPayloadBytes, [signer]);
+        message.authorization = { author: jwsBuilder.getJws() };
 
         const reply = await dwn.processMessage(tenant, message);
 

--- a/tests/handlers/records-query.spec.ts
+++ b/tests/handlers/records-query.spec.ts
@@ -916,7 +916,7 @@ export function testRecordsQueryHandler(): void {
         recordsQuery.message.descriptor.filter.protocol = 'example.com/';
 
         // Re-create auth because we altered the descriptor after signing
-        recordsQuery.message.authorization = await Message.signAsAuthorization(
+        recordsQuery.message.authorization = await Message.signAuthorizationAsAuthor(
           recordsQuery.message.descriptor,
           Jws.createSigner(alice)
         );
@@ -940,7 +940,7 @@ export function testRecordsQueryHandler(): void {
         recordsQuery.message.descriptor.filter.schema = 'example.com/';
 
         // Re-create auth because we altered the descriptor after signing
-        recordsQuery.message.authorization = await Message.signAsAuthorization(
+        recordsQuery.message.authorization = await Message.signAuthorizationAsAuthor(
           recordsQuery.message.descriptor,
           Jws.createSigner(alice)
         );

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -2772,9 +2772,9 @@ export function testRecordsWriteHandler(): void {
         const authorizationPayload = { ...recordsWrite.authorizationPayload };
         authorizationPayload.recordId = await TestDataGenerator.randomCborSha256Cid(); // make recordId mismatch in authorization payload
         const authorizationPayloadBytes = Encoder.objectToBytes(authorizationPayload);
-        const signatureInput = Jws.createSigner(author);
-        const jwsBuilder = await GeneralJwsBuilder.create(authorizationPayloadBytes, [signatureInput]);
-        message.authorization = jwsBuilder.getJws();
+        const signer = Jws.createSigner(author);
+        const jwsBuilder = await GeneralJwsBuilder.create(authorizationPayloadBytes, [signer]);
+        message.authorization = { author: jwsBuilder.getJws() };
 
         const tenant = author.did;
         const didResolver = TestStubGenerator.createDidResolverStub(author);
@@ -2796,9 +2796,9 @@ export function testRecordsWriteHandler(): void {
         const authorizationPayload = { ...recordsWrite.authorizationPayload };
         authorizationPayload.contextId = await TestDataGenerator.randomCborSha256Cid(); // make contextId mismatch in authorization payload
         const authorizationPayloadBytes = Encoder.objectToBytes(authorizationPayload);
-        const signatureInput = Jws.createSigner(author);
-        const jwsBuilder = await GeneralJwsBuilder.create(authorizationPayloadBytes, [signatureInput]);
-        message.authorization = jwsBuilder.getJws();
+        const signer = Jws.createSigner(author);
+        const jwsBuilder = await GeneralJwsBuilder.create(authorizationPayloadBytes, [signer]);
+        message.authorization = { author: jwsBuilder.getJws() };
 
         const tenant = author.did;
         const didResolver = sinon.createStubInstance(DidResolver);
@@ -2851,21 +2851,21 @@ export function testRecordsWriteHandler(): void {
       it('should fail with 400 if `attestation` payload contains properties other than `descriptorCid`', async () => {
         const { author, message, recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite();
         const tenant = author.did;
-        const signatureInput = Jws.createSigner(author);
+        const signer = Jws.createSigner(author);
 
         // replace `attestation` with one that has an additional property, but go the extra mile of making sure signature is valid
         const descriptorCid = recordsWrite.authorizationPayload!.descriptorCid;
         const attestationPayload = { descriptorCid, someAdditionalProperty: 'anyValue' }; // additional property is not allowed
         const attestationPayloadBytes = Encoder.objectToBytes(attestationPayload);
-        const attestationBuilder = await GeneralJwsBuilder.create(attestationPayloadBytes, [signatureInput]);
+        const attestationBuilder = await GeneralJwsBuilder.create(attestationPayloadBytes, [signer]);
         message.attestation = attestationBuilder.getJws();
 
         // recreate the `authorization` based on the new` attestationCid`
         const authorizationPayload = { ...recordsWrite.authorizationPayload };
         authorizationPayload.attestationCid = await Cid.computeCid(attestationPayload);
         const authorizationPayloadBytes = Encoder.objectToBytes(authorizationPayload);
-        const authorizationBuilder = await GeneralJwsBuilder.create(authorizationPayloadBytes, [signatureInput]);
-        message.authorization = authorizationBuilder.getJws();
+        const authorizationBuilder = await GeneralJwsBuilder.create(authorizationPayloadBytes, [signer]);
+        message.authorization = { author: authorizationBuilder.getJws() };
 
         const didResolver = TestStubGenerator.createDidResolverStub(author);
         const messageStore = stubInterface<MessageStore>();

--- a/tests/interfaces/records-write.spec.ts
+++ b/tests/interfaces/records-write.spec.ts
@@ -222,7 +222,7 @@ describe('RecordsWrite', () => {
 
       const recordsWrite = await RecordsWrite.create(options);
 
-      expect(recordsWrite.message.authorization!.signatures[0].signature).to.equal(Encoder.bytesToBase64Url(hardCodedSignature));
+      expect(recordsWrite.message.authorization!.author.signatures[0].signature).to.equal(Encoder.bytesToBase64Url(hardCodedSignature));
     });
 
     it('should throw if attempting to use `protocols` key derivation encryption scheme on non-protocol-based record', async () => {

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -1,7 +1,7 @@
 import type { DidResolutionResult } from '../../src/did/did-resolver.js';
-import type { Pagination } from '../../src/types/message-types.js';
 import type { Readable } from 'readable-stream';
 import type { RecordsFilter } from '../../src/types/records-types.js';
+import type { AuthorizationModel, Pagination } from '../../src/types/message-types.js';
 
 import type {
   CreateFromOptions,
@@ -766,6 +766,21 @@ export class TestDataGenerator {
       author,
       messagesGet,
       message: messagesGet.message,
+    };
+  }
+
+  /**
+   * Generates a dummy `authorization` property for a DWN message that only conforms to schema validation.
+   */
+  public static generateAuthorization(): AuthorizationModel {
+    return {
+      author: {
+        payload    : 'anyPayload',
+        signatures : [{
+          protected : 'anyProtectedHeader',
+          signature : 'anySignature'
+        }]
+      }
     };
   }
 

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -35,11 +35,13 @@ describe('ProtocolsConfigure schema definition', () => {
         definition       : protocolDefinition
       },
       authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
+        author: {
+          payload    : 'anyPayload',
+          signatures : [{
+            protected : 'anyProtectedHeader',
+            signature : 'anySignature'
+          }]
+        }
       },
     };
 

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -1,8 +1,9 @@
-import { expect } from 'chai';
+import type { ProtocolDefinition, ProtocolsConfigureMessage } from '../../../../src/types/protocols-types.js';
 
+import { expect } from 'chai';
+import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { validateJsonSchema } from '../../../../src/schema-validator.js';
 import { DwnInterfaceName, DwnMethodName, Message } from '../../../../src/core/message.js';
-import type { ProtocolDefinition, ProtocolsConfigureMessage } from '../../../../src/types/protocols-types.js';
 
 describe('ProtocolsConfigure schema definition', () => {
   it('should throw if unknown actor is encountered in action rule', async () => {
@@ -34,15 +35,7 @@ describe('ProtocolsConfigure schema definition', () => {
         messageTimestamp : '2022-10-14T10:20:30.405060Z',
         definition       : protocolDefinition
       },
-      authorization: {
-        author: {
-          payload    : 'anyPayload',
-          signatures : [{
-            protected : 'anyProtectedHeader',
-            signature : 'anySignature'
-          }]
-        }
-      },
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     expect(() => {

--- a/tests/validation/json-schemas/records/records-query.spec.ts
+++ b/tests/validation/json-schemas/records/records-query.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { Message } from '../../../../src/core/message.js';
+import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 
 describe('RecordsQuery schema validation', () => {
   it('should allow descriptor with only required properties', async () => {
@@ -10,13 +11,7 @@ describe('RecordsQuery schema validation', () => {
         messageTimestamp : '2022-10-14T10:20:30.405060Z',
         filter           : { schema: 'anySchema' }
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      },
+      authorization: TestDataGenerator.generateAuthorization()
     };
     Message.validateJsonSchema(validMessage);
   });
@@ -79,13 +74,7 @@ describe('RecordsQuery schema validation', () => {
           filter           : { schema: 'anySchema' },
           dateSort         : dateSortValue
         },
-        authorization: {
-          payload    : 'anyPayload',
-          signatures : [{
-            protected : 'anyProtectedHeader',
-            signature : 'anySignature'
-          }]
-        },
+        authorization: TestDataGenerator.generateAuthorization()
       };
 
       Message.validateJsonSchema(validMessage);
@@ -100,13 +89,7 @@ describe('RecordsQuery schema validation', () => {
         filter           : { schema: 'anySchema' },
         dateSort         : 'unacceptable', // bad value
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      },
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     expect(() => {
@@ -123,13 +106,7 @@ describe('RecordsQuery schema validation', () => {
           messageTimestamp : '2022-10-14T10:20:30.405060Z',
           filter           : { }
         },
-        authorization: {
-          payload    : 'anyPayload',
-          signatures : [{
-            protected : 'anyProtectedHeader',
-            signature : 'anySignature'
-          }]
-        },
+        authorization: TestDataGenerator.generateAuthorization()
       };
 
       expect(() => {
@@ -146,11 +123,13 @@ describe('RecordsQuery schema validation', () => {
           filter           : { dateCreated: { } } // empty `dateCreated` criteria
         },
         authorization: {
-          payload    : 'anyPayload',
-          signatures : [{
-            protected : 'anyProtectedHeader',
-            signature : 'anySignature'
-          }]
+          author: {
+            payload    : 'anyPayload',
+            signatures : [{
+              protected : 'anyProtectedHeader',
+              signature : 'anySignature'
+            }]
+          }
         },
       };
 

--- a/tests/validation/json-schemas/records/records-query.spec.ts
+++ b/tests/validation/json-schemas/records/records-query.spec.ts
@@ -24,14 +24,8 @@ describe('RecordsQuery schema validation', () => {
         messageTimestamp : '2022-10-14T10:20:30.405060Z',
         filter           : { schema: 'anySchema' }
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      },
-      unknownProperty: 'unknownProperty' // unknown property
+      authorization   : TestDataGenerator.generateAuthorization(),
+      unknownProperty : 'unknownProperty' // unknown property
     };
 
     expect(() => {
@@ -48,13 +42,7 @@ describe('RecordsQuery schema validation', () => {
         filter           : { schema: 'anySchema' },
         unknownProperty  : 'unknownProperty' // unknown property
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      },
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     expect(() => {
@@ -122,15 +110,7 @@ describe('RecordsQuery schema validation', () => {
           messageTimestamp : '2022-10-14T10:20:30.405060Z',
           filter           : { dateCreated: { } } // empty `dateCreated` criteria
         },
-        authorization: {
-          author: {
-            payload    : 'anyPayload',
-            signatures : [{
-              protected : 'anyProtectedHeader',
-              signature : 'anySignature'
-            }]
-          }
-        },
+        authorization: TestDataGenerator.generateAuthorization()
       };
 
       expect(() => {
@@ -146,13 +126,7 @@ describe('RecordsQuery schema validation', () => {
           messageTimestamp : '2022-10-14T10:20:30.405060Z',
           filter           : { dateCreated: { unexpectedProperty: 'anyValue' } } // unexpected property in `dateCreated` criteria
         },
-        authorization: {
-          payload    : 'anyPayload',
-          signatures : [{
-            protected : 'anyProtectedHeader',
-            signature : 'anySignature'
-          }]
-        },
+        authorization: TestDataGenerator.generateAuthorization()
       };
 
       expect(() => {

--- a/tests/validation/json-schemas/records/records-write.spec.ts
+++ b/tests/validation/json-schemas/records/records-write.spec.ts
@@ -70,14 +70,8 @@ describe('RecordsWrite schema definition', () => {
         dateCreated      : '2022-12-19T10:20:30.123456Z',
         messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      },
-      unknownProperty: 'unknownProperty' // unknown property
+      authorization   : TestDataGenerator.generateAuthorization(),
+      unknownProperty : 'unknownProperty' // unknown property
     };
 
     expect(() => {
@@ -98,13 +92,7 @@ describe('RecordsWrite schema definition', () => {
         messageTimestamp : '2022-12-19T10:20:30.123456Z',
         unknownProperty  : 'unknownProperty' // unknown property
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      },
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     expect(() => {
@@ -189,13 +177,7 @@ describe('RecordsWrite schema definition', () => {
         dateCreated      : '2022-12-19T10:20:30.123456Z',
         messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      }
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     expect(() => {
@@ -216,13 +198,7 @@ describe('RecordsWrite schema definition', () => {
         dateCreated      : '2022-12-19T10:20:30.123456Z',
         messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      }
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     expect(() => {
@@ -269,13 +245,7 @@ describe('RecordsWrite schema definition', () => {
         dateCreated      : '2022-12-19T10:20:30.123456Z',
         messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      }
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     expect(() => {
@@ -298,13 +268,7 @@ describe('RecordsWrite schema definition', () => {
         dateCreated      : '2022-12-19T10:20:30.123456Z',
         messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      }
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     expect(() => {
@@ -328,13 +292,7 @@ describe('RecordsWrite schema definition', () => {
         dateCreated      : '2022-12-19T10:20:30.123456Z',
         messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      }
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     expect(() => {
@@ -359,13 +317,7 @@ describe('RecordsWrite schema definition', () => {
         dateCreated      : '2022-12-19T10:20:30.123456Z',
         messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      }
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     expect(() => {
@@ -475,15 +427,7 @@ describe('RecordsWrite schema definition', () => {
         messageTimestamp : '2022-12-19T10:20:30.123456Z',
         datePublished    : '2022-12-19T10:20:30.123456Z' //published must be present
       },
-      authorization: {
-        author: {
-          payload    : 'anyPayload',
-          signatures : [{
-            protected : 'anyProtectedHeader',
-            signature : 'anySignature'
-          }]
-        }
-      }
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     expect(() => {

--- a/tests/validation/json-schemas/records/records-write.spec.ts
+++ b/tests/validation/json-schemas/records/records-write.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { Message } from '../../../../src/core/message.js';
+import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 
 describe('RecordsWrite schema definition', () => {
   it('should allow descriptor with only required properties', async () => {
@@ -14,13 +15,7 @@ describe('RecordsWrite schema definition', () => {
         dateCreated      : '2022-12-19T10:20:30.123456Z',
         messageTimestamp : '2022-12-19T10:20:30.123456Z',
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      },
+      authorization: TestDataGenerator.generateAuthorization()
     };
     Message.validateJsonSchema(validMessage);
   });
@@ -36,13 +31,7 @@ describe('RecordsWrite schema definition', () => {
         dateCreated      : '2022-12-19T10:20:30.123456Z',
         messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      },
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     expect(() => {
@@ -139,13 +128,7 @@ describe('RecordsWrite schema definition', () => {
         dateCreated      : '2022-12-19T10:20:30.123456Z',
         messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      }
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     Message.validateJsonSchema(validMessage);
@@ -167,13 +150,7 @@ describe('RecordsWrite schema definition', () => {
         dateCreated      : '2022-12-19T10:20:30.123456Z',
         messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      }
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     expect(() => {
@@ -193,13 +170,7 @@ describe('RecordsWrite schema definition', () => {
         dateCreated      : '2022-12-19T10:20:30.123456Z',
         messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      }
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     Message.validateJsonSchema(invalidMessage);
@@ -275,13 +246,7 @@ describe('RecordsWrite schema definition', () => {
         dateCreated      : '2022-12-19T10:20:30.123456Z',
         messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      }
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     expect(() => {
@@ -425,13 +390,7 @@ describe('RecordsWrite schema definition', () => {
         dateCreated      : '2022-12-19T10:20:30.123456Z',
         messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      }
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     Message.validateJsonSchema(invalidMessage);
@@ -454,13 +413,7 @@ describe('RecordsWrite schema definition', () => {
         dateCreated      : '2022-12-19T10:20:30.123456Z',
         messageTimestamp : '2022-12-19T10:20:30.123456Z'
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      }
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     Message.validateJsonSchema(invalidMessage);
@@ -480,13 +433,7 @@ describe('RecordsWrite schema definition', () => {
         dateCreated      : '2022-12-19T10:20:30.123456Z',
         datePublished    : '2022-12-19T10:20:30.123456Z' // must not be present when not published
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      }
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     expect(() => {
@@ -507,13 +454,7 @@ describe('RecordsWrite schema definition', () => {
         messageTimestamp : '2022-12-19T10:20:30.123456Z',
         published        : true //datePublished must be present
       },
-      authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
-      }
+      authorization: TestDataGenerator.generateAuthorization()
     };
 
     expect(() => {
@@ -535,11 +476,13 @@ describe('RecordsWrite schema definition', () => {
         datePublished    : '2022-12-19T10:20:30.123456Z' //published must be present
       },
       authorization: {
-        payload    : 'anyPayload',
-        signatures : [{
-          protected : 'anyProtectedHeader',
-          signature : 'anySignature'
-        }]
+        author: {
+          payload    : 'anyPayload',
+          signatures : [{
+            protected : 'anyProtectedHeader',
+            signature : 'anySignature'
+          }]
+        }
       }
     };
 


### PR DESCRIPTION
This is the first PR for #439, where the `authorization` property in a DWN message is becoming an object with potentially multiple JWS.

Calling out that this wrapping will be useful for the likes of `RecordsWrite` but useless for ~dozen interface methods as they will just have `author` and not have `retainer`/`tenant` property in the `authorization`. Not necessarily a deal breaker, but just want to call out for awareness for reviewers.

Also as I worked on this PR, I can't help yet again having doubts on the scope of "independent verifiability" and its impact on the DWN design throughout, specifically on the reliance of being able to verify signatures of others, but that's something requiring further articulation!