### PR TITLE
Removed `UnsignedRecordsWriteMessage` type

### DIFF
--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -71,13 +71,6 @@ export type EncryptedKey = {
   encryptedKey: string;
 };
 
-export type UnsignedRecordsWriteMessage = {
-  recordId: string,
-  contextId?: string;
-  descriptor: RecordsWriteDescriptor;
-  encryption?: EncryptionProperty;
-};
-
 /**
  * Data structure returned in a `RecordsQuery` reply entry.
  * NOTE: the message structure is a modified version of the message received, the most notable differences are:

--- a/src/utils/records.ts
+++ b/src/utils/records.ts
@@ -1,7 +1,7 @@
 import type { DerivedPrivateJwk } from './hd-key.js';
 import type { Readable } from 'readable-stream';
 import type { Filter, RangeFilter } from '../types/message-types.js';
-import type { RecordsFilter, RecordsWriteDescriptor, UnsignedRecordsWriteMessage } from '../types/records-types.js';
+import type { RecordsFilter, RecordsWriteDescriptor, RecordsWriteMessage } from '../types/records-types.js';
 
 import { Encoder } from './encoder.js';
 import { Encryption } from './encryption.js';
@@ -19,7 +19,7 @@ export class Records {
    * @param ancestorPrivateKey Any ancestor private key in the key derivation path.
    */
   public static async decrypt(
-    recordsWrite: UnsignedRecordsWriteMessage,
+    recordsWrite: RecordsWriteMessage,
     ancestorPrivateKey: DerivedPrivateJwk,
     cipherStream: Readable
   ): Promise<Readable> {
@@ -69,7 +69,7 @@ export class Records {
    */
   public static constructKeyDerivationPath(
     keyDerivationScheme: KeyDerivationScheme,
-    recordsWriteMessage: UnsignedRecordsWriteMessage
+    recordsWriteMessage: RecordsWriteMessage
   ): string[] {
 
     const descriptor = recordsWriteMessage.descriptor;

--- a/tests/handlers/records-delete.spec.ts
+++ b/tests/handlers/records-delete.spec.ts
@@ -320,9 +320,9 @@ export function testRecordsDeleteHandler(): void {
           expect(reply.status.code).to.equal(202);
 
           const newWrite = await RecordsWrite.createFrom({
-            unsignedRecordsWriteMessage : recordsWrite.message,
-            published                   : true,
-            authorizationSigner         : Jws.createSigner(author)
+            recordsWriteMessage : recordsWrite.message,
+            published           : true,
+            authorizationSigner : Jws.createSigner(author)
           });
 
           const newWriteReply = await dwn.handleRecordsWrite(author.did, newWrite.message);

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -292,9 +292,9 @@ export function testRecordsWriteHandler(): void {
         expect(initialWriteReply.status.code).to.equal(202);
 
         const write2 = await RecordsWrite.createFrom({
-          unsignedRecordsWriteMessage : message,
-          published                   : true,
-          authorizationSigner         : Jws.createSigner(author),
+          recordsWriteMessage : message,
+          published           : true,
+          authorizationSigner : Jws.createSigner(author),
         });
 
         const writeUpdateReply = await dwn.handleRecordsWrite(tenant, write2.message);
@@ -489,9 +489,9 @@ export function testRecordsWriteHandler(): void {
           expect(initialWriteReply.status.code).to.equal(202);
 
           const write2 = await RecordsWrite.createFrom({
-            unsignedRecordsWriteMessage : message,
-            published                   : true,
-            authorizationSigner         : Jws.createSigner(author),
+            recordsWriteMessage : message,
+            published           : true,
+            authorizationSigner : Jws.createSigner(author),
           });
 
           const writeUpdateReply = await dwn.handleRecordsWrite(tenant, write2.message);
@@ -522,9 +522,9 @@ export function testRecordsWriteHandler(): void {
           expect(initialWriteReply.status.code).to.equal(202);
 
           const write2 = await RecordsWrite.createFrom({
-            unsignedRecordsWriteMessage : message,
-            published                   : true,
-            authorizationSigner         : Jws.createSigner(author),
+            recordsWriteMessage : message,
+            published           : true,
+            authorizationSigner : Jws.createSigner(author),
           });
 
           const writeUpdateReply = await dwn.handleRecordsWrite(tenant, write2.message);
@@ -648,8 +648,8 @@ export function testRecordsWriteHandler(): void {
         expect(deleteReply.status.code).to.equal(202);
 
         const write = await RecordsWrite.createFrom({
-          unsignedRecordsWriteMessage : message,
-          authorizationSigner         : Jws.createSigner(author),
+          recordsWriteMessage : message,
+          authorizationSigner : Jws.createSigner(author),
         });
 
         const withoutDataReply = await dwn.handleRecordsWrite(tenant, write.message);
@@ -680,8 +680,8 @@ export function testRecordsWriteHandler(): void {
         expect(deleteReply.status.code).to.equal(202);
 
         const write = await RecordsWrite.createFrom({
-          unsignedRecordsWriteMessage : message,
-          authorizationSigner         : Jws.createSigner(author),
+          recordsWriteMessage : message,
+          authorizationSigner : Jws.createSigner(author),
         });
 
         const withoutDataReply = await dwn.handleRecordsWrite(tenant, write.message);
@@ -839,9 +839,9 @@ export function testRecordsWriteHandler(): void {
 
             // changing the `published` property
             const newWrite = await RecordsWrite.createFrom({
-              unsignedRecordsWriteMessage : recordsWrite.message,
-              published                   : true,
-              authorizationSigner         : Jws.createSigner(author)
+              recordsWriteMessage : recordsWrite.message,
+              published           : true,
+              authorizationSigner : Jws.createSigner(author)
             });
 
             const newWriteReply = await dwn.handleRecordsWrite(tenant, newWrite.message);
@@ -876,9 +876,9 @@ export function testRecordsWriteHandler(): void {
 
             const newData = Encoder.stringToBytes('new data');
             const newWrite = await RecordsWrite.createFrom({
-              unsignedRecordsWriteMessage : recordsWrite.message,
-              data                        : newData,
-              authorizationSigner         : Jws.createSigner(author)
+              recordsWriteMessage : recordsWrite.message,
+              data                : newData,
+              authorizationSigner : Jws.createSigner(author)
             });
 
             const newWriteReply = await dwn.handleRecordsWrite(tenant, newWrite.message, DataStream.fromBytes(newData));
@@ -968,18 +968,18 @@ export function testRecordsWriteHandler(): void {
             expect(reply.status.code).to.equal(202);
 
             const newWrite = await RecordsWrite.createFrom({
-              unsignedRecordsWriteMessage : recordsWrite.message,
-              published                   : true,
-              authorizationSigner         : Jws.createSigner(author)
+              recordsWriteMessage : recordsWrite.message,
+              published           : true,
+              authorizationSigner : Jws.createSigner(author)
             });
 
             const newWriteReply = await dwn.handleRecordsWrite(author.did, newWrite.message);
             expect(newWriteReply.status.code).to.equal(202);
 
             const newestWrite = await RecordsWrite.createFrom({
-              unsignedRecordsWriteMessage : recordsWrite.message,
-              published                   : true,
-              authorizationSigner         : Jws.createSigner(author)
+              recordsWriteMessage : recordsWrite.message,
+              published           : true,
+              authorizationSigner : Jws.createSigner(author)
             });
 
             const newestWriteReply = await dwn.handleRecordsWrite(author.did, newestWrite.message);
@@ -3392,10 +3392,10 @@ export function testRecordsWriteHandler(): void {
 
           const updatedDataBytes = TestDataGenerator.randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded);
           const newWrite = await RecordsWrite.createFrom({
-            unsignedRecordsWriteMessage : message,
-            published                   : true,
-            authorizationSigner         : Jws.createSigner(alice),
-            data                        : updatedDataBytes,
+            recordsWriteMessage : message,
+            published           : true,
+            authorizationSigner : Jws.createSigner(alice),
+            data                : updatedDataBytes,
           });
 
           const updateDataStream = DataStream.fromBytes(updatedDataBytes);

--- a/tests/interfaces/records-write.spec.ts
+++ b/tests/interfaces/records-write.spec.ts
@@ -285,9 +285,9 @@ describe('RecordsWrite', () => {
       });
 
       const write = await RecordsWrite.createFrom({
-        unsignedRecordsWriteMessage : recordsWrite.message,
-        datePublished               : getCurrentTimeInHighPrecision(),
-        authorizationSigner         : Jws.createSigner(author)
+        recordsWriteMessage : recordsWrite.message,
+        datePublished       : getCurrentTimeInHighPrecision(),
+        authorizationSigner : Jws.createSigner(author)
       });
 
       expect(write.message.descriptor.published).to.be.true;

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -547,12 +547,12 @@ export class TestDataGenerator {
     const dataStream = DataStream.fromBytes(dataBytes);
 
     const options: CreateFromOptions = {
-      unsignedRecordsWriteMessage : input.existingWrite.message,
-      data                        : dataBytes,
+      recordsWriteMessage : input.existingWrite.message,
+      data                : dataBytes,
       published,
       datePublished,
-      messageTimestamp            : input.messageTimestamp,
-      authorizationSigner         : Jws.createSigner(input.author)
+      messageTimestamp    : input.messageTimestamp,
+      authorizationSigner : Jws.createSigner(input.author)
     };
 
     const recordsWrite = await RecordsWrite.createFrom(options);


### PR DESCRIPTION
Noticed some lingering incorrect naming due to recent inclusion of author signature in query/read results. `UnsignedRecordsWriteMessage` turned out to be no longer referenced upon fixing the names.