### PR TITLE
Add codecov coverage job in `integrity-check.yml`

### DIFF
--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -53,8 +53,15 @@ jobs:
       - run: npm run lint
       # runs tests in node environment without attempting to generate code coverage badges
       - run: npm run test:node:ci
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          verbose: true
       # runs code coverage badge generation, throws if README output differs to README to be checked in (thus detects if tests were not run)
-      - run: npm run make-coverage-badges:ci
+      #- run: npm run make-coverage-badges:ci
+
 
   test-with-browsers:
     # Run browser tests using macOS so that WebKit tests don't fail under a Linux environment

--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -59,9 +59,8 @@ jobs:
         with:
           fail_ci_if_error: true
           verbose: true
-      # runs code coverage badge generation, throws if README output differs to README to be checked in (thus detects if tests were not run)
-      #- run: npm run make-coverage-badges:ci
-
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   test-with-browsers:
     # Run browser tests using macOS so that WebKit tests don't fail under a Linux environment

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ Here's to a thrilling Hacktoberfest voyage with us! 🎉
 
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
-Code Coverage
-![Statements](https://img.shields.io/badge/statements-98.35%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.14%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.73%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.35%25-brightgreen.svg?style=flat)
+[![codecov](https://codecov.io/github/TBD54566975/dwn-sdk-js/graphs/badge.svg)](https://codecov.io/github/TBD54566975/dwn-sdk-js)
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+
+ignore:
+  - "src/types"


### PR DESCRIPTION
Added Codecov to the CI pipeline to display test coverage on pull requests and on Readme badge.

See #534.