### PR TITLE
revert network unavailable stub, breaks in the browser test

### DIFF
--- a/src/did/did-ion-resolver.ts
+++ b/src/did/did-ion-resolver.ts
@@ -1,20 +1,18 @@
-import crossFetch from 'cross-fetch';
 import type { DidMethodResolver, DidResolutionResult } from './did-resolver.js';
+
+import crossFetch from 'cross-fetch';
+// supports fetch in: node, browsers, and browser extensions.
+// uses native fetch if available in environment or falls back to a ponyfill.
+// 'cross-fetch' is a ponyfill that uses `XMLHTTPRequest` under the hood.
+// `XMLHTTPRequest` cannot be used in browser extension background service workers.
+// browser extensions get even more strict with `fetch` in that it cannot be referenced
+// indirectly.
+const fetch = globalThis.fetch ?? crossFetch;
 
 /**
  * Resolver for ION DIDs.
  */
 export class DidIonResolver implements DidMethodResolver {
-
-  // supports fetch in: node, browsers, and browser extensions.
-  // uses native fetch if available in environment or falls back to a ponyfill.
-  // 'cross-fetch' is a ponyfill that uses `XMLHTTPRequest` under the hood.
-  // `XMLHTTPRequest` cannot be used in browser extension background service workers.
-  // browser extensions get even more strict with `fetch` in that it cannot be referenced
-  // indirectly.
-  // member field allows for test stubbing
-  private fetch = globalThis.fetch ?? crossFetch;
-
   /**
    * @param resolutionEndpoint optional custom URL to send DID resolution request to
    */
@@ -28,7 +26,7 @@ export class DidIonResolver implements DidMethodResolver {
     // using `URL` constructor to handle both existence and absence of trailing slash '/' in resolution endpoint
     // appending './' to DID so 'did' in 'did:ion:abc' doesn't get interpreted as a URL scheme (e.g. like 'http') due to the colon
     const resolutionUrl = new URL('./' + did, this.resolutionEndpoint).toString();
-    const response = await this.fetch(resolutionUrl);
+    const response = await fetch(resolutionUrl);
 
     if (response.status !== 200) {
       throw new Error(`unable to resolve ${did}, got http status ${response.status}`);

--- a/tests/did/did-ion-resolver.spec.ts
+++ b/tests/did/did-ion-resolver.spec.ts
@@ -1,6 +1,4 @@
 import chaiAsPromised from 'chai-as-promised';
-import fetch from 'cross-fetch';
-import sinon from 'sinon';
 import chai, { expect } from 'chai';
 
 import { DidIonResolver } from '../../src/did/did-ion-resolver.js';
@@ -10,21 +8,6 @@ chai.use(chaiAsPromised);
 
 describe('DidIonResolver', () => {
   const defaultResolutionEndpoint = 'https://discover.did.msidentity.com/1.0/identifiers/';
-  let networkAvailable = false;
-  before(async () => {
-    // test network connectivity, `networkAvailable` is used by tests to decide whether to run tests through real network calls or stubs
-    const testDidUrl = `${defaultResolutionEndpoint}did:ion:EiClkZMDxPKqC9c-umQfTkR8vvZ9JPhl_xLDI9Nfk38w5w`;
-
-    try {
-      const response = await fetch(testDidUrl);
-
-      if (response.status === 200) {
-        networkAvailable = true;
-      }
-    } catch {
-      // no op, all tests will run through stubs
-    }
-  });
 
   it('should set a default resolution endpoint when none is given in constructor', async () => {
     const didIonResolver = new DidIonResolver();
@@ -36,22 +19,7 @@ describe('DidIonResolver', () => {
     const did = 'did:ion:EiClkZMDxPKqC9c-umQfTkR8vvZ9JPhl_xLDI9Nfk38w5w';
     const didIonResolver = new DidIonResolver();
 
-    let resolverStub;
-    // stub network call if network is not available
-    if (!networkAvailable) {
-      resolverStub = sinon.stub(didIonResolver as any, 'fetch').resolves({
-        status : 200,
-        json   : async () => Promise.resolve({
-          didDocument         : { id: did },
-          didDocumentMetadata : { canonicalId: did }
-        })
-      });
-    }
-
     const resolutionDocument = await didIonResolver.resolve(did);
-    if (resolverStub) {
-      resolverStub.restore();
-    }
     expect(resolutionDocument.didDocument?.id).to.equal(did);
     expect(resolutionDocument.didDocumentMetadata.canonicalId).to.equal(did);
   });
@@ -60,16 +28,7 @@ describe('DidIonResolver', () => {
     const did = 'did:ion:SomethingThatCannotBeResolved';
     const didIonResolver = new DidIonResolver();
 
-    let resolverStub;
-    // stub network call if network is not available
-    if (!networkAvailable) {
-      resolverStub = sinon.stub(didIonResolver as any, 'fetch').resolves({ status: 404 });
-    }
-
     const resolutionPromise = didIonResolver.resolve(did);
-    if (resolverStub) {
-      resolverStub.restore();
-    }
     await expect(resolutionPromise).to.be.rejectedWith('unable to resolve');
   });
 });


### PR DESCRIPTION
Removed `networkAvailable` tests in `DidIonResolver` as it wasn't working in all environments. 

Created issue to track: https://github.com/TBD54566975/dwn-sdk-js/issues/544