### PR TITLE
Add Dwn.handleRecordsDelete function

### DIFF
--- a/src/dwn.ts
+++ b/src/dwn.ts
@@ -8,7 +8,8 @@ import type { RecordsWriteHandlerOptions } from './handlers/records-write.js';
 import type { TenantGate } from './core/tenant-gate.js';
 import type { GenericMessageReply, UnionMessageReply } from './core/message-reply.js';
 import type { MessagesGetMessage, MessagesGetReply } from './types/messages-types.js';
-import type { RecordsQueryMessage, RecordsQueryReply, RecordsReadMessage, RecordsReadReply, RecordsWriteMessage, RecordsWriteReply } from './types/records-types.js';
+import type { RecordsDeleteMessage, RecordsDeleteReply, RecordsQueryMessage, RecordsQueryReply,
+  RecordsReadMessage, RecordsReadReply, RecordsWriteMessage, RecordsWriteReply } from './types/records-types.js';
 
 import { AllowAllTenantGate } from './core/tenant-gate.js';
 import { DidResolver } from './did/did-resolver.js';
@@ -152,6 +153,21 @@ export class Dwn {
     }
 
     const handler = new RecordsReadHandler(this.didResolver, this.messageStore, this.dataStore);
+    return handler.handle({ tenant, message });
+  }
+
+  /**
+   * Handles a `RecordsDelete` message.
+   */
+  public async handleRecordsDelete(tenant: string, message: RecordsDeleteMessage): Promise<RecordsDeleteReply> {
+    const errorMessageReply =
+      await this.validateTenant(tenant) ??
+      await this.validateMessageIntegrity(message, DwnInterfaceName.Records, DwnMethodName.Delete);
+    if (errorMessageReply !== undefined) {
+      return errorMessageReply;
+    }
+
+    const handler = new RecordsDeleteHandler(this.didResolver, this.messageStore, this.dataStore, this.eventLog);
     return handler.handle({ tenant, message });
   }
 

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -27,6 +27,8 @@ export type RecordsWriteDescriptor = {
 
 export type RecordsWriteReply = GenericMessageReply;
 
+export type RecordsDeleteReply = GenericMessageReply;
+
 /**
  * Internal RecordsWrite message representation that can be in an incomplete state.
  */

--- a/tests/dwn.spec.ts
+++ b/tests/dwn.spec.ts
@@ -365,5 +365,21 @@ export function testDwnClass(): void {
 
     });
 
+    describe('handleRecordsDelete', () => {
+      it('should return 400 error for bad message (invalid method)', async () => {
+        const alice = await DidKeyResolver.generate();
+
+        const { message } = await TestDataGenerator.generateRecordsDelete();
+
+        ( message as any).descriptor.method = 'Foo';
+
+        const reply = await dwn.handleRecordsDelete(alice.did, message);
+
+        expect(reply.status.code).to.equal(400);
+        expect(reply.status.detail).to.equal('Expected method RecordsDelete, received RecordsFoo');
+      });
+
+    });
+
   });
 }

--- a/tests/handlers/records-delete.spec.ts
+++ b/tests/handlers/records-delete.spec.ts
@@ -81,7 +81,7 @@ export function testRecordsDeleteHandler(): void {
           authorizationSigner : Jws.createSigner(alice)
         });
 
-        const deleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
+        const deleteReply = await dwn.handleRecordsDelete(alice.did, recordsDelete.message);
         expect(deleteReply.status.code).to.equal(202);
 
         // ensure a query will no longer find the deleted record
@@ -95,7 +95,7 @@ export function testRecordsDeleteHandler(): void {
           authorizationSigner : Jws.createSigner(alice)
         });
 
-        const recordsDelete2Reply = await dwn.processMessage(alice.did, recordsDelete2.message);
+        const recordsDelete2Reply = await dwn.handleRecordsDelete(alice.did, recordsDelete2.message);
         expect(recordsDelete2Reply.status.code).to.equal(404);
       });
 
@@ -129,7 +129,7 @@ export function testRecordsDeleteHandler(): void {
           author   : alice,
           recordId : aliceWriteData.message.recordId
         });
-        const aliceDeleteWriteReply = await dwn.processMessage(alice.did, aliceDeleteWriteData.message);
+        const aliceDeleteWriteReply = await dwn.handleRecordsDelete(alice.did, aliceDeleteWriteData.message);
         expect(aliceDeleteWriteReply.status.code).to.equal(202);
 
         // verify the other record with the same data is unaffected
@@ -151,7 +151,7 @@ export function testRecordsDeleteHandler(): void {
           author   : alice,
           recordId : aliceAssociateData.message.recordId
         });
-        const aliceDeleteAssociateReply = await dwn.processMessage(alice.did, aliceDeleteAssociateData.message);
+        const aliceDeleteAssociateReply = await dwn.handleRecordsDelete(alice.did, aliceDeleteAssociateData.message);
         expect(aliceDeleteAssociateReply.status.code).to.equal(202);
 
         // verify that alice can no longer fetch the 2nd record
