### PR TITLE
Normalize schema and protocol in create method of permission-grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here's to a thrilling Hacktoberfest voyage with us! 🎉
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-97.78%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.06%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-94.26%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.78%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-97.78%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.07%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-94.26%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-97.78%25-brightgreen.svg?style=flat)
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here's to a thrilling Hacktoberfest voyage with us! 🎉
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-98.04%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.1%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.14%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.04%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-98.04%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.12%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.14%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.04%25-brightgreen.svg?style=flat)
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/src/interfaces/permissions-grant.ts
+++ b/src/interfaces/permissions-grant.ts
@@ -8,6 +8,7 @@ import { removeUndefinedProperties } from '../utils/object.js';
 import { validateAuthorizationIntegrity } from '../core/auth.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 import { DwnInterfaceName, DwnMethodName, Message } from '../core/message.js';
+import { normalizeProtocolUrl, normalizeSchemaUrl } from '../utils/url.js';
 
 export type PermissionsGrantOptions = {
   messageTimestamp?: string;
@@ -42,6 +43,10 @@ export class PermissionsGrant extends Message<PermissionsGrantMessage> {
   }
 
   static async create(options: PermissionsGrantOptions): Promise<PermissionsGrant> {
+    const scope = { ...options.scope } as RecordsPermissionScope;
+    scope.protocol = scope.protocol !== undefined ? normalizeProtocolUrl(scope.protocol) : undefined;
+    scope.schema = scope.schema !== undefined ? normalizeSchemaUrl(scope.schema) : undefined;
+
     const descriptor: PermissionsGrantDescriptor = {
       interface            : DwnInterfaceName.Permissions,
       method               : DwnMethodName.Grant,
@@ -52,7 +57,7 @@ export class PermissionsGrant extends Message<PermissionsGrantMessage> {
       grantedBy            : options.grantedBy,
       grantedFor           : options.grantedFor,
       permissionsRequestId : options.permissionsRequestId,
-      scope                : options.scope,
+      scope                : scope,
       conditions           : options.conditions,
     };
 

--- a/tests/interfaces/permissions-grant.spec.ts
+++ b/tests/interfaces/permissions-grant.spec.ts
@@ -68,7 +68,7 @@ describe('PermissionsGrant', () => {
         const scope: PermissionScope = {
           interface : DwnInterfaceName.Records,
           method    : DwnMethodName.Write,
-          protocol  : 'https://example.com/',
+          protocol  : 'example.com/',
         };
 
         const { message } = await PermissionsGrant.create({
@@ -82,7 +82,7 @@ describe('PermissionsGrant', () => {
         });
 
 
-        expect((message.descriptor.scope as RecordsPermissionScope).protocol).to.equal('https://example.com');
+        expect((message.descriptor.scope as RecordsPermissionScope).protocol).to.equal('http://example.com');
       });
     });
 


### PR DESCRIPTION
Fixes #530 

1. Normalize `schema` and `protocol`  properties of `PermissionScope` object in `create` method of `PermissionGrant` interface.
2. Added tests to validate normalization.