### PR TITLE
#439 - Return `authorization` in queries and reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here's to a thrilling Hacktoberfest voyage with us! 🎉
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.77%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.04%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-94.28%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.77%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.77%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.03%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-94.26%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.77%25-brightgreen.svg?style=flat)
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/src/handlers/records-query.ts
+++ b/src/handlers/records-query.ts
@@ -53,26 +53,11 @@ export class RecordsQueryHandler implements MethodHandler {
       }
     }
 
-    const entries = RecordsQueryHandler.removeAuthorization(recordsWrites);
-
     return {
-      status: { code: 200, detail: 'OK' },
-      entries,
+      status  : { code: 200, detail: 'OK' },
+      entries : recordsWrites,
       paginationMessageCid
     };
-  }
-
-  /**
-   * Removes `authorization` property from each and every `RecordsWrite` message given and returns the result as a different array.
-   */
-  private static removeAuthorization(recordsWriteMessages: RecordsWriteMessageWithOptionalEncodedData[]): RecordsQueryReplyEntry[] {
-    const recordsQueryReplyEntries: RecordsQueryReplyEntry[] = [];
-    for (const record of recordsWriteMessages) {
-      const { authorization: _, ...objectWithRemainingProperties } = record; // a trick to stripping away `authorization`
-      recordsQueryReplyEntries.push(objectWithRemainingProperties);
-    }
-
-    return recordsQueryReplyEntries;
   }
 
   /**

--- a/src/handlers/records-query.ts
+++ b/src/handlers/records-query.ts
@@ -2,7 +2,7 @@ import type { MethodHandler } from '../types/method-handler.js';
 import type { RecordsWriteMessageWithOptionalEncodedData } from '../store/storage-controller.js';
 import type { DataStore, DidResolver, MessageStore } from '../index.js';
 import type { Filter, GenericMessage, MessageSort } from '../types/message-types.js';
-import type { RecordsQueryMessage, RecordsQueryReply, RecordsQueryReplyEntry } from '../types/records-types.js';
+import type { RecordsQueryMessage, RecordsQueryReply } from '../types/records-types.js';
 
 import { authenticate } from '../core/auth.js';
 import { messageReplyFromError } from '../core/message-reply.js';

--- a/src/handlers/records-read.ts
+++ b/src/handlers/records-read.ts
@@ -79,11 +79,10 @@ export class RecordsReadHandler implements MethodHandler {
       data = result.dataStream;
     }
 
-    const { authorization: _, ...recordsWriteWithoutAuthorization } = newestRecordsWrite; // a trick to stripping away `authorization`
-    const messageReply: RecordsReadReply ={
+    const messageReply: RecordsReadReply = {
       status : { code: 200, detail: 'OK' },
       record : {
-        ...recordsWriteWithoutAuthorization,
+        ...newestRecordsWrite,
         data,
       }
     };

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -145,13 +145,7 @@ export type RecordsReadMessage = {
 };
 
 export type RecordsReadReply = GenericMessageReply & {
-  record?: {
-    recordId: string,
-    contextId?: string;
-    descriptor: RecordsWriteDescriptor;
-    // authorization: AuthorizationModel; // intentionally omitted
-    attestation?: GeneralJws;
-    encryption?: EncryptionProperty;
+  record?: RecordsWriteMessage & {
     data: Readable;
   }
 };

--- a/tests/handlers/records-read.spec.ts
+++ b/tests/handlers/records-read.spec.ts
@@ -88,7 +88,8 @@ export function testRecordsReadHandler(): void {
         const readReply = await dwn.handleRecordsRead(alice.did, recordsRead.message);
         expect(readReply.status.code).to.equal(200);
         expect(readReply.record).to.exist;
-        expect(readReply.record?.descriptor).to.exist;
+        expect(readReply.record?.authorization).to.deep.equal(message.authorization);
+        expect(readReply.record?.descriptor).to.deep.equal(message.descriptor);
 
         const dataFetched = await DataStream.toBytes(readReply.record!.data!);
         expect(ArrayUtility.byteArraysEqual(dataFetched, dataBytes!)).to.be.true;


### PR DESCRIPTION
This is necessary to allow a third party retainer of the message to ensure the authenticity of the message author.