### PR TITLE
Add support for both compressed and uncompressed secp256k1 publicKey

### DIFF
--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -67,9 +67,9 @@ export class Encryption {
    * with SECP256K1 for the asymmetric calculations, HKDF as the key-derivation function,
    * and AES-GCM for the symmetric encryption and MAC algorithms.
    */
-  public static async eciesSecp256k1Encrypt(uncompressedPublicKey: Uint8Array, plaintext: Uint8Array): Promise<EciesEncryptionOutput> {
+  public static async eciesSecp256k1Encrypt(publicKeyBytes: Uint8Array, plaintext: Uint8Array): Promise<EciesEncryptionOutput> {
     // underlying library requires Buffer as input
-    const publicKey = Buffer.from(uncompressedPublicKey);
+    const publicKey = Buffer.from(publicKeyBytes);
     const plaintextBuffer = Buffer.from(plaintext);
 
     const cryptogram = eciesjs.encrypt(publicKey, plaintextBuffer);

--- a/src/utils/secp256k1.ts
+++ b/src/utils/secp256k1.ts
@@ -129,11 +129,13 @@ export class Secp256k1 {
   }
 
   /**
-   * Generates key pair in raw bytes, where the `publicKey` is uncompressed.
+   * Generates key pair in raw bytes.
+   * 
+   * @param {boolean} [isCompressed=false] controls `publicKey` to be compressed bytes
    */
-  public static async generateKeyPairRaw(): Promise<{publicKey: Uint8Array, privateKey: Uint8Array}> {
+  public static async generateKeyPairRaw(isCompressed: boolean=false): Promise<{publicKey: Uint8Array, privateKey: Uint8Array}> {
     const privateKey = secp256k1.utils.randomPrivateKey();
-    const publicKey = secp256k1.getPublicKey(privateKey, false); // `false` = uncompressed
+    const publicKey = secp256k1.getPublicKey(privateKey, isCompressed);
 
     return { publicKey, privateKey };
   }

--- a/src/utils/secp256k1.ts
+++ b/src/utils/secp256k1.ts
@@ -69,13 +69,20 @@ export class Secp256k1 {
   /**
    * Creates a uncompressed key in raw bytes from the given SECP256K1 JWK.
    */
-  public static publicJwkToBytes(publicJwk: PublicJwk): Uint8Array {
+  public static publicJwkToBytes(publicJwk: PublicJwk, isCompresed: boolean=false): Uint8Array {
     const x = Encoder.base64UrlToBytes(publicJwk.x);
     const y = Encoder.base64UrlToBytes(publicJwk.y!);
 
-    // leading byte of 0x04 indicates that the public key is uncompressed
-    const publicKey = new Uint8Array([0x04, ...x, ...y]);
-    return publicKey;
+    if(isCompresed){
+      return secp256k1.ProjectivePoint.fromAffine({
+        x: secp256k1.etc.bytesToNumberBE(x),
+        y: secp256k1.etc.bytesToNumberBE(y)
+      }).toRawBytes(isCompresed);
+    }else{
+      // leading byte of 0x04 indicates that the public key is uncompressed
+      const publicKey = new Uint8Array([0x04, ...x, ...y]);
+      return publicKey;
+    }
   }
 
   /**

--- a/tests/utils/encryption.spec.ts
+++ b/tests/utils/encryption.spec.ts
@@ -107,15 +107,17 @@ describe('Encryption', () => {
   });
 
   describe('ECIES-SECP256K1', () => {
-    it('should be able to encrypt and decrypt given bytes correctly', async () => {
-      const { publicKey, privateKey } = await Secp256k1.generateKeyPairRaw();
-
-      const originalPlaintext = TestDataGenerator.randomBytes(32);
-      const encryptionOutput = await Encryption.eciesSecp256k1Encrypt(publicKey, originalPlaintext);
-      const decryptionInput = { privateKey, ...encryptionOutput };
-      const decryptedPlaintext = await Encryption.eciesSecp256k1Decrypt(decryptionInput);
-
-      expect(ArrayUtility.byteArraysEqual(originalPlaintext, decryptedPlaintext)).to.be.true;
+    describe('should be able to encrypt and decrypt given bytes correctly', async ()=>{
+      for(const isCompressed of [true, false]){
+        const { publicKey, privateKey } = await Secp256k1.generateKeyPairRaw(isCompressed);
+  
+        const originalPlaintext = TestDataGenerator.randomBytes(32);
+        const encryptionOutput = await Encryption.eciesSecp256k1Encrypt(publicKey, originalPlaintext);
+        const decryptionInput = { privateKey, ...encryptionOutput };
+        const decryptedPlaintext = await Encryption.eciesSecp256k1Decrypt(decryptionInput);
+  
+        expect(ArrayUtility.byteArraysEqual(originalPlaintext, decryptedPlaintext)).to.be.true;
+      }
     });
   });
 });

--- a/tests/utils/secp256k1.spec.ts
+++ b/tests/utils/secp256k1.spec.ts
@@ -28,6 +28,9 @@ describe('Secp256k1', () => {
 
       expect(publicJwk1.x).to.equal(publicJwk2.x);
       expect(publicJwk1.y).to.equal(publicJwk2.y);
+
+      expect(base64url.baseEncode(Secp256k1.publicJwkToBytes(publicJwk1, true))).to.equal(compressedPublicKeyBase64UrlString);
+      expect(base64url.baseEncode(Secp256k1.publicJwkToBytes(publicJwk2, false))).to.equal(uncompressedPublicKeyBase64UrlString);
     });
   });
 

--- a/tests/utils/secp256k1.spec.ts
+++ b/tests/utils/secp256k1.spec.ts
@@ -42,6 +42,15 @@ describe('Secp256k1', () => {
     });
   });
 
+  describe('generateKeyPairRaw()', () => {
+    it('should generate compressed and uncompressed publicKey', async ()=>{
+      const { publicKey:uncompressed } = await Secp256k1.generateKeyPairRaw(false);
+      expect(uncompressed.length).to.equal(65);
+      const { publicKey:compressed } = await Secp256k1.generateKeyPairRaw(true);
+      expect(compressed.length).to.equal(33);
+    })
+  });
+
   describe('derivePublic/PrivateKey()', () => {
     it('should be able to derive same key using different ancestor along the chain path', async () => {
       const { privateKey } = await Secp256k1.generateKeyPairRaw();

--- a/tests/utils/secp256k1.spec.ts
+++ b/tests/utils/secp256k1.spec.ts
@@ -72,12 +72,14 @@ describe('Secp256k1', () => {
     });
 
     it('should throw if derivation path is invalid', async () => {
-      const { publicKey, privateKey } = await Secp256k1.generateKeyPairRaw();
+      for(const compressed of [true, false]){
+        const { publicKey, privateKey } = await Secp256k1.generateKeyPairRaw(compressed);
 
-      const invalidPath = ['should not have segment with empty string', ''];
+        const invalidPath = ['should not have segment with empty string', ''];
 
-      await expect(Secp256k1.derivePublicKey(publicKey, invalidPath)).to.be.rejectedWith(DwnErrorCode.HdKeyDerivationPathInvalid);
-      await expect(Secp256k1.derivePrivateKey(privateKey, invalidPath)).to.be.rejectedWith(DwnErrorCode.HdKeyDerivationPathInvalid);
+        await expect(Secp256k1.derivePublicKey(publicKey, invalidPath)).to.be.rejectedWith(DwnErrorCode.HdKeyDerivationPathInvalid);
+        await expect(Secp256k1.derivePrivateKey(privateKey, invalidPath)).to.be.rejectedWith(DwnErrorCode.HdKeyDerivationPathInvalid);
+      }
     });
   });
 });


### PR DESCRIPTION
Added compressed pubkey input test for eciesSecp256k1Encrypt().
Added compressed pubkey input test for derivePublicKey().
Added compressed pubkey ouput switch in generateKeyPairRaw() and test.
Added compressed pubkey ouput switch in publicJwkToBytes() and test.

resolves #397 
