### PR TITLE
Make protocol record validation and authorization distinct actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here's to a thrilling Hacktoberfest voyage with us! 🎉
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-98.37%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.19%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.71%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.37%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-98.35%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.14%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.71%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.35%25-brightgreen.svg?style=flat)
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here's to a thrilling Hacktoberfest voyage with us! 🎉
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-98.37%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.11%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.7%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.37%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-98.37%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.19%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.71%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.37%25-brightgreen.svg?style=flat)
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here's to a thrilling Hacktoberfest voyage with us! 🎉
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-98.37%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.18%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.71%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.37%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-98.37%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.19%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.71%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.37%25-brightgreen.svg?style=flat)
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here's to a thrilling Hacktoberfest voyage with us! 🎉
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-98.37%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.19%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.71%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.37%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-98.37%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.18%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.71%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.37%25-brightgreen.svg?style=flat)
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -43,6 +43,7 @@ export enum DwnErrorCode {
   ProtocolAuthorizationInvalidType = 'ProtocolAuthorizationInvalidType',
   ProtocolAuthorizationMissingRole = 'ProtocolAuthorizationMissingRole',
   ProtocolAuthorizationMissingRuleSet = 'ProtocolAuthorizationMissingRuleSet',
+  ProtocolAuthorizationParentlessIncorrectProtocolPath = 'ProtocolAuthorizationParentlessIncorrectProtocolPath',
   ProtocolAuthorizationNotARole = 'ProtocolAuthorizationNotARole',
   ProtocolAuthorizationRoleMissingRecipient = 'ProtocolAuthorizationRoleMissingRecipient',
   ProtocolsConfigureContextRoleAtProhibitedProtocolPath = 'ProtocolsConfigureContextRoleAtProhibitedProtocolPath',

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -1,10 +1,9 @@
 import type { Filter } from '../types/message-types.js';
 import type { MessageStore } from '../types/message-store.js';
 import type { RecordsRead } from '../interfaces/records-read.js';
-import type { InternalRecordsWriteMessage, RecordsReadMessage, RecordsWriteMessage } from '../types/records-types.js';
+import type { RecordsWriteMessage } from '../types/records-types.js';
 import type { ProtocolActionRule, ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureMessage, ProtocolType, ProtocolTypes } from '../types/protocols-types.js';
 
-import { RecordsGrantAuthorization } from './records-grant-authorization.js';
 import { RecordsWrite } from '../interfaces/records-write.js';
 import { DwnError, DwnErrorCode } from './dwn-error.js';
 import { DwnInterfaceName, DwnMethodName, Message } from './message.js';
@@ -16,6 +15,56 @@ const methodToAllowedActionMap: Record<string, ProtocolAction> = {
 };
 
 export class ProtocolAuthorization {
+
+  /**
+   * Performs validation on the structure of RecordsWrite messages that use a protocol.
+   * @throws {Error} if validation fails.
+   */
+  public static async validate(
+    tenant: string,
+    incomingMessage: RecordsWrite,
+    messageStore: MessageStore,
+  ): Promise<void> {
+    // fetch ancestor message chain
+    const ancestorMessageChain: RecordsWriteMessage[] =
+      await ProtocolAuthorization.constructAncestorMessageChain(tenant, incomingMessage, incomingMessage, messageStore);
+
+    // fetch the protocol definition
+    const protocolDefinition = await ProtocolAuthorization.fetchProtocolDefinition(
+      tenant,
+      incomingMessage,
+      messageStore,
+    );
+
+    // verify declared protocol type exists in protocol and that it conforms to type specification
+    ProtocolAuthorization.verifyType(
+      incomingMessage.message,
+      protocolDefinition.types
+    );
+
+    // validate `protocolPath`
+    ProtocolAuthorization.verifyProtocolPath(
+      incomingMessage,
+      ancestorMessageChain,
+    );
+
+    // get the rule set for the inbound message
+    const inboundMessageRuleSet = ProtocolAuthorization.getRuleSet(
+      incomingMessage,
+      protocolDefinition,
+    );
+
+    // If the incoming message is writing a $globalRole record, validate that the recipient is unique
+    await ProtocolAuthorization.verifyUniqueRoleRecipient(
+      tenant,
+      incomingMessage,
+      inboundMessageRuleSet,
+      messageStore,
+    );
+
+    // verify allowed condition of incoming message
+    await ProtocolAuthorization.verifyActionCondition(tenant, incomingMessage, messageStore);
+  }
 
   /**
    * Performs protocol-based authorization against the given message.
@@ -40,18 +89,6 @@ export class ProtocolAuthorization {
       messageStore,
     );
 
-    // verify declared protocol type exists in protocol and that it conforms to type specification
-    ProtocolAuthorization.verifyType(
-      incomingMessage.message,
-      protocolDefinition.types
-    );
-
-    // validate `protocolPath`
-    ProtocolAuthorization.verifyProtocolPath(
-      incomingMessage,
-      ancestorMessageChain,
-    );
-
     // get the rule set for the inbound message
     const inboundMessageRuleSet = ProtocolAuthorization.getRuleSet(
       recordsWrite,
@@ -69,24 +106,10 @@ export class ProtocolAuthorization {
 
     // verify method invoked against the allowed actions
     await ProtocolAuthorization.verifyAllowedActions(
-      tenant,
       incomingMessage,
-      recordsWrite,
       inboundMessageRuleSet,
       ancestorMessageChain,
-      messageStore,
     );
-
-    // If the incoming message is writing a $globalRole record, validate that the recipient is unique
-    await ProtocolAuthorization.verifyUniqueRoleRecipient(
-      tenant,
-      incomingMessage,
-      inboundMessageRuleSet,
-      messageStore,
-    );
-
-    // verify allowed condition of incoming message
-    await ProtocolAuthorization.verifyActionCondition(tenant, incomingMessage, messageStore);
   }
 
   /**
@@ -184,14 +207,9 @@ export class ProtocolAuthorization {
    * @throws {DwnError} if fails verification.
    */
   private static verifyProtocolPath(
-    inboundMessage: RecordsRead | RecordsWrite,
+    inboundMessage: RecordsWrite,
     ancestorMessageChain: RecordsWriteMessage[],
   ): void {
-    // skip verification if this is not a RecordsWrite
-    if (inboundMessage.message.descriptor.method !== DwnMethodName.Write) {
-      return;
-    }
-
     const declaredProtocolPath = (inboundMessage as RecordsWrite).message.descriptor.protocolPath!;
     const declaredTypeName = ProtocolAuthorization.getTypeName(declaredProtocolPath);
 
@@ -218,30 +236,25 @@ export class ProtocolAuthorization {
    * @throws {DwnError} if fails verification.
    */
   private static verifyType(
-    inboundMessage: RecordsReadMessage | InternalRecordsWriteMessage,
+    inboundMessage: RecordsWriteMessage,
     protocolTypes: ProtocolTypes,
   ): void {
-    // skip verification if this is not a RecordsWrite
-    if (inboundMessage.descriptor.method !== DwnMethodName.Write) {
-      return;
-    }
-    const recordsWriteMessage = inboundMessage as RecordsWriteMessage;
 
     const typeNames = Object.keys(protocolTypes);
-    const declaredProtocolPath = recordsWriteMessage.descriptor.protocolPath!;
+    const declaredProtocolPath = inboundMessage.descriptor.protocolPath!;
     const declaredTypeName = ProtocolAuthorization.getTypeName(declaredProtocolPath);
     if (!typeNames.includes(declaredTypeName)) {
       throw new DwnError(DwnErrorCode.ProtocolAuthorizationInvalidType,
         `record with type ${declaredTypeName} not allowed in protocol`);
     }
 
-    const protocolPath = recordsWriteMessage.descriptor.protocolPath!;
+    const protocolPath = inboundMessage.descriptor.protocolPath!;
     // existence of `protocolType` has already been verified
     const typeName = ProtocolAuthorization.getTypeName(protocolPath);
     const protocolType: ProtocolType = protocolTypes[typeName];
 
     // no `schema` specified in protocol definition means that any schema is allowed
-    const { schema } = recordsWriteMessage.descriptor;
+    const { schema } = inboundMessage.descriptor;
     if (protocolType.schema !== undefined && protocolType.schema !== schema) {
       throw new DwnError(
         DwnErrorCode.ProtocolAuthorizationInvalidSchema,
@@ -251,7 +264,7 @@ export class ProtocolAuthorization {
     }
 
     // no `dataFormats` specified in protocol definition means that all dataFormats are allowed
-    const { dataFormat } = recordsWriteMessage.descriptor;
+    const { dataFormat } = inboundMessage.descriptor;
     if (protocolType.dataFormats !== undefined && !protocolType.dataFormats.includes(dataFormat)) {
       throw new DwnError(
         DwnErrorCode.ProtocolAuthorizationIncorrectDataFormat,
@@ -312,40 +325,17 @@ export class ProtocolAuthorization {
    * @throws {Error} if action not allowed.
    */
   private static async verifyAllowedActions(
-    tenant: string,
     incomingMessage: RecordsRead | RecordsWrite,
-    recordsWrite: RecordsWrite,
     inboundMessageRuleSet: ProtocolRuleSet,
     ancestorMessageChain: RecordsWriteMessage[],
-    messageStore: MessageStore,
   ): Promise<void> {
     const incomingMessageMethod = incomingMessage.message.descriptor.method;
     const inboundMessageAction = methodToAllowedActionMap[incomingMessageMethod];
     const author = incomingMessage.author;
     const actionRules = inboundMessageRuleSet.$actions;
 
-    if (incomingMessage.message.authorization?.ownerSignature !== undefined) {
-      // if incoming message is a write retained by this tenant, we by design bypass allowed action verification
-      // NOTE: the "owner === tenant" check is already done before this method is invoked
-      return;
-    } else if (author === tenant) {
-      // tenant is always authorized
-      return;
-    } else if (incomingMessage.author !== undefined && incomingMessage.authorSignaturePayload?.permissionsGrantId !== undefined) {
-      // PermissionsGrant gives the author explicit access to this record
-      if (incomingMessageMethod === DwnMethodName.Write) {
-        await RecordsGrantAuthorization.authorizeWrite(tenant, incomingMessage as RecordsWrite, incomingMessage.author, messageStore);
-      } else {
-        await RecordsGrantAuthorization.authorizeRead(
-          tenant,
-          incomingMessage as RecordsRead,
-          recordsWrite,
-          incomingMessage.author,
-          messageStore
-        );
-      }
-      return;
-    } else if (actionRules === undefined) {
+    // We have already checked that the message is not from tenant, owner, or permissionsGrant
+    if (actionRules === undefined) {
       throw new Error(`no action rule defined for ${incomingMessageMethod}, ${author} is unauthorized`);
     }
 
@@ -386,14 +376,10 @@ export class ProtocolAuthorization {
    */
   private static async verifyUniqueRoleRecipient(
     tenant: string,
-    incomingMessage: RecordsRead | RecordsWrite,
+    incomingMessage: RecordsWrite,
     inboundMessageRuleSet: ProtocolRuleSet,
     messageStore: MessageStore,
   ): Promise<void> {
-    if (incomingMessage.message.descriptor.method !== DwnMethodName.Write) {
-      return;
-    }
-
     const incomingRecordsWrite = incomingMessage as RecordsWrite;
     if (!inboundMessageRuleSet.$globalRole && !inboundMessageRuleSet.$contextRole) {
       return;
@@ -444,25 +430,21 @@ export class ProtocolAuthorization {
    * Currently the only check is: if the write is not the initial write, the author must be the same as the initial write
    * @throws {Error} if fails verification
    */
-  private static async verifyActionCondition(tenant: string, incomingMessage: RecordsRead | RecordsWrite, messageStore: MessageStore): Promise<void> {
-    if (incomingMessage.message.descriptor.method === DwnMethodName.Read) {
-      // Currently no conditions for reads
-    } else if (incomingMessage.message.descriptor.method === DwnMethodName.Write) {
-      const recordsWrite = incomingMessage as RecordsWrite;
-      const isInitialWrite = await recordsWrite.isInitialWrite();
-      if (!isInitialWrite) {
-        // fetch the initialWrite
-        const query = {
-          entryId: recordsWrite.message.recordId
-        };
-        const { messages: result } = await messageStore.query(tenant, [ query ]);
+  private static async verifyActionCondition(tenant: string, incomingMessage: RecordsWrite, messageStore: MessageStore): Promise<void> {
+    const recordsWrite = incomingMessage as RecordsWrite;
+    const isInitialWrite = await recordsWrite.isInitialWrite();
+    if (!isInitialWrite) {
+      // fetch the initialWrite
+      const query = {
+        entryId: recordsWrite.message.recordId
+      };
+      const { messages: result } = await messageStore.query(tenant, [ query ]);
 
-        // check the author of the initial write matches the author of the incoming message
-        const initialWrite = result[0] as RecordsWriteMessage;
-        const authorOfInitialWrite = Message.getAuthor(initialWrite);
-        if (recordsWrite.author !== authorOfInitialWrite) {
-          throw new Error(`author of incoming message '${recordsWrite.author}' must match to author of initial write '${authorOfInitialWrite}'`);
-        }
+      // check the author of the initial write matches the author of the incoming message
+      const initialWrite = result[0] as RecordsWriteMessage;
+      const authorOfInitialWrite = Message.getAuthor(initialWrite);
+      if (recordsWrite.author !== authorOfInitialWrite) {
+        throw new Error(`author of incoming message '${recordsWrite.author}' must match to author of initial write '${authorOfInitialWrite}'`);
       }
     }
   }

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -444,9 +444,8 @@ export class ProtocolAuthorization {
    * @throws {Error} if fails verification
    */
   private static async verifyActionCondition(tenant: string, incomingMessage: RecordsRead | RecordsWrite, messageStore: MessageStore): Promise<void> {
-    if (incomingMessage.message.descriptor.method === DwnMethodName.Read) {
-      // Currently no conditions for reads
-    } else if (incomingMessage.message.descriptor.method === DwnMethodName.Write) {
+    // Currently no conditions for methods other than Write
+    if (incomingMessage.message.descriptor.method === DwnMethodName.Write) {
       const recordsWrite = incomingMessage as RecordsWrite;
       const isInitialWrite = await recordsWrite.isInitialWrite();
       if (!isInitialWrite) {

--- a/src/handlers/records-write.ts
+++ b/src/handlers/records-write.ts
@@ -7,6 +7,7 @@ import type { RecordsDeleteMessage, RecordsWriteMessage } from '../types/records
 
 import { authenticate } from '../core/auth.js';
 import { messageReplyFromError } from '../core/message-reply.js';
+import { ProtocolAuthorization } from '../core/protocol-authorization.js';
 import { RecordsWrite } from '../interfaces/records-write.js';
 import { StorageController } from '../store/storage-controller.js';
 import { Cid, DataStream, DwnConstant, Encoder } from '../index.js';
@@ -32,6 +33,11 @@ export class RecordsWriteHandler implements MethodHandler {
     let recordsWrite: RecordsWrite;
     try {
       recordsWrite = await RecordsWrite.parse(message);
+
+      // Protocol record specific validation
+      if (message.descriptor.protocol !== undefined) {
+        await ProtocolAuthorization.validate(tenant, recordsWrite, this.messageStore);
+      }
     } catch (e) {
       return messageReplyFromError(e, 400);
     }

--- a/src/handlers/records-write.ts
+++ b/src/handlers/records-write.ts
@@ -36,7 +36,7 @@ export class RecordsWriteHandler implements MethodHandler {
 
       // Protocol record specific validation
       if (message.descriptor.protocol !== undefined) {
-        await ProtocolAuthorization.validate(tenant, recordsWrite, this.messageStore);
+        await ProtocolAuthorization.validateReferentialIntegrity(tenant, recordsWrite, this.messageStore);
       }
     } catch (e) {
       return messageReplyFromError(e, 400);

--- a/src/interfaces/records-read.ts
+++ b/src/interfaces/records-read.ts
@@ -79,11 +79,10 @@ export class RecordsRead extends Message<RecordsReadMessage> {
     } else if (this.author !== undefined && this.author === descriptor.recipient) {
       // The recipient of a message may always read it
       return;
-    } else if (descriptor.protocol !== undefined) {
-      // All protocol RecordsWrites must go through protocol auth, because protocolPath, contextId, and record type must be validated
-      await ProtocolAuthorization.authorize(tenant, this, newestRecordsWrite, messageStore);
-    } else if (this.author !== undefined && this.authorSignaturePayload?.permissionsGrantId !== undefined) {
+    } else if (this.author !== undefined && this.authorSignaturePayload!.permissionsGrantId !== undefined) {
       await RecordsGrantAuthorization.authorizeRead(tenant, this, newestRecordsWrite, this.author, messageStore);
+    } else if (descriptor.protocol !== undefined) {
+      await ProtocolAuthorization.authorize(tenant, this, newestRecordsWrite, messageStore);
     } else {
       throw new Error('message failed authorization');
     }

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -451,10 +451,9 @@ export class RecordsWrite {
       );
     }
 
-    // All protocol RecordsWrites must go through protocol auth, because protocolPath, contextId, and record type must be validated
+    // All protocol RecordsWrites must go through protocol validation
     if (this.message.descriptor.protocol !== undefined) {
-      await ProtocolAuthorization.authorize(tenant, this, this, messageStore);
-      return;
+      await ProtocolAuthorization.validate(tenant, this, messageStore);
     }
 
     // Remainder of the code is for flat-space writes
@@ -468,6 +467,8 @@ export class RecordsWrite {
       return;
     } else if (this.author !== undefined && this.authorSignaturePayload!.permissionsGrantId !== undefined) {
       await RecordsGrantAuthorization.authorizeWrite(tenant, this, this.author, messageStore);
+    } else if (this.message.descriptor.protocol !== undefined) {
+      await ProtocolAuthorization.authorize(tenant, this, this, messageStore);
     } else {
       throw new Error('message failed authorization');
     }

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -451,8 +451,6 @@ export class RecordsWrite {
       );
     }
 
-    // Remainder of the code is for flat-space writes
-
     if (this.owner !== undefined) {
       // if incoming message is a write retained by this tenant, we by-design always allow
       // NOTE: the "owner === tenant" check is already done earlier in this method

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -451,11 +451,6 @@ export class RecordsWrite {
       );
     }
 
-    // All protocol RecordsWrites must go through protocol validation
-    if (this.message.descriptor.protocol !== undefined) {
-      await ProtocolAuthorization.validate(tenant, this, messageStore);
-    }
-
     // Remainder of the code is for flat-space writes
 
     if (this.owner !== undefined) {

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -1920,7 +1920,7 @@ export function testRecordsWriteHandler(): void {
           );
 
           const carolWriteReply = await dwn.handleRecordsWrite(alice.did, modifiedMessageFromCarol.message, modifiedMessageFromCarol.dataStream);
-          expect(carolWriteReply.status.code).to.equal(400);
+          expect(carolWriteReply.status.code).to.equal(401);
           expect(carolWriteReply.status.detail).to.contain('must match to author of initial write');
         });
 

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -1261,7 +1261,7 @@ export function testRecordsWriteHandler(): void {
                 data         : new TextEncoder().encode('Bob is my friend'),
               });
               const friendRoleReply = await dwn.processMessage(alice.did, friendRoleRecord.message, friendRoleRecord.dataStream);
-              expect(friendRoleReply.status.code).to.equal(401);
+              expect(friendRoleReply.status.code).to.equal(400);
               expect(friendRoleReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationRoleMissingRecipient);
             });
 
@@ -1301,7 +1301,7 @@ export function testRecordsWriteHandler(): void {
                 data         : new TextEncoder().encode('Bob is still my friend'),
               });
               const duplicateFriendReply = await dwn.handleRecordsWrite(alice.did, duplicateFriendRecord.message, duplicateFriendRecord.dataStream);
-              expect(duplicateFriendReply.status.code).to.equal(401);
+              expect(duplicateFriendReply.status.code).to.equal(400);
               expect(duplicateFriendReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationDuplicateGlobalRoleRecipient);
             });
 
@@ -1507,7 +1507,7 @@ export function testRecordsWriteHandler(): void {
                 parentId     : threadRecord.message.recordId,
               });
               const participantRecordReply2 = await dwn.processMessage(alice.did, participantRecord2.message, participantRecord2.dataStream);
-              expect(participantRecordReply2.status.code).to.equal(401);
+              expect(participantRecordReply2.status.code).to.equal(400);
               expect(participantRecordReply2.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationDuplicateContextRoleRecipient);
             });
 
@@ -1920,7 +1920,7 @@ export function testRecordsWriteHandler(): void {
           );
 
           const carolWriteReply = await dwn.handleRecordsWrite(alice.did, modifiedMessageFromCarol.message, modifiedMessageFromCarol.dataStream);
-          expect(carolWriteReply.status.code).to.equal(401);
+          expect(carolWriteReply.status.code).to.equal(400);
           expect(carolWriteReply.status.detail).to.contain('must match to author of initial write');
         });
 
@@ -2067,7 +2067,7 @@ export function testRecordsWriteHandler(): void {
           });
 
           const reply = await dwn.handleRecordsWrite(alice.did, credentialApplication.message, credentialApplication.dataStream);
-          expect(reply.status.code).to.equal(401);
+          expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain('unable to find protocol definition');
         });
 
@@ -2095,7 +2095,7 @@ export function testRecordsWriteHandler(): void {
           });
 
           const reply = await dwn.handleRecordsWrite(alice.did, credentialApplication.message, credentialApplication.dataStream);
-          expect(reply.status.code).to.equal(401);
+          expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationInvalidSchema);
         });
 
@@ -2123,7 +2123,7 @@ export function testRecordsWriteHandler(): void {
           });
 
           const reply = await dwn.handleRecordsWrite(alice.did, credentialApplication.message, credentialApplication.dataStream);
-          expect(reply.status.code).to.equal(401);
+          expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationInvalidType);
         });
 
@@ -2151,7 +2151,7 @@ export function testRecordsWriteHandler(): void {
           });
 
           const reply = await dwn.handleRecordsWrite(alice.did, credentialApplication.message, credentialApplication.dataStream);
