### PR TITLE
Replace `handle<Xyz>` methods in `Dwn` class with overloaded `process…

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here's to a thrilling Hacktoberfest voyage with us! 🎉
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-98.5%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.69%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.68%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.5%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-98.47%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.61%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.68%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.47%25-brightgreen.svg?style=flat)
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here's to a thrilling Hacktoberfest voyage with us! 🎉
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-98.41%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.53%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.67%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.41%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-98.5%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.69%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.68%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.5%25-brightgreen.svg?style=flat)
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here's to a thrilling Hacktoberfest voyage with us! 🎉
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-98.46%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.29%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.73%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.46%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-98.41%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.53%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.67%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.41%25-brightgreen.svg?style=flat)
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/src/dwn.ts
+++ b/src/dwn.ts
@@ -9,7 +9,7 @@ import type { TenantGate } from './core/tenant-gate.js';
 import type { EventsGetMessage, EventsGetReply, PermissionsGrantMessage, PermissionsRequestMessage, PermissionsRevokeMessage, ProtocolsConfigureMessage, ProtocolsQueryMessage, ProtocolsQueryReply } from './index.js';
 import type { GenericMessageReply, UnionMessageReply } from './core/message-reply.js';
 import type { MessagesGetMessage, MessagesGetReply } from './types/messages-types.js';
-import type { RecordsDeleteMessage, RecordsQueryMessage, RecordsQueryReply, RecordsReadMessage, RecordsReadReply, RecordsWriteMessage, RecordsWriteReply } from './types/records-types.js';
+import type { RecordsDeleteMessage, RecordsQueryMessage, RecordsQueryReply, RecordsReadMessage, RecordsReadReply, RecordsWriteMessage } from './types/records-types.js';
 
 import { AllowAllTenantGate } from './core/tenant-gate.js';
 import { DidResolver } from './did/did-resolver.js';
@@ -117,70 +117,6 @@ export class Dwn {
     });
 
     return methodHandlerReply;
-  }
-
-  /**
-   * Handles a `RecordsWrite` message.
-   */
-  public async handleRecordsWrite(
-    tenant: string,
-    message: RecordsWriteMessage,
-    dataStream?: Readable,
-    options?: RecordsWriteHandlerOptions): Promise<RecordsWriteReply> {
-    const errorMessageReply =
-      await this.validateTenant(tenant) ??
-      await this.validateMessageIntegrity(message, DwnInterfaceName.Records, DwnMethodName.Write);
-    if (errorMessageReply !== undefined) {
-      return errorMessageReply;
-    }
-
-    const handler = new RecordsWriteHandler(this.didResolver, this.messageStore, this.dataStore, this.eventLog);
-    return handler.handle({ tenant, message, options, dataStream });
-  }
-
-  /**
-   * Handles a `RecordsQuery` message.
-   */
-  public async handleRecordsQuery(tenant: string, message: RecordsQueryMessage): Promise<RecordsQueryReply> {
-    const errorMessageReply =
-      await this.validateTenant(tenant) ??
-      await this.validateMessageIntegrity(message, DwnInterfaceName.Records, DwnMethodName.Query);
-    if (errorMessageReply !== undefined) {
-      return errorMessageReply;
-    }
-
-    const handler = new RecordsQueryHandler(this.didResolver, this.messageStore, this.dataStore);
-    return handler.handle({ tenant, message });
-  }
-
-  /**
-   * Handles a `RecordsRead` message.
-   */
-  public async handleRecordsRead(tenant: string, message: RecordsReadMessage): Promise<RecordsReadReply> {
-    const errorMessageReply =
-      await this.validateTenant(tenant) ??
-      await this.validateMessageIntegrity(message, DwnInterfaceName.Records, DwnMethodName.Read);
-    if (errorMessageReply !== undefined) {
-      return errorMessageReply;
-    }
-
-    const handler = new RecordsReadHandler(this.didResolver, this.messageStore, this.dataStore);
-    return handler.handle({ tenant, message });
-  }
-
-  /**
-   * Handles a `MessagesGet` message.
-   */
-  public async handleMessagesGet(tenant: string, message: MessagesGetMessage): Promise<MessagesGetReply> {
-    const errorMessageReply =
-      await this.validateTenant(tenant) ??
-      await this.validateMessageIntegrity(message, DwnInterfaceName.Messages, DwnMethodName.Get);
-    if (errorMessageReply !== undefined) {
-      return errorMessageReply;
-    }
-
-    const handler = new MessagesGetHandler(this.didResolver, this.messageStore, this.dataStore);
-    return handler.handle({ tenant, message });
   }
 
   /**

--- a/tests/dwn.spec.ts
+++ b/tests/dwn.spec.ts
@@ -53,7 +53,7 @@ export function testDwnClass(): void {
           author: alice,
         });
 
-        const reply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+        const reply = await dwn.processMessage(alice.did, message, dataStream);
 
         expect(reply.status.code).to.equal(202);
       });
@@ -157,7 +157,7 @@ export function testDwnClass(): void {
           authorizationSigner: Jws.createSigner(alice)
         });
         (recordsRead.message as any).descriptor.method = 'Write'; // Will cause interface and method check to fail
-        const reply = await dwn.handleRecordsRead(alice.did, recordsRead.message);
+        const reply = await dwn.processMessage(alice.did, recordsRead.message);
 
         expect(reply.status.code).to.not.equal(200);
       });
@@ -177,7 +177,7 @@ export function testDwnClass(): void {
         const messageCid = await Message.getCid(recordsWrite.message);
         messageCids.push(messageCid);
 
-        const reply = await dwn.handleRecordsWrite(alice.did, recordsWrite.toJSON(), dataStream);
+        const reply = await dwn.processMessage(alice.did, recordsWrite.toJSON(), dataStream);
         expect(reply.status.code).to.equal(202);
 
         const { messagesGet } = await TestDataGenerator.generateMessagesGet({
@@ -185,7 +185,7 @@ export function testDwnClass(): void {
           messageCids
         });
 
-        const messagesGetReply = await dwn.handleMessagesGet(alice.did, messagesGet.message);
+        const messagesGetReply = await dwn.processMessage(alice.did, messagesGet.message);
         expect(messagesGetReply.status.code).to.equal(200);
         expect(messagesGetReply.messages!.length).to.equal(messageCids.length);
 
@@ -212,7 +212,7 @@ export function testDwnClass(): void {
           messageCids
         });
         (messagesGet.message as any).descriptor.interface = 'Protocols'; // Will cause interface and method check to fail
-        const reply = await dwn.handleMessagesGet(alice.did, messagesGet.message);
+        const reply = await dwn.processMessage(alice.did, messagesGet.message);
 
         expect(reply.status.code).to.not.equal(200);
       });
@@ -248,7 +248,7 @@ export function testDwnClass(): void {
           data          : newDataBytes
         });
 
-        const newRecordsWriteReply = await dwn.handleRecordsWrite(alice.did, newRecordsWrite.message, newRecordsWrite.dataStream);
+        const newRecordsWriteReply = await dwn.processMessage(alice.did, newRecordsWrite.message, newRecordsWrite.dataStream);
         expect(newRecordsWriteReply.status.code).to.equal(202);
 
         // verify new `RecordsWrite` has overwritten the existing record with new data
@@ -340,12 +340,11 @@ export function testDwnClass(): void {
           data
         });
 
-        (aliceWriteData.message as any).descriptor.method = 'Foo';
+        (aliceWriteData.message as any).descriptor.method = 'IncorrectMethod';
 
-        const reply = await dwn.handleRecordsWrite(alice.did, aliceWriteData.message);
+        const reply = await dwn.processMessage(alice.did, aliceWriteData.message);
 
         expect(reply.status.code).to.equal(400);
-        expect(reply.status.detail).to.equal('Expected method RecordsWrite, received RecordsFoo');
       });
 
       it('should successfully write a record', async () => {
@@ -358,7 +357,7 @@ export function testDwnClass(): void {
           data
         });
 
-        const reply = await dwn.handleRecordsWrite(alice.did, aliceWriteData.message, aliceWriteData.dataStream);
+        const reply = await dwn.processMessage(alice.did, aliceWriteData.message, aliceWriteData.dataStream);
 
         expect(reply.status.code).to.equal(202);
       });

--- a/tests/dwn.spec.ts
+++ b/tests/dwn.spec.ts
@@ -12,7 +12,6 @@ import { stubInterface } from 'ts-sinon';
 import { TestDataGenerator } from './utils/test-data-generator.js';
 import { TestStores } from './test-stores.js';
 import { DwnInterfaceName, DwnMethodName, Message } from '../src/core/message.js';
-import { Jws, RecordsRead } from '../src/index.js';
 
 chai.use(chaiAsPromised);
 
@@ -146,78 +145,6 @@ export function testDwnClass(): void {
       });
     });
 
-    describe('handleRecordsRead', () => {
-      it('should return error if preprocessing checks fail', async () => {
-        const alice = await DidKeyResolver.generate();
-
-        const recordsRead = await RecordsRead.create({
-          filter: {
-            recordId: 'recordId-doesnt-matter',
-          },
-          authorizationSigner: Jws.createSigner(alice)
-        });
-        (recordsRead.message as any).descriptor.method = 'Write'; // Will cause interface and method check to fail
-        const reply = await dwn.processMessage(alice.did, recordsRead.message);
-
-        expect(reply.status.code).to.not.equal(200);
-      });
-    });
-
-    describe('handleMessagesGet', () => {
-    // increases test coverage :)
-      it('runs successfully', async () => {
-        const did = await DidKeyResolver.generate();
-        const alice = await TestDataGenerator.generatePersona(did);
-        const messageCids: string[] = [];
-
-        const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({
-          author: alice
-        });
-
-        const messageCid = await Message.getCid(recordsWrite.message);
-        messageCids.push(messageCid);
-
-        const reply = await dwn.processMessage(alice.did, recordsWrite.toJSON(), dataStream);
-        expect(reply.status.code).to.equal(202);
-
-        const { messagesGet } = await TestDataGenerator.generateMessagesGet({
-          author: alice,
-          messageCids
-        });
-
-        const messagesGetReply = await dwn.processMessage(alice.did, messagesGet.message);
-        expect(messagesGetReply.status.code).to.equal(200);
-        expect(messagesGetReply.messages!.length).to.equal(messageCids.length);
-
-        for (const messageReply of messagesGetReply.messages!) {
-          expect(messageReply.messageCid).to.not.be.undefined;
-          expect(messageReply.message).to.not.be.undefined;
-          expect(messageCids).to.include(messageReply.messageCid);
-
-          const cid = await Message.getCid(messageReply.message!);
-          expect(messageReply.messageCid).to.equal(cid);
-        }
-      });
-
-      it('should return error if preprocessing checks fail', async () => {
-        const alice = await DidKeyResolver.generate();
-
-        const { recordsWrite } = await TestDataGenerator.generateRecordsWrite({
-          author: alice
-        });
-
-        const messageCids = [await Message.getCid(recordsWrite.message)];
-        const { messagesGet } = await TestDataGenerator.generateMessagesGet({
-          author: alice,
-          messageCids
-        });
-        (messagesGet.message as any).descriptor.interface = 'Protocols'; // Will cause interface and method check to fail
-        const reply = await dwn.processMessage(alice.did, messagesGet.message);
-
-        expect(reply.status.code).to.not.equal(200);
-      });
-    });
-
     describe('synchronizePrunedInitialRecordsWrite()', () => {
       it('should allow an initial `RecordsWrite` to be written without supplying data', async () => {
         const alice = await DidKeyResolver.generate();
@@ -328,41 +255,5 @@ export function testDwnClass(): void {
         expect(reply3.status.detail).to.contain(`Expected method ${DwnInterfaceName.Records}${DwnMethodName.Write}`);
       });
     });
-
-    describe('handleRecordsWrite', () => {
-      it('should return 400 error for bad message (invalid method)', async () => {
-        const alice = await DidKeyResolver.generate();
-        const data = Encoder.stringToBytes('test');
-
-        // alice writes a record
-        const aliceWriteData = await TestDataGenerator.generateRecordsWrite({
-          author: alice,
-          data
-        });
-
-        (aliceWriteData.message as any).descriptor.method = 'IncorrectMethod';
-
-        const reply = await dwn.processMessage(alice.did, aliceWriteData.message);
-
-        expect(reply.status.code).to.equal(400);
-      });
-
-      it('should successfully write a record', async () => {
-        const alice = await DidKeyResolver.generate();
-        const data = Encoder.stringToBytes('test');
-
-        // alice writes a record
-        const aliceWriteData = await TestDataGenerator.generateRecordsWrite({
-          author: alice,
-          data
-        });
-
-        const reply = await dwn.processMessage(alice.did, aliceWriteData.message, aliceWriteData.dataStream);
-
-        expect(reply.status.code).to.equal(202);
-      });
-
-    });
-
   });
 }

--- a/tests/handlers/records-delete.spec.ts
+++ b/tests/handlers/records-delete.spec.ts
@@ -62,7 +62,7 @@ export function testRecordsDeleteHandler(): void {
 
         // insert data
         const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice });
-        const writeReply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+        const writeReply = await dwn.processMessage(alice.did, message, dataStream);
         expect(writeReply.status.code).to.equal(202);
 
         // ensure data is inserted
@@ -106,22 +106,22 @@ export function testRecordsDeleteHandler(): void {
 
         // alice writes a records with data
         const aliceWriteData = await TestDataGenerator.generateRecordsWrite({ author: alice, data });
-        const aliceWriteReply = await dwn.handleRecordsWrite(alice.did, aliceWriteData.message, aliceWriteData.dataStream);
+        const aliceWriteReply = await dwn.processMessage(alice.did, aliceWriteData.message, aliceWriteData.dataStream);
         expect(aliceWriteReply.status.code).to.equal(202);
 
         // alice writes another record with the same data
         const aliceAssociateData = await TestDataGenerator.generateRecordsWrite({ author: alice, data });
-        const aliceAssociateReply = await dwn.handleRecordsWrite(alice.did, aliceAssociateData.message, aliceAssociateData.dataStream);
+        const aliceAssociateReply = await dwn.processMessage(alice.did, aliceAssociateData.message, aliceAssociateData.dataStream);
         expect(aliceAssociateReply.status.code).to.equal(202);
 
         // bob writes a records with same data
         const bobWriteData = await TestDataGenerator.generateRecordsWrite({ author: bob, data });
-        const bobWriteReply = await dwn.handleRecordsWrite(bob.did, bobWriteData.message, bobWriteData.dataStream);
+        const bobWriteReply = await dwn.processMessage(bob.did, bobWriteData.message, bobWriteData.dataStream);
         expect(bobWriteReply.status.code).to.equal(202);
 
         // bob writes another record with the same data
         const bobAssociateData = await TestDataGenerator.generateRecordsWrite({ author: bob, data });
-        const bobAssociateReply = await dwn.handleRecordsWrite(bob.did, bobAssociateData.message, bobAssociateData.dataStream);
+        const bobAssociateReply = await dwn.processMessage(bob.did, bobAssociateData.message, bobAssociateData.dataStream);
         expect(bobAssociateReply.status.code).to.equal(202);
 
         // alice deletes one of the two records
@@ -140,7 +140,7 @@ export function testRecordsDeleteHandler(): void {
           authorizationSigner: Jws.createSigner(alice)
         });
 
-        const aliceRead1Reply = await dwn.handleRecordsRead(alice.did, aliceRead1.message);
+        const aliceRead1Reply = await dwn.processMessage(alice.did, aliceRead1.message);
         expect(aliceRead1Reply.status.code).to.equal(200);
 
         const aliceDataFetched = await DataStream.toBytes(aliceRead1Reply.record!.data!);
@@ -155,7 +155,7 @@ export function testRecordsDeleteHandler(): void {
         expect(aliceDeleteAssociateReply.status.code).to.equal(202);
 
         // verify that alice can no longer fetch the 2nd record
-        const aliceRead2Reply = await dwn.handleRecordsRead(alice.did, aliceRead1.message);
+        const aliceRead2Reply = await dwn.processMessage(alice.did, aliceRead1.message);
         expect(aliceRead2Reply.status.code).to.equal(404);
 
         // verify that bob can still fetch record with the same data
@@ -166,7 +166,7 @@ export function testRecordsDeleteHandler(): void {
           authorizationSigner: Jws.createSigner(bob)
         });
 
-        const bobRead1Reply = await dwn.handleRecordsRead(bob.did, bobRead1.message);
+        const bobRead1Reply = await dwn.processMessage(bob.did, bobRead1.message);
         expect(bobRead1Reply.status.code).to.equal(200);
 
         const bobDataFetched = await DataStream.toBytes(bobRead1Reply.record!.data!);
@@ -191,7 +191,7 @@ export function testRecordsDeleteHandler(): void {
 
         // initial write
         const initialWriteData = await TestDataGenerator.generateRecordsWrite({ author: alice });
-        const initialWriteReply = await dwn.handleRecordsWrite(alice.did, initialWriteData.message, initialWriteData.dataStream);
+        const initialWriteReply = await dwn.processMessage(alice.did, initialWriteData.message, initialWriteData.dataStream);
         expect(initialWriteReply.status.code).to.equal(202);
 
         // generate subsequent write and delete with the delete having an earlier timestamp
@@ -207,7 +207,7 @@ export function testRecordsDeleteHandler(): void {
         });
 
         // subsequent write
-        const subsequentWriteReply = await dwn.handleRecordsWrite(alice.did, subsequentWriteData.message, subsequentWriteData.dataStream);
+        const subsequentWriteReply = await dwn.processMessage(alice.did, subsequentWriteData.message, subsequentWriteData.dataStream);
         expect(subsequentWriteReply.status.code).to.equal(202);
 
         // test that a delete with an earlier `messageTimestamp` results in a 409
@@ -236,7 +236,7 @@ export function testRecordsDeleteHandler(): void {
           author: alice,
           data
         });
-        const aliceWriteReply = await dwn.handleRecordsWrite(alice.did, aliceWriteData.message, aliceWriteData.dataStream);
+        const aliceWriteReply = await dwn.processMessage(alice.did, aliceWriteData.message, aliceWriteData.dataStream);
         expect(aliceWriteReply.status.code).to.equal(202);
 
         const aliceQueryWriteAfterAliceWriteData = await TestDataGenerator.generateRecordsQuery({
@@ -269,7 +269,7 @@ export function testRecordsDeleteHandler(): void {
           author: alice,
           data
         });
-        const aliceRewriteReply = await dwn.handleRecordsWrite(alice.did, aliceRewriteData.message, aliceRewriteData.dataStream);
+        const aliceRewriteReply = await dwn.processMessage(alice.did, aliceRewriteData.message, aliceRewriteData.dataStream);
         expect(aliceRewriteReply.status.code).to.equal(202);
 
         const aliceQueryWriteAfterAliceRewriteData = await TestDataGenerator.generateRecordsQuery({
@@ -287,7 +287,7 @@ export function testRecordsDeleteHandler(): void {
           const alice = await DidKeyResolver.generate();
 
           const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice });
-          const writeReply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+          const writeReply = await dwn.processMessage(alice.did, message, dataStream);
           expect(writeReply.status.code).to.equal(202);
 
           const recordsDelete = await RecordsDelete.create({
@@ -316,7 +316,7 @@ export function testRecordsDeleteHandler(): void {
           const { message, author, dataStream, recordsWrite } = await TestDataGenerator.generateRecordsWrite();
           TestStubGenerator.stubDidResolver(didResolver, [author]);
 
-          const reply = await dwn.handleRecordsWrite(author.did, message, dataStream);
+          const reply = await dwn.processMessage(author.did, message, dataStream);
           expect(reply.status.code).to.equal(202);
 
           const newWrite = await RecordsWrite.createFrom({
@@ -325,7 +325,7 @@ export function testRecordsDeleteHandler(): void {
             authorizationSigner : Jws.createSigner(author)
           });
 
-          const newWriteReply = await dwn.handleRecordsWrite(author.did, newWrite.message);
+          const newWriteReply = await dwn.processMessage(author.did, newWrite.message);
           expect(newWriteReply.status.code).to.equal(202);
 
           const recordsDelete = await RecordsDelete.create({

--- a/tests/handlers/records-query.spec.ts
+++ b/tests/handlers/records-query.spec.ts
@@ -73,7 +73,7 @@ export function testRecordsQueryHandler(): void {
         const dataFormat = 'myAwesomeDataFormat';
 
         const write = await TestDataGenerator.generateRecordsWrite({ author: alice, attesters: [bob], dataFormat });
-        const writeReply = await dwn.handleRecordsWrite(alice.did, write.message, write.dataStream);
+        const writeReply = await dwn.processMessage(alice.did, write.message, write.dataStream);
         expect(writeReply.status.code).to.equal(202);
 
         const query = await TestDataGenerator.generateRecordsQuery({ author: alice, filter: { dataFormat } });
@@ -100,9 +100,9 @@ export function testRecordsQueryHandler(): void {
         sinon.stub(didResolver, 'resolve').resolves(mockResolution);
 
         // insert data
-        const writeReply1 = await dwn.handleRecordsWrite(alice.did, write1.message, write1.dataStream);
-        const writeReply2 = await dwn.handleRecordsWrite(alice.did, write2.message, write2.dataStream);
-        const writeReply3 = await dwn.handleRecordsWrite(alice.did, write3.message, write3.dataStream);
+        const writeReply1 = await dwn.processMessage(alice.did, write1.message, write1.dataStream);
+        const writeReply2 = await dwn.processMessage(alice.did, write2.message, write2.dataStream);
+        const writeReply3 = await dwn.processMessage(alice.did, write3.message, write3.dataStream);
         expect(writeReply1.status.code).to.equal(202);
         expect(writeReply2.status.code).to.equal(202);
         expect(writeReply3.status.code).to.equal(202);
@@ -135,7 +135,7 @@ export function testRecordsQueryHandler(): void {
         const alice = await DidKeyResolver.generate();
         const write= await TestDataGenerator.generateRecordsWrite({ author: alice, data });
 
-        const writeReply = await dwn.handleRecordsWrite(alice.did, write.message, write.dataStream);
+        const writeReply = await dwn.processMessage(alice.did, write.message, write.dataStream);
         expect(writeReply.status.code).to.equal(202);
 
         const messageData = await TestDataGenerator.generateRecordsQuery({ author: alice, filter: { recordId: write.message.recordId } });
@@ -151,7 +151,7 @@ export function testRecordsQueryHandler(): void {
         const alice = await DidKeyResolver.generate();
         const write= await TestDataGenerator.generateRecordsWrite({ author: alice, data });
 
-        const writeReply = await dwn.handleRecordsWrite(alice.did, write.message, write.dataStream);
+        const writeReply = await dwn.processMessage(alice.did, write.message, write.dataStream);
         expect(writeReply.status.code).to.equal(202);
 
         const messageData = await TestDataGenerator.generateRecordsQuery({ author: alice, filter: { recordId: write.message.recordId } });
@@ -170,8 +170,8 @@ export function testRecordsQueryHandler(): void {
         const recordsWrite2 = await TestDataGenerator.generateRecordsWrite({ author: alice, attesters: [bob] });
 
         // insert data
-        const writeReply1 = await dwn.handleRecordsWrite(alice.did, recordsWrite1.message, recordsWrite1.dataStream);
-        const writeReply2 = await dwn.handleRecordsWrite(alice.did, recordsWrite2.message, recordsWrite2.dataStream);
+        const writeReply1 = await dwn.processMessage(alice.did, recordsWrite1.message, recordsWrite1.dataStream);
+        const writeReply2 = await dwn.processMessage(alice.did, recordsWrite2.message, recordsWrite2.dataStream);
         expect(writeReply1.status.code).to.equal(202);
         expect(writeReply2.status.code).to.equal(202);
 
@@ -210,9 +210,9 @@ export function testRecordsQueryHandler(): void {
         const write3 = await TestDataGenerator.generateRecordsWrite({ author: alice, dateCreated: firstDayOf2023, messageTimestamp: firstDayOf2023 });
 
         // insert data
-        const writeReply1 = await dwn.handleRecordsWrite(alice.did, write1.message, write1.dataStream);
-        const writeReply2 = await dwn.handleRecordsWrite(alice.did, write2.message, write2.dataStream);
-        const writeReply3 = await dwn.handleRecordsWrite(alice.did, write3.message, write3.dataStream);
+        const writeReply1 = await dwn.processMessage(alice.did, write1.message, write1.dataStream);
+        const writeReply2 = await dwn.processMessage(alice.did, write2.message, write2.dataStream);
+        const writeReply3 = await dwn.processMessage(alice.did, write3.message, write3.dataStream);
         expect(writeReply1.status.code).to.equal(202);
         expect(writeReply2.status.code).to.equal(202);
         expect(writeReply3.status.code).to.equal(202);
@@ -281,9 +281,9 @@ export function testRecordsQueryHandler(): void {
         });
 
         // insert data
-        const writeReply1 = await dwn.handleRecordsWrite(alice.did, write1.message, write1.dataStream);
-        const writeReply2 = await dwn.handleRecordsWrite(alice.did, write2.message, write2.dataStream);
-        const writeReply3 = await dwn.handleRecordsWrite(alice.did, write3.message, write3.dataStream);
+        const writeReply1 = await dwn.processMessage(alice.did, write1.message, write1.dataStream);
+        const writeReply2 = await dwn.processMessage(alice.did, write2.message, write2.dataStream);
+        const writeReply3 = await dwn.processMessage(alice.did, write3.message, write3.dataStream);
         expect(writeReply1.status.code).to.equal(202);
         expect(writeReply2.status.code).to.equal(202);
         expect(writeReply3.status.code).to.equal(202);
@@ -312,7 +312,7 @@ export function testRecordsQueryHandler(): void {
         const mockResolution = TestDataGenerator.createDidResolutionResult(alice);
         sinon.stub(didResolver, 'resolve').resolves(mockResolution);
 
-        const writeReply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+        const writeReply = await dwn.processMessage(alice.did, message, dataStream);
         expect(writeReply.status.code).to.equal(202);
 
         const queryData = await TestDataGenerator.generateRecordsQuery({
@@ -332,7 +332,7 @@ export function testRecordsQueryHandler(): void {
         const alice = await DidKeyResolver.generate();
         const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice, attesters: [alice] });
 
-        const writeReply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+        const writeReply = await dwn.processMessage(alice.did, message, dataStream);
         expect(writeReply.status.code).to.equal(202);
 
         const queryData = await TestDataGenerator.generateRecordsQuery({
@@ -364,8 +364,8 @@ export function testRecordsQueryHandler(): void {
         sinon.stub(didResolver, 'resolve').resolves(mockResolution);
 
         // insert data
-        const publishedWriteReply = await dwn.handleRecordsWrite(alice.did, publishedWriteData.message, publishedWriteData.dataStream);
-        const unpublishedWriteReply = await dwn.handleRecordsWrite(alice.did, unpublishedWriteData.message, unpublishedWriteData.dataStream);
+        const publishedWriteReply = await dwn.processMessage(alice.did, publishedWriteData.message, publishedWriteData.dataStream);
+        const unpublishedWriteReply = await dwn.processMessage(alice.did, unpublishedWriteData.message, unpublishedWriteData.dataStream);
         expect(publishedWriteReply.status.code).to.equal(202);
         expect(unpublishedWriteReply.status.code).to.equal(202);
 
@@ -375,7 +375,7 @@ export function testRecordsQueryHandler(): void {
           dateSort : DateSort.PublishedAscending,
           filter   : { schema }
         });
-        const publishedAscendingQueryReply = await dwn.handleRecordsQuery(alice.did, publishedAscendingQueryData.message);
+        const publishedAscendingQueryReply = await dwn.processMessage(alice.did, publishedAscendingQueryData.message);
 
         expect(publishedAscendingQueryReply.entries?.length).to.equal(1);
         expect(publishedAscendingQueryReply.entries![0].descriptor['datePublished']).to.equal(publishedWriteData.message.descriptor.datePublished);
@@ -386,7 +386,7 @@ export function testRecordsQueryHandler(): void {
           dateSort : DateSort.PublishedDescending,
           filter   : { schema }
         });
-        const publishedDescendingQueryReply = await dwn.handleRecordsQuery(alice.did, publishedDescendingQueryData.message);
+        const publishedDescendingQueryReply = await dwn.processMessage(alice.did, publishedDescendingQueryData.message);
 
         expect(publishedDescendingQueryReply.entries?.length).to.equal(1);
         expect(publishedDescendingQueryReply.entries![0].descriptor['datePublished']).to.equal(publishedWriteData.message.descriptor.datePublished);
@@ -406,9 +406,9 @@ export function testRecordsQueryHandler(): void {
         sinon.stub(didResolver, 'resolve').resolves(mockResolution);
 
         // insert data, intentionally out of order
-        const writeReply2 = await dwn.handleRecordsWrite(alice.did, write2Data.message, write2Data.dataStream);
-        const writeReply1 = await dwn.handleRecordsWrite(alice.did, write1Data.message, write1Data.dataStream);
-        const writeReply3 = await dwn.handleRecordsWrite(alice.did, write3Data.message, write3Data.dataStream);
+        const writeReply2 = await dwn.processMessage(alice.did, write2Data.message, write2Data.dataStream);
+        const writeReply1 = await dwn.processMessage(alice.did, write1Data.message, write1Data.dataStream);
+        const writeReply3 = await dwn.processMessage(alice.did, write3Data.message, write3Data.dataStream);
         expect(writeReply1.status.code).to.equal(202);
         expect(writeReply2.status.code).to.equal(202);
         expect(writeReply3.status.code).to.equal(202);
@@ -419,7 +419,7 @@ export function testRecordsQueryHandler(): void {
           dateSort : DateSort.CreatedAscending,
           filter   : { schema }
         });
-        const createdAscendingQueryReply = await dwn.handleRecordsQuery(alice.did, createdAscendingQueryData.message);
+        const createdAscendingQueryReply = await dwn.processMessage(alice.did, createdAscendingQueryData.message);
 
         expect(createdAscendingQueryReply.entries?.[0].descriptor['dateCreated']).to.equal(write1Data.message.descriptor.dateCreated);
         expect(createdAscendingQueryReply.entries?.[1].descriptor['dateCreated']).to.equal(write2Data.message.descriptor.dateCreated);
@@ -431,7 +431,7 @@ export function testRecordsQueryHandler(): void {
           dateSort : DateSort.CreatedDescending,
           filter   : { schema }
         });
-        const createdDescendingQueryReply = await dwn.handleRecordsQuery(alice.did, createdDescendingQueryData.message);
+        const createdDescendingQueryReply = await dwn.processMessage(alice.did, createdDescendingQueryData.message);
 
         expect(createdDescendingQueryReply.entries?.[0].descriptor['dateCreated']).to.equal(write3Data.message.descriptor.dateCreated);
         expect(createdDescendingQueryReply.entries?.[1].descriptor['dateCreated']).to.equal(write2Data.message.descriptor.dateCreated);
@@ -443,7 +443,7 @@ export function testRecordsQueryHandler(): void {
           dateSort : DateSort.PublishedAscending,
           filter   : { schema }
         });
-        const publishedAscendingQueryReply = await dwn.handleRecordsQuery(alice.did, publishedAscendingQueryData.message);
+        const publishedAscendingQueryReply = await dwn.processMessage(alice.did, publishedAscendingQueryData.message);
 
         expect(publishedAscendingQueryReply.entries?.[0].descriptor['datePublished']).to.equal(write1Data.message.descriptor.datePublished);
         expect(publishedAscendingQueryReply.entries?.[1].descriptor['datePublished']).to.equal(write2Data.message.descriptor.datePublished);
@@ -455,7 +455,7 @@ export function testRecordsQueryHandler(): void {
           dateSort : DateSort.PublishedDescending,
           filter   : { schema }
         });
-        const publishedDescendingQueryReply = await dwn.handleRecordsQuery(alice.did, publishedDescendingQueryData.message);
+        const publishedDescendingQueryReply = await dwn.processMessage(alice.did, publishedDescendingQueryData.message);
 
         expect(publishedDescendingQueryReply.entries?.[0].descriptor['datePublished']).to.equal(write3Data.message.descriptor.datePublished);
         expect(publishedDescendingQueryReply.entries?.[1].descriptor['datePublished']).to.equal(write2Data.message.descriptor.datePublished);
@@ -480,11 +480,11 @@ export function testRecordsQueryHandler(): void {
         );
 
         // intentionally write the RecordsWrite of out lexicographical order to avoid the test query below accidentally having the correct order
-        const reply2 = await dwn.handleRecordsWrite(alice.did, middleWrite.message, middleWrite.dataStream);
+        const reply2 = await dwn.processMessage(alice.did, middleWrite.message, middleWrite.dataStream);
         expect(reply2.status.code).to.equal(202);
-        const reply3 = await dwn.handleRecordsWrite(alice.did, newestWrite.message, newestWrite.dataStream);
+        const reply3 = await dwn.processMessage(alice.did, newestWrite.message, newestWrite.dataStream);
         expect(reply3.status.code).to.equal(202);
-        const reply1 = await dwn.handleRecordsWrite(alice.did, oldestWrite.message, oldestWrite.dataStream);
+        const reply1 = await dwn.processMessage(alice.did, oldestWrite.message, oldestWrite.dataStream);
         expect(reply1.status.code).to.equal(202);
 
         const queryMessageData = await TestDataGenerator.generateRecordsQuery({
@@ -510,7 +510,7 @@ export function testRecordsQueryHandler(): void {
           schema : 'https://schema'
         })));
         for (const message of messages) {
-          const result = await dwn.handleRecordsWrite(alice.did, message.message, message.dataStream);
+          const result = await dwn.processMessage(alice.did, message.message, message.dataStream);
           expect(result.status.code).to.equal(202);
         }
 
@@ -529,7 +529,7 @@ export function testRecordsQueryHandler(): void {
             },
           });
 
-          const pageReply = await dwn.handleRecordsQuery(alice.did, pageQuery.message);
+          const pageReply = await dwn.processMessage(alice.did, pageQuery.message);
           expect(pageReply.status.code).to.equal(200);
           messageCid = pageReply.paginationMessageCid;
           expect(pageReply.entries?.length).to.be.lte(limit);
@@ -550,7 +550,7 @@ export function testRecordsQueryHandler(): void {
           schema : 'https://schema'
         })));
         for (const message of messages) {
-          const result = await dwn.handleRecordsWrite(alice.did, message.message, message.dataStream);
+          const result = await dwn.processMessage(alice.did, message.message, message.dataStream);
           expect(result.status.code).to.equal(202);
         }
 
@@ -565,7 +565,7 @@ export function testRecordsQueryHandler(): void {
           },
         });
 
-        const pageReply = await dwn.handleRecordsQuery(alice.did, pageQuery.message);
+        const pageReply = await dwn.processMessage(alice.did, pageQuery.message);
         expect(pageReply.status.code).to.equal(200);
         expect(pageReply.entries?.length).to.be.lte(limit);
         expect(pageReply.paginationMessageCid).to.exist;
@@ -586,9 +586,9 @@ export function testRecordsQueryHandler(): void {
           { author: alice, schema: 'https://schema2', published: true }
         );
 
-        const recordsWrite1Reply = await dwn.handleRecordsWrite(alice.did, record1Data.message, record1Data.dataStream);
+        const recordsWrite1Reply = await dwn.processMessage(alice.did, record1Data.message, record1Data.dataStream);
         expect(recordsWrite1Reply.status.code).to.equal(202);
-        const recordsWrite2Reply = await dwn.handleRecordsWrite(alice.did, record2Data.message, record2Data.dataStream);
+        const recordsWrite2Reply = await dwn.processMessage(alice.did, record2Data.message, record2Data.dataStream);
         expect(recordsWrite2Reply.status.code).to.equal(202);
 
         // test correctness for anonymous query
@@ -846,7 +846,7 @@ export function testRecordsQueryHandler(): void {
           { author: alice, schema, data: Encoder.stringToBytes('1'), published: false } // explicitly setting `published` to `false`
         );
 
-        const result1 = await dwn.handleRecordsWrite(alice.did, unpublishedRecordsWrite.message, unpublishedRecordsWrite.dataStream);
+        const result1 = await dwn.processMessage(alice.did, unpublishedRecordsWrite.message, unpublishedRecordsWrite.dataStream);
         expect(result1.status.code).to.equal(202);
 
         // alice should be able to see the unpublished record
@@ -896,8 +896,8 @@ export function testRecordsQueryHandler(): void {
         });
 
         // insert data into 2 different tenants
-        await dwn.handleRecordsWrite(alice.did, recordsWriteMessage1Data.message, recordsWriteMessage1Data.dataStream);
-        await dwn.handleRecordsWrite(bob.did, recordsWriteMessage2Data.message, recordsWriteMessage2Data.dataStream);
+        await dwn.processMessage(alice.did, recordsWriteMessage1Data.message, recordsWriteMessage1Data.dataStream);
+        await dwn.processMessage(bob.did, recordsWriteMessage2Data.message, recordsWriteMessage2Data.dataStream);
 
         const reply = await dwn.processMessage(alice.did, aliceQueryMessageData.message);
 

--- a/tests/handlers/records-read.spec.ts
+++ b/tests/handlers/records-read.spec.ts
@@ -76,7 +76,7 @@ export function testRecordsReadHandler(): void {
 
         // insert data
         const { message, dataStream, dataBytes } = await TestDataGenerator.generateRecordsWrite({ author: alice });
-        const writeReply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+        const writeReply = await dwn.processMessage(alice.did, message, dataStream);
         expect(writeReply.status.code).to.equal(202);
 
         // testing RecordsRead
@@ -87,7 +87,7 @@ export function testRecordsReadHandler(): void {
           authorizationSigner: Jws.createSigner(alice)
         });
 
-        const readReply = await dwn.handleRecordsRead(alice.did, recordsRead.message);
+        const readReply = await dwn.processMessage(alice.did, recordsRead.message);
         expect(readReply.status.code).to.equal(200);
         expect(readReply.record).to.exist;
         expect(readReply.record?.authorization).to.deep.equal(message.authorization);
@@ -102,7 +102,7 @@ export function testRecordsReadHandler(): void {
 
         // insert data
         const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice });
-        const writeReply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+        const writeReply = await dwn.processMessage(alice.did, message, dataStream);
         expect(writeReply.status.code).to.equal(202);
 
         // testing RecordsRead
@@ -124,7 +124,7 @@ export function testRecordsReadHandler(): void {
 
         // insert public data
         const { message, dataStream, dataBytes } = await TestDataGenerator.generateRecordsWrite({ author: alice, published: true });
-        const writeReply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+        const writeReply = await dwn.processMessage(alice.did, message, dataStream);
         expect(writeReply.status.code).to.equal(202);
 
         // testing public RecordsRead
@@ -135,7 +135,7 @@ export function testRecordsReadHandler(): void {
         });
         expect(recordsRead.author).to.be.undefined; // making sure no author/authorization is created
 
-        const readReply = await dwn.handleRecordsRead(alice.did, recordsRead.message);
+        const readReply = await dwn.processMessage(alice.did, recordsRead.message);
         expect(readReply.status.code).to.equal(200);
 
         const dataFetched = await DataStream.toBytes(readReply.record!.data!);
@@ -147,7 +147,7 @@ export function testRecordsReadHandler(): void {
 
         // insert public data
         const { message, dataStream, dataBytes } = await TestDataGenerator.generateRecordsWrite({ author: alice, published: true });
-        const writeReply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+        const writeReply = await dwn.processMessage(alice.did, message, dataStream);
         expect(writeReply.status.code).to.equal(202);
 
         // testing public RecordsRead
@@ -160,7 +160,7 @@ export function testRecordsReadHandler(): void {
           authorizationSigner: Jws.createSigner(bob)
         });
 
-        const readReply = await dwn.handleRecordsRead(alice.did, recordsRead.message);
+        const readReply = await dwn.processMessage(alice.did, recordsRead.message);
         expect(readReply.status.code).to.equal(200);
 
         const dataFetched = await DataStream.toBytes(readReply.record!.data!);
@@ -176,7 +176,7 @@ export function testRecordsReadHandler(): void {
           author    : alice,
           recipient : bob.did,
         });
-        const writeReply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+        const writeReply = await dwn.processMessage(alice.did, message, dataStream);
         expect(writeReply.status.code).to.equal(202);
 
         // Bob reads the data that Alice sent him
@@ -187,7 +187,7 @@ export function testRecordsReadHandler(): void {
           authorizationSigner: Jws.createSigner(bob)
         });
 
-        const readReply = await dwn.handleRecordsRead(alice.did, recordsRead.message);
+        const readReply = await dwn.processMessage(alice.did, recordsRead.message);
         expect(readReply.status.code).to.equal(200);
         expect(readReply.record).to.exist;
         expect(readReply.record?.descriptor).to.exist;
@@ -224,7 +224,7 @@ export function testRecordsReadHandler(): void {
             data         : encodedImage,
             recipient    : alice.did
           });
-          const imageReply = await dwn.handleRecordsWrite(alice.did, imageRecordsWrite.message, imageRecordsWrite.dataStream);
+          const imageReply = await dwn.processMessage(alice.did, imageRecordsWrite.message, imageRecordsWrite.dataStream);
           expect(imageReply.status.code).to.equal(202);
 
           // Bob (anyone) reads the image that Alice wrote
@@ -308,7 +308,7 @@ export function testRecordsReadHandler(): void {
               data         : encodedEmail,
               recipient    : bob.did
             });
-            const imageReply = await dwn.handleRecordsWrite(alice.did, emailRecordsWrite.message, emailRecordsWrite.dataStream);
+            const imageReply = await dwn.processMessage(alice.did, emailRecordsWrite.message, emailRecordsWrite.dataStream);
             expect(imageReply.status.code).to.equal(202);
 
             // Bob reads Alice's email
@@ -363,7 +363,7 @@ export function testRecordsReadHandler(): void {
               data         : encodedEmail,
               recipient    : alice.did
             });
-            const imageReply = await dwn.handleRecordsWrite(alice.did, emailRecordsWrite.message, emailRecordsWrite.dataStream);
+            const imageReply = await dwn.processMessage(alice.did, emailRecordsWrite.message, emailRecordsWrite.dataStream);
             expect(imageReply.status.code).to.equal(202);
 
             // Bob reads the email he just sent
@@ -410,7 +410,7 @@ export function testRecordsReadHandler(): void {
               data         : new TextEncoder().encode('foo'),
               recipient    : alice.did
             });
-            const foo1WriteReply = await dwn.handleRecordsWrite(alice.did, foo1Write.message, foo1Write.dataStream);
+            const foo1WriteReply = await dwn.processMessage(alice.did, foo1Write.message, foo1Write.dataStream);
             expect(foo1WriteReply.status.code).to.equal(202);
 
             const fooPathRead = await RecordsRead.create({
@@ -421,7 +421,7 @@ export function testRecordsReadHandler(): void {
               authorizationSigner: Jws.createSigner(alice),
             });
 
-            const fooPathReply = await dwn.handleRecordsRead(alice.did, fooPathRead.message);
+            const fooPathReply = await dwn.processMessage(alice.did, fooPathRead.message);
             expect(fooPathReply.status.code).to.equal(200);
             expect(fooPathReply.record!.recordId).to.equal(foo1Write.message.recordId);
           });
@@ -446,7 +446,7 @@ export function testRecordsReadHandler(): void {
               data         : new TextEncoder().encode('foo'),
               recipient    : alice.did
             });
-            const foo1WriteReply = await dwn.handleRecordsWrite(alice.did, foo1Write.message, foo1Write.dataStream);
+            const foo1WriteReply = await dwn.processMessage(alice.did, foo1Write.message, foo1Write.dataStream);
             expect(foo1WriteReply.status.code).to.equal(202);
 
             const foo2Write = await TestDataGenerator.generateRecordsWrite({
@@ -458,7 +458,7 @@ export function testRecordsReadHandler(): void {
               data         : new TextEncoder().encode('foo'),
               recipient    : alice.did
             });
-            const foo2WriteReply = await dwn.handleRecordsWrite(alice.did, foo2Write.message, foo2Write.dataStream);
+            const foo2WriteReply = await dwn.processMessage(alice.did, foo2Write.message, foo2Write.dataStream);
             expect(foo2WriteReply.status.code).to.equal(202);
 
             // Since there are two 'foo' records, this should fail.
@@ -469,7 +469,7 @@ export function testRecordsReadHandler(): void {
               },
               authorizationSigner: Jws.createSigner(alice),
             });
-            const fooPathReply = await dwn.handleRecordsRead(alice.did, fooPathRead.message);
+            const fooPathReply = await dwn.processMessage(alice.did, fooPathRead.message);
             expect(fooPathReply.status.code).to.equal(400);
             expect(fooPathReply.status.detail).to.contain(DwnErrorCode.RecordsReadReturnedMultiple);
           });
@@ -500,7 +500,7 @@ export function testRecordsReadHandler(): void {
               protocolPath : 'friend',
               data         : new TextEncoder().encode('Bob is my friend'),
             });
-            const friendRoleReply = await dwn.handleRecordsWrite(alice.did, friendRoleRecord.message, friendRoleRecord.dataStream);
+            const friendRoleReply = await dwn.processMessage(alice.did, friendRoleRecord.message, friendRoleRecord.dataStream);
             expect(friendRoleReply.status.code).to.equal(202);
 
             // Alice writes a 'chat' record
@@ -511,7 +511,7 @@ export function testRecordsReadHandler(): void {
               protocolPath : 'chat',
               data         : new TextEncoder().encode('Bob can read this cuz he is my friend'),
             });
-            const chatReply = await dwn.handleRecordsWrite(alice.did, chatRecord.message, chatRecord.dataStream);
+            const chatReply = await dwn.processMessage(alice.did, chatRecord.message, chatRecord.dataStream);
             expect(chatReply.status.code).to.equal(202);
 
             // Bob reads Alice's chat record
@@ -551,7 +551,7 @@ export function testRecordsReadHandler(): void {
               protocolPath : 'chat',
               data         : new TextEncoder().encode('Blah blah blah'),
             });
-            const chatReply = await dwn.handleRecordsWrite(alice.did, chatRecord.message, chatRecord.dataStream);
+            const chatReply = await dwn.processMessage(alice.did, chatRecord.message, chatRecord.dataStream);
             expect(chatReply.status.code).to.equal(202);
 
             // Bob tries to invoke a 'chat' role but 'chat' is not a role
@@ -591,7 +591,7 @@ export function testRecordsReadHandler(): void {
               protocolPath : 'chat',
               data         : new TextEncoder().encode('Blah blah blah'),
             });
-            const chatReply = await dwn.handleRecordsWrite(alice.did, chatRecord.message, chatRecord.dataStream);
+            const chatReply = await dwn.processMessage(alice.did, chatRecord.message, chatRecord.dataStream);
             expect(chatReply.status.code).to.equal(202);
 
             // Bob tries to invoke a 'friend' role but he is not a 'friend'
@@ -777,7 +777,7 @@ export function testRecordsReadHandler(): void {
           const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({
             author: alice,
           });
-          const recordsWriteReply = await dwn.handleRecordsWrite(alice.did, recordsWrite.message, dataStream);
+          const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, dataStream);
           expect(recordsWriteReply.status.code).to.equal(202);
 
           // Alice gives Bob a PermissionsGrant with scope RecordsRead
@@ -818,7 +818,7 @@ export function testRecordsReadHandler(): void {
           const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({
             author: alice,
           });
-          const writeReply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+          const writeReply = await dwn.processMessage(alice.did, message, dataStream);
           expect(writeReply.status.code).to.equal(202);
 
           // Alice issues a PermissionsGrant allowing Bob to read any record in her DWN
@@ -872,7 +872,7 @@ export function testRecordsReadHandler(): void {
               protocol     : protocolDefinition.protocol,
               protocolPath : 'foo',
             });
-            const recordsWriteReply = await dwn.handleRecordsWrite(alice.did, recordsWrite.message, dataStream);
+            const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, dataStream);
             expect(recordsWriteReply.status.code).to.equal(202);
 
             // Alice gives Bob a PermissionsGrant with scope RecordsRead
@@ -936,7 +936,7 @@ export function testRecordsReadHandler(): void {
               protocol     : protocolDefinition.protocol,
               protocolPath : 'foo',
             });
-            const recordsWriteReply = await dwn.handleRecordsWrite(alice.did, recordsWrite.message, dataStream);
+            const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, dataStream);
             expect(recordsWriteReply.status.code).to.equal(202);
 
             // Alice gives Bob a PermissionsGrant with scope RecordsRead
@@ -1000,7 +1000,7 @@ export function testRecordsReadHandler(): void {
               protocol     : protocolDefinition.protocol,
               protocolPath : 'foo',
             });
-            const recordsWriteReply = await dwn.handleRecordsWrite(alice.did, recordsWrite.message, dataStream);
+            const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, dataStream);
             expect(recordsWriteReply.status.code).to.equal(202);
 
             // Alice gives Bob a PermissionsGrant with scope RecordsRead
@@ -1054,7 +1054,7 @@ export function testRecordsReadHandler(): void {
               protocol     : protocolDefinition.protocol,
               protocolPath : 'foo',
             });
-            const recordsWriteReply = await dwn.handleRecordsWrite(alice.did, recordsWrite.message, dataStream);
+            const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, dataStream);
             expect(recordsWriteReply.status.code).to.equal(202);
 
             // Alice gives Bob a PermissionsGrant with scope RecordsRead
@@ -1107,7 +1107,7 @@ export function testRecordsReadHandler(): void {
               protocol     : protocolDefinition.protocol,
               protocolPath : 'foo',
             });
-            const recordsWriteReply = await dwn.handleRecordsWrite(alice.did, recordsWrite.message, dataStream);
+            const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, dataStream);
             expect(recordsWriteReply.status.code).to.equal(202);
 
             // Alice gives Bob a PermissionsGrant with scope RecordsRead
@@ -1160,7 +1160,7 @@ export function testRecordsReadHandler(): void {
               protocol     : protocolDefinition.protocol,
               protocolPath : 'foo',
             });
-            const recordsWriteReply = await dwn.handleRecordsWrite(alice.did, recordsWrite.message, dataStream);
+            const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, dataStream);
             expect(recordsWriteReply.status.code).to.equal(202);
 
             // Alice gives Bob a PermissionsGrant with scope RecordsRead
@@ -1214,7 +1214,7 @@ export function testRecordsReadHandler(): void {
               protocol     : protocolDefinition.protocol,
               protocolPath : 'foo',
             });
-            const recordsWriteReply = await dwn.handleRecordsWrite(alice.did, recordsWrite.message, dataStream);
+            const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, dataStream);
             expect(recordsWriteReply.status.code).to.equal(202);
 
             // Alice gives Bob a PermissionsGrant with scope RecordsRead
@@ -1267,7 +1267,7 @@ export function testRecordsReadHandler(): void {
               protocol     : protocolDefinition.protocol,
               protocolPath : 'foo',
             });
-            const recordsWriteReply = await dwn.handleRecordsWrite(alice.did, recordsWrite.message, dataStream);
+            const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, dataStream);
             expect(recordsWriteReply.status.code).to.equal(202);
 
             // Alice gives Bob a PermissionsGrant with scope RecordsRead
@@ -1313,7 +1313,7 @@ export function testRecordsReadHandler(): void {
               author : alice,
               schema : 'some-schema',
             });
-            const writeReply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+            const writeReply = await dwn.processMessage(alice.did, message, dataStream);
             expect(writeReply.status.code).to.equal(202);
 
             // Alice issues a PermissionsGrant allowing Bob to read a specific recordId
@@ -1356,7 +1356,7 @@ export function testRecordsReadHandler(): void {
               author : alice,
               schema : recordSchema,
             });
-            const writeReply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+            const writeReply = await dwn.processMessage(alice.did, message, dataStream);
             expect(writeReply.status.code).to.equal(202);
 
             // Alice issues a PermissionsGrant allowing Bob to read a specific recordId
@@ -1409,7 +1409,7 @@ export function testRecordsReadHandler(): void {
 
         // insert public data
         const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice, published: true });
-        const writeReply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+        const writeReply = await dwn.processMessage(alice.did, message, dataStream);
         expect(writeReply.status.code).to.equal(202);
 
         // ensure data is inserted
@@ -1453,7 +1453,7 @@ export function testRecordsReadHandler(): void {
           author : alice,
           data   : TestDataGenerator.randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded +1)
         });
-        const writeReply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+        const writeReply = await dwn.processMessage(alice.did, message, dataStream);
         expect(writeReply.status.code).to.equal(202);
 
         // testing RecordsRead
@@ -1478,7 +1478,7 @@ export function testRecordsReadHandler(): void {
             data   : TestDataGenerator.randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded)
           });
 
-          const writeReply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+          const writeReply = await dwn.processMessage(alice.did, message, dataStream);
           expect(writeReply.status.code).to.equal(202);
 
           const recordRead = await RecordsRead.create({
@@ -1490,7 +1490,7 @@ export function testRecordsReadHandler(): void {
 
           const dataStoreGet = sinon.spy(dataStore, 'get');
 
-          const recordsReadResponse = await dwn.handleRecordsRead(alice.did, recordRead.message);
+          const recordsReadResponse = await dwn.processMessage(alice.did, recordRead.message);
           expect(recordsReadResponse.status.code).to.equal(200);
           expect(recordsReadResponse.record).to.exist;
           expect(recordsReadResponse.record!.data).to.exist;
@@ -1509,7 +1509,7 @@ export function testRecordsReadHandler(): void {
             data   : TestDataGenerator.randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded +1)
           });
 
-          const writeReply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+          const writeReply = await dwn.processMessage(alice.did, message, dataStream);
           expect(writeReply.status.code).to.equal(202);
 
           const recordRead = await RecordsRead.create({
@@ -1521,7 +1521,7 @@ export function testRecordsReadHandler(): void {
 
           const dataStoreGet = sinon.spy(dataStore, 'get');
 
-          const recordsReadResponse = await dwn.handleRecordsRead(alice.did, recordRead.message);
+          const recordsReadResponse = await dwn.processMessage(alice.did, recordRead.message);
           expect(recordsReadResponse.status.code).to.equal(200);
           expect(recordsReadResponse.record).to.exist;
           expect(recordsReadResponse.record!.data).to.exist;
@@ -1593,7 +1593,7 @@ export function testRecordsReadHandler(): void {
             encryptionInput
           });
 
-          const writeReply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+          const writeReply = await dwn.processMessage(alice.did, message, dataStream);
           expect(writeReply.status.code).to.equal(202);
 
           const recordsRead = await RecordsRead.create({
@@ -1604,7 +1604,7 @@ export function testRecordsReadHandler(): void {
           });
 
           // test able to derive correct key using `schemas` scheme from root key to decrypt the message
-          const readReply = await dwn.handleRecordsRead(alice.did, recordsRead.message);
+          const readReply = await dwn.processMessage(alice.did, recordsRead.message);
           expect(readReply.status.code).to.equal(200);
           const recordsWriteMessage = readReply.record!;
           const cipherStream = readReply.record!.data;
@@ -1615,7 +1615,7 @@ export function testRecordsReadHandler(): void {
 
 
           // test able to derive correct key using `dataFormat` scheme from root key to decrypt the message
-          const readReply2 = await dwn.handleRecordsRead(alice.did, recordsRead.message); // send the same read message to get a new cipher stream
+          const readReply2 = await dwn.processMessage(alice.did, recordsRead.message); // send the same read message to get a new cipher stream
           expect(readReply2.status.code).to.equal(200);
           const cipherStream2 = readReply2.record!.data;
 
@@ -1625,7 +1625,7 @@ export function testRecordsReadHandler(): void {
 
 
           // test unable to decrypt the message if dataFormat-derived key is derived without taking `schema` as input to derivation path
-          const readReply3 = await dwn.handleRecordsRead(alice.did, recordsRead.message); // process the same read message to get a new cipher stream
+          const readReply3 = await dwn.processMessage(alice.did, recordsRead.message); // process the same read message to get a new cipher stream
           expect(readReply3.status.code).to.equal(200);
           const cipherStream3 = readReply3.record!.data;
 
@@ -1681,7 +1681,7 @@ export function testRecordsReadHandler(): void {
           });
 
           const dataStream = DataStream.fromBytes(encryptedDataBytes);
-          const writeReply = await dwn.handleRecordsWrite(alice.did, recordsWrite.message, dataStream);
+          const writeReply = await dwn.processMessage(alice.did, recordsWrite.message, dataStream);
           expect(writeReply.status.code).to.equal(202);
 
           const recordsRead = await RecordsRead.create({
@@ -1693,7 +1693,7 @@ export function testRecordsReadHandler(): void {
 
 
           // test able to derive correct key using `dataFormat` scheme from root key to decrypt the message
-          const readReply = await dwn.handleRecordsRead(alice.did, recordsRead.message); // send the same read message to get a new cipher stream
+          const readReply = await dwn.processMessage(alice.did, recordsRead.message); // send the same read message to get a new cipher stream
           expect(readReply.status.code).to.equal(200);
           const cipherStream = readReply.record!.data;
           const recordsWriteMessage = readReply.record!;
@@ -1764,7 +1764,7 @@ export function testRecordsReadHandler(): void {
           });
 
           // Bob writes the encrypted chat thread to Alice's DWN
-          const bobToAliceWriteReply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+          const bobToAliceWriteReply = await dwn.processMessage(alice.did, message, dataStream);
           expect(bobToAliceWriteReply.status.code).to.equal(202);
 
           // Bob also needs to write the same encrypted chat thread to his own DWN
@@ -1797,7 +1797,7 @@ export function testRecordsReadHandler(): void {
           await bobToBobRecordsWrite.sign(Jws.createSigner(bob));
 
           const dataStreamForBobsDwn = DataStream.fromBytes(encryptedDataBytes);
-          const bobToBobWriteReply = await dwn.handleRecordsWrite(bob.did, bobToBobRecordsWrite.message, dataStreamForBobsDwn);
+          const bobToBobWriteReply = await dwn.processMessage(bob.did, bobToBobRecordsWrite.message, dataStreamForBobsDwn);
           expect(bobToBobWriteReply.status.code).to.equal(202);
 
           // NOTE: we know Alice is able to decrypt the message using protocol-path derived key through other tests, so we won't verify it again
@@ -1809,7 +1809,7 @@ export function testRecordsReadHandler(): void {
             },
             authorizationSigner: Jws.createSigner(alice)
           });
-          const readReply = await dwn.handleRecordsRead(alice.did, recordsRead.message);
+          const readReply = await dwn.processMessage(alice.did, recordsRead.message);
           expect(readReply.status.code).to.equal(200);
 
           const fetchedRecordsWrite = readReply.record!;
@@ -1843,7 +1843,7 @@ export function testRecordsReadHandler(): void {
           });
 
           // Alice sends the message to Bob
-          const aliceWriteReply = await dwn.handleRecordsWrite(bob.did, recordsWriteToBob.message, recordsWriteToBob.dataStream);
+          const aliceWriteReply = await dwn.processMessage(bob.did, recordsWriteToBob.message, recordsWriteToBob.dataStream);
           expect(aliceWriteReply.status.code).to.equal(202);
 
           // test that Bob is able to read and decrypt Alice's message
@@ -1853,7 +1853,7 @@ export function testRecordsReadHandler(): void {
             },
             authorizationSigner: Jws.createSigner(bob)
           });
-          const readByBobReply = await dwn.handleRecordsRead(bob.did, recordsReadByBob.message);
+          const readByBobReply = await dwn.processMessage(bob.did, recordsReadByBob.message);
           expect(readByBobReply.status.code).to.equal(200);
 
           const fetchedRecordsWrite2 = readByBobReply.record!;
@@ -1933,7 +1933,7 @@ export function testRecordsReadHandler(): void {
           );
 
           // Bob writes the encrypted email to Alice's DWN
-          const bobWriteReply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+          const bobWriteReply = await dwn.processMessage(alice.did, message, dataStream);
           expect(bobWriteReply.status.code).to.equal(202);
 
           // Alice reads the encrypted email
@@ -1944,7 +1944,7 @@ export function testRecordsReadHandler(): void {
             },
             authorizationSigner: Jws.createSigner(alice)
           });
-          const readReply = await dwn.handleRecordsRead(alice.did, recordsRead.message);
+          const readReply = await dwn.processMessage(alice.did, recordsRead.message);
           expect(readReply.status.code).to.equal(200);
 
           // test that Alice is able decrypt the encrypted email from Bob using the root key
@@ -1962,7 +1962,7 @@ export function testRecordsReadHandler(): void {
           expect(ArrayUtility.byteArraysEqual(plaintextBytes, bobMessageBytes)).to.be.true;
 
           // test that a correct derived key is able decrypt the encrypted email from Bob
-          const readReply2 = await dwn.handleRecordsRead(alice.did, recordsRead.message);
+          const readReply2 = await dwn.processMessage(alice.did, recordsRead.message);
           expect(readReply2.status.code).to.equal(200);
 
           const relativeDescendantDerivationPath = Records.constructKeyDerivationPath(KeyDerivationScheme.ProtocolPath, fetchedRecordsWrite);

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -90,7 +90,7 @@ export function testRecordsWriteHandler(): void {
         const recordsWriteMessageData = await TestDataGenerator.generateRecordsWrite({ author, data: data1 });
 
         const tenant = author.did;
-        const recordsWriteReply = await dwn.handleRecordsWrite(tenant, recordsWriteMessageData.message, recordsWriteMessageData.dataStream);
+        const recordsWriteReply = await dwn.processMessage(tenant, recordsWriteMessageData.message, recordsWriteMessageData.dataStream);
         expect(recordsWriteReply.status.code).to.equal(202);
 
         const recordId = recordsWriteMessageData.message.recordId;
@@ -118,7 +118,7 @@ export function testRecordsWriteHandler(): void {
         // sanity check that old data and new data are different
         expect(newDataEncoded).to.not.equal(Encoder.bytesToBase64Url(recordsWriteMessageData.dataBytes!));
 
-        const newRecordsWriteReply = await dwn.handleRecordsWrite(tenant, newRecordsWrite.message, newRecordsWrite.dataStream);
+        const newRecordsWriteReply = await dwn.processMessage(tenant, newRecordsWrite.message, newRecordsWrite.dataStream);
         expect(newRecordsWriteReply.status.code).to.equal(202);
 
         // verify new record has overwritten the existing record
@@ -129,7 +129,7 @@ export function testRecordsWriteHandler(): void {
         expect(newRecordsQueryReply.entries![0].encodedData).to.equal(newDataEncoded);
 
         // try to write the older message to store again and verify that it is not accepted
-        const thirdRecordsWriteReply = await dwn.handleRecordsWrite(tenant, recordsWriteMessageData.message, recordsWriteMessageData.dataStream);
+        const thirdRecordsWriteReply = await dwn.processMessage(tenant, recordsWriteMessageData.message, recordsWriteMessageData.dataStream);
         expect(thirdRecordsWriteReply.status.code).to.equal(409); // expecting to fail
 
         // expecting unchanged
@@ -151,7 +151,7 @@ export function testRecordsWriteHandler(): void {
         // setting up a stub DID resolver
         TestStubGenerator.stubDidResolver(didResolver, [author]);
 
-        const originatingMessageWriteReply = await dwn.handleRecordsWrite(tenant, originatingMessageData.message, originatingMessageData.dataStream);
+        const originatingMessageWriteReply = await dwn.processMessage(tenant, originatingMessageData.message, originatingMessageData.dataStream);
         expect(originatingMessageWriteReply.status.code).to.equal(202);
 
         // generate two new RecordsWrite messages with the same `messageTimestamp` value
@@ -181,7 +181,7 @@ export function testRecordsWriteHandler(): void {
         }
 
         // write the message with the smaller lexicographical message CID first
-        const recordsWriteReply = await dwn.handleRecordsWrite(tenant, olderWrite.message, olderWrite.dataStream);
+        const recordsWriteReply = await dwn.processMessage(tenant, olderWrite.message, olderWrite.dataStream);
         expect(recordsWriteReply.status.code).to.equal(202);
 
         // query to fetch the record
@@ -198,7 +198,7 @@ export function testRecordsWriteHandler(): void {
           .to.equal(olderWrite.message.descriptor.dataCid);
 
         // attempt to write the message with larger lexicographical message CID
-        const newRecordsWriteReply = await dwn.handleRecordsWrite(tenant, newerWrite.message, newerWrite.dataStream);
+        const newRecordsWriteReply = await dwn.processMessage(tenant, newerWrite.message, newerWrite.dataStream);
         expect(newRecordsWriteReply.status.code).to.equal(202);
 
         // verify new record has overwritten the existing record
@@ -209,7 +209,7 @@ export function testRecordsWriteHandler(): void {
           .to.equal(newerWrite.message.descriptor.dataCid);
 
         // try to write the message with smaller lexicographical message CID again
-        const thirdRecordsWriteReply = await dwn.handleRecordsWrite(
+        const thirdRecordsWriteReply = await dwn.processMessage(
           tenant,
           olderWrite.message,
           DataStream.fromBytes(olderWrite.dataBytes) // need to create data stream again since it's already used above
@@ -230,7 +230,7 @@ export function testRecordsWriteHandler(): void {
 
         TestStubGenerator.stubDidResolver(didResolver, [initialWriteData.author]);
 
-        const initialWriteReply = await dwn.handleRecordsWrite(tenant, initialWriteData.message, initialWriteData.dataStream);
+        const initialWriteReply = await dwn.processMessage(tenant, initialWriteData.message, initialWriteData.dataStream);
         expect(initialWriteReply.status.code).to.equal(202);
 
         const recordId = initialWriteData.message.recordId;
@@ -246,7 +246,7 @@ export function testRecordsWriteHandler(): void {
           dataFormat  : initialWriteData.message.descriptor.dataFormat
         });
 
-        let reply = await dwn.handleRecordsWrite(tenant, childMessageData.message, childMessageData.dataStream);
+        let reply = await dwn.processMessage(tenant, childMessageData.message, childMessageData.dataStream);
 
         expect(reply.status.code).to.equal(400);
         expect(reply.status.detail).to.contain('dateCreated is an immutable property');
@@ -260,7 +260,7 @@ export function testRecordsWriteHandler(): void {
           dataFormat : initialWriteData.message.descriptor.dataFormat
         });
 
-        reply = await dwn.handleRecordsWrite(tenant, childMessageData.message, childMessageData.dataStream);
+        reply = await dwn.processMessage(tenant, childMessageData.message, childMessageData.dataStream);
 
         expect(reply.status.code).to.equal(400);
         expect(reply.status.detail).to.contain('schema is an immutable property');
@@ -274,7 +274,7 @@ export function testRecordsWriteHandler(): void {
           dataFormat : 'should-not-be-allowed-to-change'
         });
 
-        reply = await dwn.handleRecordsWrite(tenant, childMessageData.message, childMessageData.dataStream);
+        reply = await dwn.processMessage(tenant, childMessageData.message, childMessageData.dataStream);
 
         expect(reply.status.code).to.equal(400);
         expect(reply.status.detail).to.contain('dataFormat is an immutable property');
@@ -288,7 +288,7 @@ export function testRecordsWriteHandler(): void {
 
         TestStubGenerator.stubDidResolver(didResolver, [author]);
 
-        const initialWriteReply = await dwn.handleRecordsWrite(tenant, message, dataStream);
+        const initialWriteReply = await dwn.processMessage(tenant, message, dataStream);
         expect(initialWriteReply.status.code).to.equal(202);
 
         const write2 = await RecordsWrite.createFrom({
@@ -297,7 +297,7 @@ export function testRecordsWriteHandler(): void {
           authorizationSigner : Jws.createSigner(author),
         });
 
-        const writeUpdateReply = await dwn.handleRecordsWrite(tenant, write2.message);
+        const writeUpdateReply = await dwn.processMessage(tenant, write2.message);
         expect(writeUpdateReply.status.code).to.equal(202);
         const readMessage = await RecordsRead.create({
           filter: {
@@ -305,7 +305,7 @@ export function testRecordsWriteHandler(): void {
           }
         });
 
-        const readMessageReply = await dwn.handleRecordsRead(tenant, readMessage.message);
+        const readMessageReply = await dwn.processMessage(tenant, readMessage.message);
         expect(readMessageReply.status.code).to.equal(200);
         expect(readMessageReply.record).to.exist;
         const data = await DataStream.toBytes(readMessageReply.record!.data);
@@ -329,7 +329,7 @@ export function testRecordsWriteHandler(): void {
             authorizationSigner : Jws.createSigner(alice)
           });
 
-          const readReply = await dwn.handleRecordsRead(bob.did, recordsRead.message);
+          const readReply = await dwn.processMessage(bob.did, recordsRead.message);
           expect(readReply.status.code).to.equal(200);
           expect(readReply.record).to.exist;
           expect(readReply.record?.descriptor).to.exist;
@@ -345,7 +345,7 @@ export function testRecordsWriteHandler(): void {
           expect(aliceWriteReply.status.code).to.equal(202);
 
           // Test that Bob's message can be read from Alice's DWN
-          const readReply2 = await dwn.handleRecordsRead(alice.did, recordsRead.message);
+          const readReply2 = await dwn.processMessage(alice.did, recordsRead.message);
           expect(readReply2.status.code).to.equal(200);
           expect(readReply2.record).to.exist;
           expect(readReply2.record?.descriptor).to.exist;
@@ -395,7 +395,7 @@ export function testRecordsWriteHandler(): void {
             filter              : { recordId: bobRecordsWrite.message.recordId },
             authorizationSigner : Jws.createSigner(alice)
           });
-          const readReply = await dwn.handleRecordsRead(alice.did, recordsRead.message);
+          const readReply = await dwn.processMessage(alice.did, recordsRead.message);
           expect(readReply.status.code).to.equal(200);
           expect(readReply.record).to.exist;
           expect(readReply.record?.descriptor).to.exist;
@@ -485,7 +485,7 @@ export function testRecordsWriteHandler(): void {
 
           TestStubGenerator.stubDidResolver(didResolver, [author]);
 
-          const initialWriteReply = await dwn.handleRecordsWrite(tenant, message, dataStream);
+          const initialWriteReply = await dwn.processMessage(tenant, message, dataStream);
           expect(initialWriteReply.status.code).to.equal(202);
 
           const write2 = await RecordsWrite.createFrom({
@@ -494,7 +494,7 @@ export function testRecordsWriteHandler(): void {
             authorizationSigner : Jws.createSigner(author),
           });
 
-          const writeUpdateReply = await dwn.handleRecordsWrite(tenant, write2.message);
+          const writeUpdateReply = await dwn.processMessage(tenant, write2.message);
           expect(writeUpdateReply.status.code).to.equal(202);
           const readMessage = await RecordsRead.create({
             filter: {
@@ -502,7 +502,7 @@ export function testRecordsWriteHandler(): void {
             }
           });
 
-          const readMessageReply = await dwn.handleRecordsRead(tenant, readMessage.message);
+          const readMessageReply = await dwn.processMessage(tenant, readMessage.message);
           expect(readMessageReply.status.code).to.equal(200);
           expect(readMessageReply.record).to.exist;
           const data = await DataStream.toBytes(readMessageReply.record!.data);
@@ -518,7 +518,7 @@ export function testRecordsWriteHandler(): void {
 
           TestStubGenerator.stubDidResolver(didResolver, [author]);
 
-          const initialWriteReply = await dwn.handleRecordsWrite(tenant, message, dataStream);
+          const initialWriteReply = await dwn.processMessage(tenant, message, dataStream);
           expect(initialWriteReply.status.code).to.equal(202);
 
           const write2 = await RecordsWrite.createFrom({
@@ -527,7 +527,7 @@ export function testRecordsWriteHandler(): void {
             authorizationSigner : Jws.createSigner(author),
           });
 
-          const writeUpdateReply = await dwn.handleRecordsWrite(tenant, write2.message);
+          const writeUpdateReply = await dwn.processMessage(tenant, write2.message);
           expect(writeUpdateReply.status.code).to.equal(202);
           const readMessage = await RecordsRead.create({
             filter: {
@@ -535,7 +535,7 @@ export function testRecordsWriteHandler(): void {
             }
           });
 
-          const readMessageReply = await dwn.handleRecordsRead(tenant, readMessage.message);
+          const readMessageReply = await dwn.processMessage(tenant, readMessage.message);
           expect(readMessageReply.status.code).to.equal(200);
           expect(readMessageReply.record).to.exist;
           const data = await DataStream.toBytes(readMessageReply.record!.data);
@@ -560,7 +560,7 @@ export function testRecordsWriteHandler(): void {
           message.recordId = recordId;
           message.authorization = { authorSignature };
 
-          const reply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+          const reply = await dwn.processMessage(alice.did, message, dataStream);
           expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain(DwnErrorCode.RecordsWriteDataSizeMismatch);
         });
@@ -581,7 +581,7 @@ export function testRecordsWriteHandler(): void {
           message.recordId = recordId;
           message.authorization = { authorSignature };
 
-          const reply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+          const reply = await dwn.processMessage(alice.did, message, dataStream);
           expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain(DwnErrorCode.RecordsWriteDataSizeMismatch);
         });
@@ -602,7 +602,7 @@ export function testRecordsWriteHandler(): void {
           message.recordId = recordId;
           message.authorization = { authorSignature };
 
-          const reply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+          const reply = await dwn.processMessage(alice.did, message, dataStream);
           expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain(DwnErrorCode.RecordsWriteDataSizeMismatch);
         });
@@ -622,7 +622,7 @@ export function testRecordsWriteHandler(): void {
           message.recordId = recordId;
           message.authorization = { authorSignature };
 
-          const reply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+          const reply = await dwn.processMessage(alice.did, message, dataStream);
           expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain(DwnErrorCode.RecordsWriteDataSizeMismatch);
         });
@@ -637,7 +637,7 @@ export function testRecordsWriteHandler(): void {
 
         TestStubGenerator.stubDidResolver(didResolver, [author]);
 
-        const initialWriteReply = await dwn.handleRecordsWrite(tenant, message, dataStream);
+        const initialWriteReply = await dwn.processMessage(tenant, message, dataStream);
         expect(initialWriteReply.status.code).to.equal(202);
 
         const recordsDelete = await RecordsDelete.create({
@@ -652,11 +652,11 @@ export function testRecordsWriteHandler(): void {
           authorizationSigner : Jws.createSigner(author),
         });
 
-        const withoutDataReply = await dwn.handleRecordsWrite(tenant, write.message);
+        const withoutDataReply = await dwn.processMessage(tenant, write.message);
         expect(withoutDataReply.status.code).to.equal(400);
         expect(withoutDataReply.status.detail).to.contain(DwnErrorCode.RecordsWriteMissingDataStream);
         const updatedWriteData = DataStream.fromBytes(dataBytes!);
-        const withoutDataReply2 = await dwn.handleRecordsWrite(tenant, write.message, updatedWriteData);
+        const withoutDataReply2 = await dwn.processMessage(tenant, write.message, updatedWriteData);
         expect(withoutDataReply2.status.code).to.equal(202);
       });
 
@@ -669,7 +669,7 @@ export function testRecordsWriteHandler(): void {
 
         TestStubGenerator.stubDidResolver(didResolver, [author]);
 
-        const initialWriteReply = await dwn.handleRecordsWrite(tenant, message, dataStream);
+        const initialWriteReply = await dwn.processMessage(tenant, message, dataStream);
         expect(initialWriteReply.status.code).to.equal(202);
 
         const recordsDelete = await RecordsDelete.create({
@@ -684,11 +684,11 @@ export function testRecordsWriteHandler(): void {
           authorizationSigner : Jws.createSigner(author),
         });
 
-        const withoutDataReply = await dwn.handleRecordsWrite(tenant, write.message);
+        const withoutDataReply = await dwn.processMessage(tenant, write.message);
         expect(withoutDataReply.status.code).to.equal(400);
         expect(withoutDataReply.status.detail).to.contain(DwnErrorCode.RecordsWriteMissingDataStream);
         const updatedWriteData = DataStream.fromBytes(dataBytes!);
-        const withoutDataReply2 = await dwn.handleRecordsWrite(tenant, write.message, updatedWriteData);
+        const withoutDataReply2 = await dwn.processMessage(tenant, write.message, updatedWriteData);
         expect(withoutDataReply2.status.code).to.equal(202);
       });
 
@@ -701,7 +701,7 @@ export function testRecordsWriteHandler(): void {
         const dataStream =
           DataStream.fromBytes(TestDataGenerator.randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded + 1)); // mismatch data stream
 
-        const reply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+        const reply = await dwn.processMessage(alice.did, message, dataStream);
         expect(reply.status.code).to.equal(400);
         expect(reply.status.detail).to.contain(DwnErrorCode.RecordsWriteDataCidMismatch);
       });
@@ -715,7 +715,7 @@ export function testRecordsWriteHandler(): void {
         const dataStream =
           DataStream.fromBytes(TestDataGenerator.randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded)); // mismatch data stream
 
-        const reply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+        const reply = await dwn.processMessage(alice.did, message, dataStream);
         expect(reply.status.code).to.equal(400);
         expect(reply.status.detail).to.contain(DwnErrorCode.RecordsWriteDataCidMismatch);
       });
@@ -729,7 +729,7 @@ export function testRecordsWriteHandler(): void {
         const dataStream =
           DataStream.fromBytes(TestDataGenerator.randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded + 1)); // mismatch data stream
 
-        const reply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+        const reply = await dwn.processMessage(alice.did, message, dataStream);
         expect(reply.status.code).to.equal(400);
         expect(reply.status.detail).to.contain(DwnErrorCode.RecordsWriteDataCidMismatch);
       });
@@ -755,7 +755,7 @@ export function testRecordsWriteHandler(): void {
           author: alice,
         });
 
-        const reply = await dwn.handleRecordsWrite(alice.did, message);
+        const reply = await dwn.processMessage(alice.did, message);
 
         expect(reply.status.code).to.equal(400);
         expect(reply.status.detail).to.contain(DwnErrorCode.RecordsWriteMissingDataInPrevious);
@@ -775,12 +775,12 @@ export function testRecordsWriteHandler(): void {
           data,
         });
 
-        const write1Reply = await dwn.handleRecordsWrite(alice.did, write1.message, write1.dataStream);
+        const write1Reply = await dwn.processMessage(alice.did, write1.message, write1.dataStream);
         expect(write1Reply.status.code).to.equal(202);
 
         // alice writes another record (which will be modified later)
         const write2 = await TestDataGenerator.generateRecordsWrite({ author: alice });
-        const write2Reply = await dwn.handleRecordsWrite(alice.did, write2.message, write2.dataStream);
+        const write2Reply = await dwn.processMessage(alice.did, write2.message, write2.dataStream);
         expect(write2Reply.status.code).to.equal(202);
 
         // modify write2 by referencing the `dataCid` in write1 (which should not be allowed)
@@ -799,7 +799,7 @@ export function testRecordsWriteHandler(): void {
           dataCid,
           dataSize
         });
-        const write2ChangeReply = await dwn.handleRecordsWrite(alice.did, write2Change.message);
+        const write2ChangeReply = await dwn.processMessage(alice.did, write2Change.message);
         expect(write2ChangeReply.status.code).to.equal(400); // should be disallowed
         expect(write2ChangeReply.status.detail).to.contain(DwnErrorCode.RecordsWriteDataCidMismatch);
 
@@ -811,7 +811,7 @@ export function testRecordsWriteHandler(): void {
           authorizationSigner: Jws.createSigner(alice)
         });
 
-        const readReply = await dwn.handleRecordsRead(alice.did, read.message);
+        const readReply = await dwn.processMessage(alice.did, read.message);
         expect(readReply.status.code).to.equal(200);
 
         const readDataBytes = await DataStream.toBytes(readReply.record!.data!);
@@ -834,7 +834,7 @@ export function testRecordsWriteHandler(): void {
             // setting up a stub DID resolver
             TestStubGenerator.stubDidResolver(didResolver, [author]);
 
-            const reply = await dwn.handleRecordsWrite(tenant, message, dataStream);
+            const reply = await dwn.processMessage(tenant, message, dataStream);
             expect(reply.status.code).to.equal(202);
 
             // changing the `published` property
@@ -844,7 +844,7 @@ export function testRecordsWriteHandler(): void {
               authorizationSigner : Jws.createSigner(author)
             });
 
-            const newWriteReply = await dwn.handleRecordsWrite(tenant, newWrite.message);
+            const newWriteReply = await dwn.processMessage(tenant, newWrite.message);
             expect(newWriteReply.status.code).to.equal(202);
 
             // verify the new record state can be queried
@@ -870,7 +870,7 @@ export function testRecordsWriteHandler(): void {
 
             // setting up a stub DID resolver
             TestStubGenerator.stubDidResolver(didResolver, [author]);
-            const reply = await dwn.handleRecordsWrite(tenant, message, dataStream);
+            const reply = await dwn.processMessage(tenant, message, dataStream);
 
             expect(reply.status.code).to.equal(202);
 
@@ -881,7 +881,7 @@ export function testRecordsWriteHandler(): void {
               authorizationSigner : Jws.createSigner(author)
             });
 
-            const newWriteReply = await dwn.handleRecordsWrite(tenant, newWrite.message, DataStream.fromBytes(newData));
+            const newWriteReply = await dwn.processMessage(tenant, newWrite.message, DataStream.fromBytes(newData));
 
             expect(newWriteReply.status.code).to.equal(202);
 
@@ -911,7 +911,7 @@ export function testRecordsWriteHandler(): void {
           const tenant = author.did;
 
           TestStubGenerator.stubDidResolver(didResolver, [author]);
-          const reply = await dwn.handleRecordsWrite(tenant, message, dataStream);
+          const reply = await dwn.processMessage(tenant, message, dataStream);
 
           expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain('initial write is not found');
@@ -926,7 +926,7 @@ export function testRecordsWriteHandler(): void {
 
           TestStubGenerator.stubDidResolver(didResolver, [author]);
 
-          const reply = await dwn.handleRecordsWrite(tenant, message, dataStream);
+          const reply = await dwn.processMessage(tenant, message, dataStream);
 
           expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain('must match dateCreated');
@@ -940,7 +940,7 @@ export function testRecordsWriteHandler(): void {
 
           TestStubGenerator.stubDidResolver(didResolver, [author]);
 
-          const reply = await dwn.handleRecordsWrite('unused-tenant-DID', message, dataStream);
+          const reply = await dwn.processMessage('unused-tenant-DID', message, dataStream);
           expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain('does not match deterministic contextId');
         });
@@ -950,7 +950,7 @@ export function testRecordsWriteHandler(): void {
             const { message, author, dataStream } = await TestDataGenerator.generateRecordsWrite();
             TestStubGenerator.stubDidResolver(didResolver, [author]);
 
-            const reply = await dwn.handleRecordsWrite(author.did, message, dataStream);
+            const reply = await dwn.processMessage(author.did, message, dataStream);
             expect(reply.status.code).to.equal(202);
 
             const events = await eventLog.getEvents(author.did);
@@ -964,7 +964,7 @@ export function testRecordsWriteHandler(): void {
             const { message, author, dataStream, recordsWrite } = await TestDataGenerator.generateRecordsWrite();
             TestStubGenerator.stubDidResolver(didResolver, [author]);
 
-            const reply = await dwn.handleRecordsWrite(author.did, message, dataStream);
+            const reply = await dwn.processMessage(author.did, message, dataStream);
             expect(reply.status.code).to.equal(202);
 
             const newWrite = await RecordsWrite.createFrom({
@@ -973,7 +973,7 @@ export function testRecordsWriteHandler(): void {
               authorizationSigner : Jws.createSigner(author)
             });
 
-            const newWriteReply = await dwn.handleRecordsWrite(author.did, newWrite.message);
+            const newWriteReply = await dwn.processMessage(author.did, newWrite.message);
             expect(newWriteReply.status.code).to.equal(202);
 
             const newestWrite = await RecordsWrite.createFrom({
@@ -982,7 +982,7 @@ export function testRecordsWriteHandler(): void {
               authorizationSigner : Jws.createSigner(author)
             });
 
-            const newestWriteReply = await dwn.handleRecordsWrite(author.did, newestWrite.message);
+            const newestWriteReply = await dwn.processMessage(author.did, newestWrite.message);
             expect(newestWriteReply.status.code).to.equal(202);
 
             const events = await eventLog.getEvents(author.did);
@@ -1032,7 +1032,7 @@ export function testRecordsWriteHandler(): void {
             }
           );
 
-          const bobWriteReply = await dwn.handleRecordsWrite(alice.did, emailFromBob.message, emailFromBob.dataStream);
+          const bobWriteReply = await dwn.processMessage(alice.did, emailFromBob.message, emailFromBob.dataStream);
           expect(bobWriteReply.status.code).to.equal(202);
 
           // verify bob's message got written to the DB
@@ -1083,7 +1083,7 @@ export function testRecordsWriteHandler(): void {
             });
             const credentialApplicationContextId = await credentialApplication.recordsWrite.getEntryId();
 
-            const credentialApplicationReply = await dwn.handleRecordsWrite(
+            const credentialApplicationReply = await dwn.processMessage(
               alice.did,
               credentialApplication.message,
               credentialApplication.dataStream
@@ -1106,7 +1106,7 @@ export function testRecordsWriteHandler(): void {
               }
             );
 
-            const credentialResponseReply = await dwn.handleRecordsWrite(alice.did, credentialResponse.message, credentialResponse.dataStream);
+            const credentialResponseReply = await dwn.processMessage(alice.did, credentialResponse.message, credentialResponse.dataStream);
             expect(credentialResponseReply.status.code).to.equal(202);
 
             // verify VC issuer's message got written to the DB
@@ -1153,7 +1153,7 @@ export function testRecordsWriteHandler(): void {
               dataFormat   : protocolDefinition.types.image.dataFormats[0],
               data         : encodedImage
             });
-            const imageReply = await dwn.handleRecordsWrite(bob.did, imageRecordsWrite.message, imageRecordsWrite.dataStream);
+            const imageReply = await dwn.processMessage(bob.did, imageRecordsWrite.message, imageRecordsWrite.dataStream);
             expect(imageReply.status.code).to.equal(202);
 
             const imageContextId = await imageRecordsWrite.recordsWrite.getEntryId();
@@ -1170,7 +1170,7 @@ export function testRecordsWriteHandler(): void {
               parentId     : imageContextId,
               data         : encodedCaptionImposter
             });
-            const captionReply = await dwn.handleRecordsWrite(bob.did, captionImposter.message, captionImposter.dataStream);
+            const captionReply = await dwn.processMessage(bob.did, captionImposter.message, captionImposter.dataStream);
             expect(captionReply.status.code).to.equal(401);
             expect(captionReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationActionNotAllowed);
 
@@ -1186,7 +1186,7 @@ export function testRecordsWriteHandler(): void {
               parentId     : imageContextId,
               data         : encodedCaption
             });
-            const captionResponse = await dwn.handleRecordsWrite(bob.did, captionRecordsWrite.message, captionRecordsWrite.dataStream);
+            const captionResponse = await dwn.processMessage(bob.did, captionRecordsWrite.message, captionRecordsWrite.dataStream);
             expect(captionResponse.status.code).to.equal(202);
 
             // Verify Alice's caption got written to the DB
@@ -1227,7 +1227,7 @@ export function testRecordsWriteHandler(): void {
                 protocolPath : 'friend',
                 data         : new TextEncoder().encode('Bob is my friend'),
               });
-              const friendRoleReply = await dwn.handleRecordsWrite(alice.did, friendRoleRecord.message, friendRoleRecord.dataStream);
+              const friendRoleReply = await dwn.processMessage(alice.did, friendRoleRecord.message, friendRoleRecord.dataStream);
               expect(friendRoleReply.status.code).to.equal(202);
 
               // Alice updates Bob's 'friend' record
@@ -1235,7 +1235,7 @@ export function testRecordsWriteHandler(): void {
                 author        : alice,
                 existingWrite : friendRoleRecord.recordsWrite,
               });
-              const updateFriendReply = await dwn.handleRecordsWrite(alice.did, updateFriendRecord.message, updateFriendRecord.dataStream);
+              const updateFriendReply = await dwn.processMessage(alice.did, updateFriendRecord.message, updateFriendRecord.dataStream);
               expect(updateFriendReply.status.code).to.equal(202);
             });
 
@@ -1289,7 +1289,7 @@ export function testRecordsWriteHandler(): void {
                 protocolPath : 'friend',
                 data         : new TextEncoder().encode('Bob is my friend'),
               });
-              const friendRoleReply = await dwn.handleRecordsWrite(alice.did, friendRoleRecord.message, friendRoleRecord.dataStream);
+              const friendRoleReply = await dwn.processMessage(alice.did, friendRoleRecord.message, friendRoleRecord.dataStream);
               expect(friendRoleReply.status.code).to.equal(202);
 
               // Alice writes a duplicate record adding Bob as a 'friend' again
@@ -1300,7 +1300,7 @@ export function testRecordsWriteHandler(): void {
                 protocolPath : 'friend',
                 data         : new TextEncoder().encode('Bob is still my friend'),
               });
-              const duplicateFriendReply = await dwn.handleRecordsWrite(alice.did, duplicateFriendRecord.message, duplicateFriendRecord.dataStream);
+              const duplicateFriendReply = await dwn.processMessage(alice.did, duplicateFriendRecord.message, duplicateFriendRecord.dataStream);
               expect(duplicateFriendReply.status.code).to.equal(400);
               expect(duplicateFriendReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationDuplicateGlobalRoleRecipient);
             });
@@ -1328,7 +1328,7 @@ export function testRecordsWriteHandler(): void {
                 protocolPath : 'friend',
                 data         : new TextEncoder().encode('Bob is my friend'),
               });
-              const friendRoleReply = await dwn.handleRecordsWrite(alice.did, friendRoleRecord.message, friendRoleRecord.dataStream);
+              const friendRoleReply = await dwn.processMessage(alice.did, friendRoleRecord.message, friendRoleRecord.dataStream);
               expect(friendRoleReply.status.code).to.equal(202);
 
               // Alice deletes Bob's 'friend' role record
@@ -1347,7 +1347,7 @@ export function testRecordsWriteHandler(): void {
                 protocolPath : 'friend',
                 data         : new TextEncoder().encode('Bob is still my friend'),
               });
-              const duplicateFriendReply = await dwn.handleRecordsWrite(alice.did, duplicateFriendRecord.message, duplicateFriendRecord.dataStream);
+              const duplicateFriendReply = await dwn.processMessage(alice.did, duplicateFriendRecord.message, duplicateFriendRecord.dataStream);
               expect(duplicateFriendReply.status.code).to.equal(202);
             });
           });
@@ -1827,7 +1827,7 @@ export function testRecordsWriteHandler(): void {
             }
           );
 
-          const bobWriteReply = await dwn.handleRecordsWrite(alice.did, messageFromBob.message, messageFromBob.dataStream);
+          const bobWriteReply = await dwn.processMessage(alice.did, messageFromBob.message, messageFromBob.dataStream);
           expect(bobWriteReply.status.code).to.equal(202);
 
           // verify bob's message got written to the DB
@@ -1848,7 +1848,7 @@ export function testRecordsWriteHandler(): void {
             data          : updatedMessageBytes
           });
 
-          const newWriteReply = await dwn.handleRecordsWrite(alice.did, updatedMessageFromBob.message, updatedMessageFromBob.dataStream);
+          const newWriteReply = await dwn.processMessage(alice.did, updatedMessageFromBob.message, updatedMessageFromBob.dataStream);
           expect(newWriteReply.status.code).to.equal(202);
 
           // verify bob's message got written to the DB
@@ -1892,7 +1892,7 @@ export function testRecordsWriteHandler(): void {
             }
           );
 
-          const bobWriteReply = await dwn.handleRecordsWrite(alice.did, messageFromBob.message, messageFromBob.dataStream);
+          const bobWriteReply = await dwn.processMessage(alice.did, messageFromBob.message, messageFromBob.dataStream);
           expect(bobWriteReply.status.code).to.equal(202);
 
           // verify bob's message got written to the DB
@@ -1919,7 +1919,7 @@ export function testRecordsWriteHandler(): void {
             }
           );
 
-          const carolWriteReply = await dwn.handleRecordsWrite(alice.did, modifiedMessageFromCarol.message, modifiedMessageFromCarol.dataStream);
+          const carolWriteReply = await dwn.processMessage(alice.did, modifiedMessageFromCarol.message, modifiedMessageFromCarol.dataStream);
           expect(carolWriteReply.status.code).to.equal(401);
           expect(carolWriteReply.status.detail).to.contain('must match to author of initial write');
         });
@@ -1960,7 +1960,7 @@ export function testRecordsWriteHandler(): void {
             }
           );
 
-          const bobWriteReply = await dwn.handleRecordsWrite(alice.did, messageFromBob.message, messageFromBob.dataStream);
+          const bobWriteReply = await dwn.processMessage(alice.did, messageFromBob.message, messageFromBob.dataStream);
           expect(bobWriteReply.status.code).to.equal(202);
 
           // verify bob's message got written to the DB
@@ -1988,7 +1988,7 @@ export function testRecordsWriteHandler(): void {
             }
           );
 
-          const newWriteReply = await dwn.handleRecordsWrite(alice.did, updatedMessageFromBob.message, updatedMessageFromBob.dataStream);
+          const newWriteReply = await dwn.processMessage(alice.did, updatedMessageFromBob.message, updatedMessageFromBob.dataStream);
           expect(newWriteReply.status.code).to.equal(400);
           expect(newWriteReply.status.detail).to.contain('recipient is an immutable property');
         });
@@ -2030,7 +2030,7 @@ export function testRecordsWriteHandler(): void {
           });
           const credentialApplicationContextId = await credentialApplication.recordsWrite.getEntryId();
 
-          const credentialApplicationReply = await dwn.handleRecordsWrite(alice.did, credentialApplication.message, credentialApplication.dataStream);
+          const credentialApplicationReply = await dwn.processMessage(alice.did, credentialApplication.message, credentialApplication.dataStream);
           expect(credentialApplicationReply.status.code).to.equal(202);
 
           // generate a credential application response message from a fake VC issuer
@@ -2049,7 +2049,7 @@ export function testRecordsWriteHandler(): void {
             }
           );
 
-          const credentialResponseReply = await dwn.handleRecordsWrite(alice.did, credentialResponse.message, credentialResponse.dataStream);
+          const credentialResponseReply = await dwn.processMessage(alice.did, credentialResponse.message, credentialResponse.dataStream);
           expect(credentialResponseReply.status.code).to.equal(401);
           expect(credentialResponseReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationActionNotAllowed);
         });
@@ -2066,7 +2066,7 @@ export function testRecordsWriteHandler(): void {
             data
           });
 
-          const reply = await dwn.handleRecordsWrite(alice.did, credentialApplication.message, credentialApplication.dataStream);
+          const reply = await dwn.processMessage(alice.did, credentialApplication.message, credentialApplication.dataStream);
           expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain('unable to find protocol definition');
         });
@@ -2094,7 +2094,7 @@ export function testRecordsWriteHandler(): void {
             data
           });
 
-          const reply = await dwn.handleRecordsWrite(alice.did, credentialApplication.message, credentialApplication.dataStream);
+          const reply = await dwn.processMessage(alice.did, credentialApplication.message, credentialApplication.dataStream);
           expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationInvalidSchema);
         });
@@ -2122,7 +2122,7 @@ export function testRecordsWriteHandler(): void {
             data
           });
 
-          const reply = await dwn.handleRecordsWrite(alice.did, credentialApplication.message, credentialApplication.dataStream);
+          const reply = await dwn.processMessage(alice.did, credentialApplication.message, credentialApplication.dataStream);
           expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationInvalidType);
         });
@@ -2150,7 +2150,7 @@ export function testRecordsWriteHandler(): void {
             data
           });
 
-          const reply = await dwn.handleRecordsWrite(alice.did, credentialApplication.message, credentialApplication.dataStream);
+          const reply = await dwn.processMessage(alice.did, credentialApplication.message, credentialApplication.dataStream);
           expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationParentlessIncorrectProtocolPath);
         });
@@ -2180,7 +2180,7 @@ export function testRecordsWriteHandler(): void {
             dataFormat   : protocolDefinition.types.image.dataFormats[0],
             data
           });
-          const replyMatch = await dwn.handleRecordsWrite(alice.did, recordsWriteMatch.message, recordsWriteMatch.dataStream);
+          const replyMatch = await dwn.processMessage(alice.did, recordsWriteMatch.message, recordsWriteMatch.dataStream);
           expect(replyMatch.status.code).to.equal(202);
 
           // write record with mismatch dataFormat
@@ -2194,7 +2194,7 @@ export function testRecordsWriteHandler(): void {
             data
           });
 
-          const replyMismatch = await dwn.handleRecordsWrite(alice.did, recordsWriteMismatch.message, recordsWriteMismatch.dataStream);
+          const replyMismatch = await dwn.processMessage(alice.did, recordsWriteMismatch.message, recordsWriteMismatch.dataStream);
           expect(replyMismatch.status.code).to.equal(400);
           expect(replyMismatch.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationIncorrectDataFormat);
         });
@@ -2225,7 +2225,7 @@ export function testRecordsWriteHandler(): void {
             schema       : credentialResponseSchema, // this is a known schema type, but not allowed for a protocol root record
             data
           });
-          const failedCredentialResponseReply = await dwn.handleRecordsWrite(
+          const failedCredentialResponseReply = await dwn.processMessage(
             alice.did, failedCredentialResponse.message, failedCredentialResponse.dataStream);
           expect(failedCredentialResponseReply.status.code).to.equal(400);
           expect(failedCredentialResponseReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationMissingRuleSet);
@@ -2239,7 +2239,7 @@ export function testRecordsWriteHandler(): void {
             schema       : credentialApplicationSchema,
             data
           });
-          const credentialApplicationReply = await dwn.handleRecordsWrite(
+          const credentialApplicationReply = await dwn.processMessage(
             alice.did, credentialApplication.message, credentialApplication.dataStream);
           expect(credentialApplicationReply.status.code).to.equal(202);
 
@@ -2254,7 +2254,7 @@ export function testRecordsWriteHandler(): void {
             parentId     : credentialApplication.message.recordId,
             data
           });
-          const failedCredentialApplicationReply2 = await dwn.handleRecordsWrite(
+          const failedCredentialApplicationReply2 = await dwn.processMessage(
             alice.did, failedCredentialApplication.message, failedCredentialApplication.dataStream);
           expect(failedCredentialApplicationReply2.status.code).to.equal(400);
           expect(failedCredentialApplicationReply2.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationMissingRuleSet);
@@ -2270,7 +2270,7 @@ export function testRecordsWriteHandler(): void {
             parentId     : credentialApplication.message.recordId,
             data
           });
-          const credentialResponseReply = await dwn.handleRecordsWrite(alice.did, credentialResponse.message, credentialResponse.dataStream);
+          const credentialResponseReply = await dwn.processMessage(alice.did, credentialResponse.message, credentialResponse.dataStream);
           expect(credentialResponseReply.status.code).to.equal(202);
 
           // Try and fail to write a 'credentialResponse' below 'credentialApplication/credentialResponse'
@@ -2285,7 +2285,7 @@ export function testRecordsWriteHandler(): void {
             parentId     : credentialResponse.message.recordId,
             data
           });
-          const nestedCredentialApplicationReply = await dwn.handleRecordsWrite(
+          const nestedCredentialApplicationReply = await dwn.processMessage(
             alice.did, nestedCredentialApplication.message, nestedCredentialApplication.dataStream);
           expect(nestedCredentialApplicationReply.status.code).to.equal(400);
           expect(nestedCredentialApplicationReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationMissingRuleSet);
@@ -2317,7 +2317,7 @@ export function testRecordsWriteHandler(): void {
             data
           });
 
-          let reply = await dwn.handleRecordsWrite(alice.did, aliceWriteMessageData.message, aliceWriteMessageData.dataStream);
+          let reply = await dwn.processMessage(alice.did, aliceWriteMessageData.message, aliceWriteMessageData.dataStream);
           expect(reply.status.code).to.equal(202);
 
           // test that Bob is not allowed to write to Alice's DWN
@@ -2332,7 +2332,7 @@ export function testRecordsWriteHandler(): void {
             data
           });
 
-          reply = await dwn.handleRecordsWrite(alice.did, bobWriteMessageData.message, bobWriteMessageData.dataStream);
+          reply = await dwn.processMessage(alice.did, bobWriteMessageData.message, bobWriteMessageData.dataStream);
           expect(reply.status.code).to.equal(401);
           expect(reply.status.detail).to.contain(`no action rule defined for Write`);
         });
@@ -2369,7 +2369,7 @@ export function testRecordsWriteHandler(): void {
           });
           const contextId = await askMessageData.recordsWrite.getEntryId();
 
-          let reply = await dwn.handleRecordsWrite(pfi.did, askMessageData.message, askMessageData.dataStream);
+          let reply = await dwn.processMessage(pfi.did, askMessageData.message, askMessageData.dataStream);
           expect(reply.status.code).to.equal(202);
 
           const offerMessageData = await TestDataGenerator.generateRecordsWrite({
@@ -2383,7 +2383,7 @@ export function testRecordsWriteHandler(): void {
             data
           });
 
-          reply = await dwn.handleRecordsWrite(pfi.did, offerMessageData.message, offerMessageData.dataStream);
+          reply = await dwn.processMessage(pfi.did, offerMessageData.message, offerMessageData.dataStream);
           expect(reply.status.code).to.equal(202);
 
           // the actual test: making sure fulfillment message is accepted
@@ -2397,7 +2397,7 @@ export function testRecordsWriteHandler(): void {
             protocolPath : 'ask/offer/fulfillment',
             data
           });
-          reply = await dwn.handleRecordsWrite(pfi.did, fulfillmentMessageData.message, fulfillmentMessageData.dataStream);
+          reply = await dwn.processMessage(pfi.did, fulfillmentMessageData.message, fulfillmentMessageData.dataStream);
           expect(reply.status.code).to.equal(202);
 
           // verify the fulfillment message is stored
@@ -2448,7 +2448,7 @@ export function testRecordsWriteHandler(): void {
           });
           const contextId = await askMessageData.recordsWrite.getEntryId();
 
-          let reply = await dwn.handleRecordsWrite(pfi.did, askMessageData.message, askMessageData.dataStream);
+          let reply = await dwn.processMessage(pfi.did, askMessageData.message, askMessageData.dataStream);
           expect(reply.status.code).to.equal(202);
 
           // the actual test: making sure fulfillment message fails
@@ -2463,7 +2463,7 @@ export function testRecordsWriteHandler(): void {
             data
           });
 
-          reply = await dwn.handleRecordsWrite(pfi.did, fulfillmentMessageData.message, fulfillmentMessageData.dataStream);
+          reply = await dwn.processMessage(pfi.did, fulfillmentMessageData.message, fulfillmentMessageData.dataStream);
           expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationIncorrectProtocolPath);
         });
@@ -2558,7 +2558,7 @@ export function testRecordsWriteHandler(): void {
           };
 
           // Send records write message
-          const reply = await dwn.handleRecordsWrite(alice.did, recordsWrite.message, recordsWrite.dataStream);
+          const reply = await dwn.processMessage(alice.did, recordsWrite.message, recordsWrite.dataStream);
           expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain(DwnErrorCode.UrlProtocolNotNormalized);
         });
@@ -2578,7 +2578,7 @@ export function testRecordsWriteHandler(): void {
             data,
           });
 
-          const reply = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+          const reply = await dwn.processMessage(alice.did, message, dataStream);
           expect(reply.status.code).to.equal(202);
 
           const protocolDefinition = socialMediaProtocolDefinition;
@@ -2604,7 +2604,7 @@ export function testRecordsWriteHandler(): void {
             dataSize,
             recipient    : alice.did
           });
-          const imageReply = await dwn.handleRecordsWrite(alice.did, imageRecordsWrite.message, imageRecordsWrite.dataStream);
+          const imageReply = await dwn.processMessage(alice.did, imageRecordsWrite.message, imageRecordsWrite.dataStream);
           expect(imageReply.status.code).to.equal(400); // should be disallowed
           expect(imageReply.status.detail).to.contain(DwnErrorCode.RecordsWriteMissingDataInPrevious);
 
@@ -2616,7 +2616,7 @@ export function testRecordsWriteHandler(): void {
             authorizationSigner: Jws.createSigner(bob)
           });
 
-          const bobRecordsReadReply = await dwn.handleRecordsRead(alice.did, bobRecordsReadData.message);
+          const bobRecordsReadReply = await dwn.processMessage(alice.did, bobRecordsReadData.message);
           expect(bobRecordsReadReply.status.code).to.equal(404);
         });
       });
@@ -2661,7 +2661,7 @@ export function testRecordsWriteHandler(): void {
             protocolPath : 'foo',
             permissionsGrantId,
           });
-          const recordsWriteReply = await dwn.handleRecordsWrite(alice.did, protocolRecordsWrite.message, protocolRecordsWrite.dataStream);
+          const recordsWriteReply = await dwn.processMessage(alice.did, protocolRecordsWrite.message, protocolRecordsWrite.dataStream);
           expect(recordsWriteReply.status.code).to.equal(202);
 
           // Bob writes a non-protocol record to Alice's DWN
@@ -2669,7 +2669,7 @@ export function testRecordsWriteHandler(): void {
             author: bob,
             permissionsGrantId,
           });
-          const recordsWriteReply2 = await dwn.handleRecordsWrite(alice.did, nonProtocolRecordsWrite.message, nonProtocolRecordsWrite.dataStream);
+          const recordsWriteReply2 = await dwn.processMessage(alice.did, nonProtocolRecordsWrite.message, nonProtocolRecordsWrite.dataStream);
           expect(recordsWriteReply2.status.code).to.equal(202);
         });
 
@@ -2713,7 +2713,7 @@ export function testRecordsWriteHandler(): void {
               protocolPath       : 'foo',
               permissionsGrantId : await Message.getCid(permissionsGrant.message),
             });
-            const recordsWriteReply = await dwn.handleRecordsWrite(alice.did, recordsWrite.message, dataStream);
+            const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, dataStream);
             expect(recordsWriteReply.status.code).to.equal(202);
           });
 
@@ -2756,7 +2756,7 @@ export function testRecordsWriteHandler(): void {
               protocolPath       : 'foo',
               permissionsGrantId : await Message.getCid(permissionsGrant.message),
             });
-            const recordsWriteReply = await dwn.handleRecordsWrite(alice.did, recordsWrite.message, dataStream);
+            const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, dataStream);
             expect(recordsWriteReply.status.code).to.equal(401);
             expect(recordsWriteReply.status.detail).to.contain(DwnErrorCode.RecordsGrantAuthorizationScopeProtocolMismatch);
           });
@@ -2800,7 +2800,7 @@ export function testRecordsWriteHandler(): void {
               protocolPath       : 'foo',
               permissionsGrantId : await Message.getCid(permissionsGrant.message),
             });
-            const recordsWriteReply = await dwn.handleRecordsWrite(alice.did, recordsWrite.message, dataStream);
+            const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, dataStream);
             expect(recordsWriteReply.status.code).to.equal(401);
             expect(recordsWriteReply.status.detail).to.contain(DwnErrorCode.RecordsGrantAuthorizationScopeNotProtocol);
           });
@@ -2831,7 +2831,7 @@ export function testRecordsWriteHandler(): void {
               schema       : protocolDefinition.types.email.schema,
               dataFormat   : protocolDefinition.types.email.dataFormats![0],
             });
-            const alicesRecordsWriteReply = await dwn.handleRecordsWrite(alice.did, alicesRecordsWrite.message, alicesRecordsWrite.dataStream);
+            const alicesRecordsWriteReply = await dwn.processMessage(alice.did, alicesRecordsWrite.message, alicesRecordsWrite.dataStream);
             expect(alicesRecordsWriteReply.status.code).to.equal(202);
 
             // Alice gives Bob a PermissionsGrant
@@ -2861,7 +2861,7 @@ export function testRecordsWriteHandler(): void {
               contextId          : alicesRecordsWrite.message.contextId,
               permissionsGrantId : await Message.getCid(permissionsGrant.message),
             });
-            const bobsRecordsWriteReply = await dwn.handleRecordsWrite(alice.did, bobsRecordsWrite.message, bobsRecordsWrite.dataStream);
+            const bobsRecordsWriteReply = await dwn.processMessage(alice.did, bobsRecordsWrite.message, bobsRecordsWrite.dataStream);
             expect(bobsRecordsWriteReply.status.code).to.equal(202);
           });
 
@@ -2891,7 +2891,7 @@ export function testRecordsWriteHandler(): void {
               schema       : protocolDefinition.types.email.schema,
               dataFormat   : protocolDefinition.types.email.dataFormats![0],
             });
-            const alicesRecordsWriteReply = await dwn.handleRecordsWrite(alice.did, alicesRecordsWrite.message, alicesRecordsWrite.dataStream);
+            const alicesRecordsWriteReply = await dwn.processMessage(alice.did, alicesRecordsWrite.message, alicesRecordsWrite.dataStream);
             expect(alicesRecordsWriteReply.status.code).to.equal(202);
 
             // Alice gives Bob a PermissionsGrant
@@ -2921,7 +2921,7 @@ export function testRecordsWriteHandler(): void {
               contextId          : alicesRecordsWrite.message.contextId,
               permissionsGrantId : await Message.getCid(permissionsGrant.message),
             });
-            const bobsRecordsWriteReply = await dwn.handleRecordsWrite(alice.did, bobsRecordsWrite.message, bobsRecordsWrite.dataStream);
+            const bobsRecordsWriteReply = await dwn.processMessage(alice.did, bobsRecordsWrite.message, bobsRecordsWrite.dataStream);
             expect(bobsRecordsWriteReply.status.code).to.equal(401);
             expect(bobsRecordsWriteReply.status.detail).to.contain(DwnErrorCode.RecordsGrantAuthorizationScopeContextIdMismatch);
           });
@@ -2966,7 +2966,7 @@ export function testRecordsWriteHandler(): void {
               protocolPath       : 'foo',
               permissionsGrantId : await Message.getCid(permissionsGrant.message),
             });
-            const bobsRecordsWriteReply = await dwn.handleRecordsWrite(alice.did, bobsRecordsWrite.message, bobsRecordsWrite.dataStream);
+            const bobsRecordsWriteReply = await dwn.processMessage(alice.did, bobsRecordsWrite.message, bobsRecordsWrite.dataStream);
             expect(bobsRecordsWriteReply.status.code).to.equal(202);
           });
 
@@ -3010,7 +3010,7 @@ export function testRecordsWriteHandler(): void {
               protocolPath       : 'foo',
               permissionsGrantId : await Message.getCid(permissionsGrant.message),
             });
-            const bobsRecordsWriteReply = await dwn.handleRecordsWrite(alice.did, bobsRecordsWrite.message, bobsRecordsWrite.dataStream);
+            const bobsRecordsWriteReply = await dwn.processMessage(alice.did, bobsRecordsWrite.message, bobsRecordsWrite.dataStream);
             expect(bobsRecordsWriteReply.status.code).to.equal(401);
             expect(bobsRecordsWriteReply.status.detail).to.contain(DwnErrorCode.RecordsGrantAuthorizationScopeProtocolPathMismatch);
           });
@@ -3046,7 +3046,7 @@ export function testRecordsWriteHandler(): void {
               schema,
               permissionsGrantId : await Message.getCid(permissionsGrant.message),
             });
-            const recordsWriteReply = await dwn.handleRecordsWrite(alice.did, recordsWrite.message, dataStream);
+            const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, dataStream);
             expect(recordsWriteReply.status.code).to.equal(202);
           });
 
@@ -3079,7 +3079,7 @@ export function testRecordsWriteHandler(): void {
               schema             : 'some-other-schema',
               permissionsGrantId : await Message.getCid(permissionsGrant.message),
             });
-            const recordsWriteReply = await dwn.handleRecordsWrite(alice.did, recordsWrite.message, dataStream);
+            const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, dataStream);
             expect(recordsWriteReply.status.code).to.equal(401);
             expect(recordsWriteReply.status.detail).to.contain(DwnErrorCode.RecordsGrantAuthorizationScopeSchema);
           });
@@ -3118,7 +3118,7 @@ export function testRecordsWriteHandler(): void {
               published : true,
               permissionsGrantId
             });
-            const publishedRecordsWriteReply = await dwn.handleRecordsWrite(
+            const publishedRecordsWriteReply = await dwn.processMessage(
               alice.did,
               publishedRecordsWrite.message,
               publishedRecordsWrite.dataStream
@@ -3132,7 +3132,7 @@ export function testRecordsWriteHandler(): void {
               permissionsGrantId
             });
             const unpublishedRecordsWriteReply =
-              await dwn.handleRecordsWrite(alice.did, unpublishedRecordsWrite.message, unpublishedRecordsWrite.dataStream);
+              await dwn.processMessage(alice.did, unpublishedRecordsWrite.message, unpublishedRecordsWrite.dataStream);
             expect(unpublishedRecordsWriteReply.status.code).to.equal(401);
             expect(unpublishedRecordsWriteReply.status.detail).to.contain(DwnErrorCode.RecordsGrantAuthorizationConditionPublicationRequired);
           });
@@ -3169,7 +3169,7 @@ export function testRecordsWriteHandler(): void {
               published : true,
               permissionsGrantId
             });
-            const publishedRecordsWriteReply = await dwn.handleRecordsWrite(
+            const publishedRecordsWriteReply = await dwn.processMessage(
               alice.did,
               publishedRecordsWrite.message,
               publishedRecordsWrite.dataStream
@@ -3184,7 +3184,7 @@ export function testRecordsWriteHandler(): void {
               permissionsGrantId
             });
             const unpublishedRecordsWriteReply =
-              await dwn.handleRecordsWrite(alice.did, unpublishedRecordsWrite.message, unpublishedRecordsWrite.dataStream);
+              await dwn.processMessage(alice.did, unpublishedRecordsWrite.message, unpublishedRecordsWrite.dataStream);
             expect(unpublishedRecordsWriteReply.status.code).to.equal(202);
           });
 
@@ -3220,7 +3220,7 @@ export function testRecordsWriteHandler(): void {
               published : true,
               permissionsGrantId
             });
-            const publishedRecordsWriteReply = await dwn.handleRecordsWrite(
+            const publishedRecordsWriteReply = await dwn.processMessage(
               alice.did,
               publishedRecordsWrite.message,
               publishedRecordsWrite.dataStream
@@ -3234,7 +3234,7 @@ export function testRecordsWriteHandler(): void {
               permissionsGrantId
             });
             const unpublishedRecordsWriteReply =
-              await dwn.handleRecordsWrite(alice.did, unpublishedRecordsWrite.message, unpublishedRecordsWrite.dataStream);
+              await dwn.processMessage(alice.did, unpublishedRecordsWrite.message, unpublishedRecordsWrite.dataStream);
             expect(unpublishedRecordsWriteReply.status.code).to.equal(202);
           });
         });
@@ -3263,7 +3263,7 @@ export function testRecordsWriteHandler(): void {
           published     : true,
           data,
         });
-        const recordsWriteReply = await dwn.handleRecordsWrite(alice.did, recordsWrite.message);
+        const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message);
         expect(recordsWriteReply.status.code).to.equal(400);
         expect(recordsWriteReply.status.detail).to.contain(DwnErrorCode.RecordsWriteMissingDataAssociation);
       });
@@ -3281,7 +3281,7 @@ export function testRecordsWriteHandler(): void {
             author: alice,
             data
           });
-          const aliceWriteReply = await dwn.handleRecordsWrite(alice.did, aliceWriteData.message, aliceWriteData.dataStream);
+          const aliceWriteReply = await dwn.processMessage(alice.did, aliceWriteData.message, aliceWriteData.dataStream);
           expect(aliceWriteReply.status.code).to.equal(202);
 
           const aliceQueryWriteAfterAliceWriteData = await TestDataGenerator.generateRecordsQuery({
@@ -3299,7 +3299,7 @@ export function testRecordsWriteHandler(): void {
             dataCid,
             dataSize : 4
           });
-          const bobAssociateReply = await dwn.handleRecordsWrite(bob.did, bobAssociateData.message, bobAssociateData.dataStream);
+          const bobAssociateReply = await dwn.processMessage(bob.did, bobAssociateData.message, bobAssociateData.dataStream);
           expect(bobAssociateReply.status.code).to.equal(400); // expecting an error
           expect(bobAssociateReply.status.detail).to.contain(DwnErrorCode.RecordsWriteMissingDataInPrevious);
 
@@ -3331,7 +3331,7 @@ export function testRecordsWriteHandler(): void {
           const processEncoded = sinon.spy(RecordsWriteHandler.prototype, 'processEncodedData');
           const putData = sinon.spy(RecordsWriteHandler.prototype, 'putData');
 
-          const writeMessage = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+          const writeMessage = await dwn.processMessage(alice.did, message, dataStream);
           expect(writeMessage.status.code).to.equal(202);
           sinon.assert.calledOnce(processEncoded);
           sinon.assert.notCalled(putData);
@@ -3344,7 +3344,7 @@ export function testRecordsWriteHandler(): void {
           const processEncoded = sinon.spy(RecordsWriteHandler.prototype, 'processEncodedData');
           const putData = sinon.spy(RecordsWriteHandler.prototype, 'putData');
 
-          const writeMessage = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+          const writeMessage = await dwn.processMessage(alice.did, message, dataStream);
           expect(writeMessage.status.code).to.equal(202);
           sinon.assert.notCalled(processEncoded);
           sinon.assert.calledOnce(putData);
@@ -3355,7 +3355,7 @@ export function testRecordsWriteHandler(): void {
           const dataBytes = TestDataGenerator.randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded);
           const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice, data: dataBytes });
 
-          const writeMessage = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+          const writeMessage = await dwn.processMessage(alice.did, message, dataStream);
           expect(writeMessage.status.code).to.equal(202);
           const messageCid = await Message.getCid(message);
 
@@ -3368,7 +3368,7 @@ export function testRecordsWriteHandler(): void {
           const dataBytes = TestDataGenerator.randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded + 1);
           const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice, data: dataBytes });
 
-          const writeMessage = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+          const writeMessage = await dwn.processMessage(alice.did, message, dataStream);
           expect(writeMessage.status.code).to.equal(202);
           const messageCid = await Message.getCid(message);
 
@@ -3381,7 +3381,7 @@ export function testRecordsWriteHandler(): void {
           const dataBytes = TestDataGenerator.randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded);
           const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice, data: dataBytes });
 
-          const writeMessage = await dwn.handleRecordsWrite(alice.did, message, dataStream);
+          const writeMessage = await dwn.processMessage(alice.did, message, dataStream);
           expect(writeMessage.status.code).to.equal(202);
           const messageCid = await Message.getCid(message);
 
@@ -3398,7 +3398,7 @@ export function testRecordsWriteHandler(): void {
 
           const updateDataStream = DataStream.fromBytes(updatedDataBytes);
 
-          const writeMessage2 = await dwn.handleRecordsWrite(alice.did, newWrite.message, updateDataStream);
+          const writeMessage2 = await dwn.processMessage(alice.did, newWrite.message, updateDataStream);
           expect(writeMessage2.status.code).to.equal(202);
 
           const originalWrite = await messageStore.get(alice.did, messageCid);


### PR DESCRIPTION
…Message`

This commit fixes #563. It replaces the four methods in `Dwn` (1) `handleRecordsWrite` (2) `handleRecordsQuery` (3) `handleRecordsRead` (4) `handleMessagesGet` with the overloaded `processMessage` function introduced in commit #554.

This commit also replaces all invocations of the four deleted functions in all tests with the single `processMessage`.  Note that because the new `processMessage` can't and doesn't use the `expectedMethod` or `expectedInterface` arguments in `validateMessageIntegrity`, any tests that are testing for incorrect method edge cases will receive errors from json schema invalidation (i.e., `schema for x not found`) rather than message integrity errors (i.e., `Expected method x, received y`)