### PR TITLE
MessageStore Index tenant partitioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here's to a thrilling Hacktoberfest voyage with us! 🎉
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-98.37%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.25%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.7%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.37%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-98.37%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.11%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.7%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.37%25-brightgreen.svg?style=flat)
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/tests/event-log/event-log-level.spec.ts
+++ b/tests/event-log/event-log-level.spec.ts
@@ -42,8 +42,6 @@ describe('EventLogLevel Tests', () => {
     expect(events.length).to.equal(1);
     expect(events[0].watermark).to.equal(watermark2);
     expect(events[0].messageCid).to.equal(messageCid2);
-
-
   });
 
   it('returns events in the order that they were appended', async () => {


### PR DESCRIPTION
The `MessageStores`'s `IndexLevel` doesn't take into account partitioning for the tenant.

This causes the following issue:
if `alice` + `bob` both put the same message in their respective tenant, the index updates accordingly and both can query.

But if `bob` deletes the message, `alice` can no longer query for the message, but she CAN do a get from the message store with the messageCid since that's still partitioned.

This PR adds a partition to the `IndexLevel` to index for each tenant separately. There are more storage-efficient ways of handing this, but puling in this low-overhead fix to handle the bug.

As a side note, we also allow "empty" querying, currently this is done by injecting the `tenant` into the index, as well as into the query. If an empty filter is provided, it will ALWAYS filter on the `tenant` property, therefore returning all of the results.

I left this behavior in tact as is for now with a note.


Also a note, this is partitioned properly on the `dwn-sql-store` repo already, the updated tests pass.