-          expect(reply.status.code).to.equal(401);
+          expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationIncorrectProtocolPath);
         });
 
@@ -2195,7 +2195,7 @@ export function testRecordsWriteHandler(): void {
           });
 
           const replyMismatch = await dwn.handleRecordsWrite(alice.did, recordsWriteMismatch.message, recordsWriteMismatch.dataStream);
-          expect(replyMismatch.status.code).to.equal(401);
+          expect(replyMismatch.status.code).to.equal(400);
           expect(replyMismatch.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationIncorrectDataFormat);
         });
 
@@ -2227,7 +2227,7 @@ export function testRecordsWriteHandler(): void {
           });
           const failedCredentialResponseReply = await dwn.handleRecordsWrite(
             alice.did, failedCredentialResponse.message, failedCredentialResponse.dataStream);
-          expect(failedCredentialResponseReply.status.code).to.equal(401);
+          expect(failedCredentialResponseReply.status.code).to.equal(400);
           expect(failedCredentialResponseReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationMissingRuleSet);
 
           // Successfully write a 'credentialApplication' at the top level of the of the record hierarchy
@@ -2256,7 +2256,7 @@ export function testRecordsWriteHandler(): void {
           });
           const failedCredentialApplicationReply2 = await dwn.handleRecordsWrite(
             alice.did, failedCredentialApplication.message, failedCredentialApplication.dataStream);