@@ -182,7 +182,7 @@ export function testRecordsDeleteHandler(): void {
           authorizationSigner : Jws.createSigner(alice)
         });
 
-        const deleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
+        const deleteReply = await dwn.handleRecordsDelete(alice.did, recordsDelete.message);
         expect(deleteReply.status.code).to.equal(404);
       });
 
@@ -211,7 +211,7 @@ export function testRecordsDeleteHandler(): void {
         expect(subsequentWriteReply.status.code).to.equal(202);
 
         // test that a delete with an earlier `messageTimestamp` results in a 409
-        const deleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
+        const deleteReply = await dwn.handleRecordsDelete(alice.did, recordsDelete.message);
         expect(deleteReply.status.code).to.equal(409);
 
         // ensure data still exists
@@ -253,7 +253,7 @@ export function testRecordsDeleteHandler(): void {
           author   : alice,
           recordId : aliceWriteData.message.recordId
         });
-        const aliceDeleteWriteReply = await dwn.processMessage(alice.did, aliceDeleteWriteData.message);
+        const aliceDeleteWriteReply = await dwn.handleRecordsDelete(alice.did, aliceDeleteWriteData.message);
         expect(aliceDeleteWriteReply.status.code).to.equal(202);
 
         const aliceQueryWriteAfterAliceDeleteData = await TestDataGenerator.generateRecordsQuery({
@@ -295,7 +295,7 @@ export function testRecordsDeleteHandler(): void {
             authorizationSigner : Jws.createSigner(alice)
           });
 
-          const deleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
+          const deleteReply = await dwn.handleRecordsDelete(alice.did, recordsDelete.message);
           expect(deleteReply.status.code).to.equal(202);
 
           const events = await eventLog.getEvents(alice.did);
@@ -333,7 +333,7 @@ export function testRecordsDeleteHandler(): void {
             authorizationSigner : Jws.createSigner(author)
           });
 
-          const deleteReply = await dwn.processMessage(author.did, recordsDelete.message);
+          const deleteReply = await dwn.handleRecordsDelete(author.did, recordsDelete.message);
           expect(deleteReply.status.code).to.equal(202);
 
           const events = await eventLog.getEvents(author.did);

--- a/tests/handlers/records-read.spec.ts
+++ b/tests/handlers/records-read.spec.ts
@@ -1428,7 +1428,7 @@ export function testRecordsReadHandler(): void {
           authorizationSigner : Jws.createSigner(alice)
         });
 
-        const deleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
+        const deleteReply = await dwn.handleRecordsDelete(alice.did, recordsDelete.message);
         expect(deleteReply.status.code).to.equal(202);
 
         // RecordsRead

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -644,7 +644,7 @@ export function testRecordsWriteHandler(): void {
           recordId            : message.recordId,
           authorizationSigner : Jws.createSigner(author),
         });
-        const deleteReply = await dwn.processMessage(tenant, recordsDelete.message);
+        const deleteReply = await dwn.handleRecordsDelete(tenant, recordsDelete.message);
         expect(deleteReply.status.code).to.equal(202);
 
         const write = await RecordsWrite.createFrom({
@@ -676,7 +676,7 @@ export function testRecordsWriteHandler(): void {
           recordId            : message.recordId,
           authorizationSigner : Jws.createSigner(author),
         });
-        const deleteReply = await dwn.processMessage(tenant, recordsDelete.message);
+        const deleteReply = await dwn.handleRecordsDelete(tenant, recordsDelete.message);
         expect(deleteReply.status.code).to.equal(202);
 
         const write = await RecordsWrite.createFrom({
@@ -1336,7 +1336,7 @@ export function testRecordsWriteHandler(): void {
                 author   : alice,
                 recordId : friendRoleRecord.message.recordId,
               });
-              const deleteFriendReply = await dwn.processMessage(alice.did, deleteFriend.message);
+              const deleteFriendReply = await dwn.handleRecordsDelete(alice.did, deleteFriend.message);
               expect(deleteFriendReply.status.code).to.equal(202);
 
               // Alice writes a new record adding Bob as a 'friend' again
@@ -1553,7 +1553,7 @@ export function testRecordsWriteHandler(): void {
                 author   : alice,
                 recordId : participantRecord1.message.recordId,
               });
-              const participantDeleteReply = await dwn.processMessage(alice.did, partipantDelete.message);
+              const participantDeleteReply = await dwn.handleRecordsDelete(alice.did, partipantDelete.message);
               expect(participantDeleteReply.status.code).to.equal(202);
 
               // Alice creates a new 'thread/participant' record


### PR DESCRIPTION
This commit introduces a handleRecordsDelete function meant to be used in place of the existing processMessage (which is eventually meant to be replaced, as described in issue #289).

This commit also updates the relevant tests in records-(write|delete|read).ts files, which were using processMessage and replaces its usage with the new handleRecordsDelete.

It also introduces a test in dwn.spec.ts, enough to bring uncovered lines of this new function to 0 (more specifically, the new test is meant to cover the exception path).