-          expect(failedCredentialApplicationReply2.status.code).to.equal(401);
+          expect(failedCredentialApplicationReply2.status.code).to.equal(400);
           expect(failedCredentialApplicationReply2.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationMissingRuleSet);
 
           // Successfully write a 'credentialResponse' below the 'credentialApplication'
@@ -2287,7 +2287,7 @@ export function testRecordsWriteHandler(): void {
           });
           const nestedCredentialApplicationReply = await dwn.handleRecordsWrite(
             alice.did, nestedCredentialApplication.message, nestedCredentialApplication.dataStream);
-          expect(nestedCredentialApplicationReply.status.code).to.equal(401);
+          expect(nestedCredentialApplicationReply.status.code).to.equal(400);
           expect(nestedCredentialApplicationReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationMissingRuleSet);
         });
 
@@ -2464,7 +2464,7 @@ export function testRecordsWriteHandler(): void {
           });
 
           reply = await dwn.handleRecordsWrite(pfi.did, fulfillmentMessageData.message, fulfillmentMessageData.dataStream);
-          expect(reply.status.code).to.equal(401);
+          expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain('no parent found');
         });
 

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -2152,7 +2152,7 @@ export function testRecordsWriteHandler(): void {
 
           const reply = await dwn.handleRecordsWrite(alice.did, credentialApplication.message, credentialApplication.dataStream);
           expect(reply.status.code).to.equal(400);
-          expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationIncorrectProtocolPath);
+          expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationParentlessIncorrectProtocolPath);
         });
 
         it('should fail authorization if given `dataFormat` is mismatching with the dataFormats in protocol definition', async () => {
@@ -2465,7 +2465,7 @@ export function testRecordsWriteHandler(): void {
 
           reply = await dwn.handleRecordsWrite(pfi.did, fulfillmentMessageData.message, fulfillmentMessageData.dataStream);
           expect(reply.status.code).to.equal(400);
-          expect(reply.status.detail).to.contain('no parent found');
+          expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationIncorrectProtocolPath);
         });
 
         it('should 400 if expected CID of `encryption` mismatches the `encryptionCid` in `authorization`', async () => {

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -2666,9 +2666,7 @@ export function testRecordsWriteHandler(): void {
 
           // Bob writes a non-protocol record to Alice's DWN
           const nonProtocolRecordsWrite = await TestDataGenerator.generateRecordsWrite({
-            author       : bob,
-            protocol     : protocolDefinition.protocol,
-            protocolPath : 'foo',
+            author: bob,
             permissionsGrantId,
           });
           const recordsWriteReply2 = await dwn.handleRecordsWrite(alice.did, nonProtocolRecordsWrite.message, nonProtocolRecordsWrite.dataStream);


### PR DESCRIPTION
Currently, protocol record validation and authorization are coupled. This PR attempts to separate the two actions into distinct calls `ProtocolAuthorization.validate()` for RecordsWrites and `ProtocolAuthorization.authorize()` for any incoming message. There is some duplication of code across `validate` and `authorize`. The most significant of which is that we iterate up the ancestor chain with `constructAncestorMessageChain()`. If we think this is an unacceptable inefficiency, we can fix by updating `verifyProtocolPath` to look at only the parent instead of the entire ancestor chain.