### PR TITLE
Add range filter support for dataSize

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here's to a thrilling Hacktoberfest voyage with us! 🎉
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-98.47%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.61%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.68%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.47%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-98.37%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.46%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.67%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.37%25-brightgreen.svg?style=flat)
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here's to a thrilling Hacktoberfest voyage with us! 🎉
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-98.37%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.46%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.67%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.37%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-98.47%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.61%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.68%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.47%25-brightgreen.svg?style=flat)
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/build/compile-validators.js
+++ b/build/compile-validators.js
@@ -26,6 +26,7 @@ import GeneralJws from '../json-schemas/general-jws.json' assert { type: 'json' 
 import GenericSignaturePayload from '../json-schemas/signature-payloads/generic-signature-payload.json' assert { type: 'json' };
 import JwkVerificationMethod from '../json-schemas/jwk-verification-method.json' assert { type: 'json' };
 import MessagesGet from '../json-schemas/interface-methods/messages-get.json' assert { type: 'json' };
+import NumberRangeFilter from '../json-schemas/interface-methods/number-range-filter.json' assert { type: 'json' };
 import PermissionsDefinitions from '../json-schemas/permissions/permissions-definitions.json' assert { type: 'json' };
 import PermissionsGrant from '../json-schemas/interface-methods/permissions-grant.json' assert { type: 'json' };
 import PermissionsRequest from '../json-schemas/interface-methods/permissions-request.json' assert { type: 'json' };
@@ -57,6 +58,7 @@ const schemas = {
   GeneralJws,
   JwkVerificationMethod,
   MessagesGet,
+  NumberRangeFilter,
   PermissionsDefinitions,
   PermissionsGrant,
   PermissionsRequest,

--- a/json-schemas/interface-methods/number-range-filter.json
+++ b/json-schemas/interface-methods/number-range-filter.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/dwn/json-schemas/number-range-filter.json",
+  "type": "object",
+  "minProperties": 1,
+  "additionalProperties": false,
+  "properties": {
+    "gt": {
+      "type": "number"
+    },
+    "gte": {
+      "type": "number"
+    },
+    "lt": {
+      "type": "number"
+    },
+    "lte": {
+      "type": "number"
+    }
+  },
+  "dependencies": {
+    "gt": {
+      "not": {
+        "required": ["gte"]
+      }
+    },
+    "gte": {
+      "not": {
+        "required": ["gt"]
+      }
+    },
+    "lt": {
+      "not": {
+        "required": ["lte"]
+      }
+    },
+    "lte": {
+      "not": {
+        "required": ["lt"]
+      }
+    }
+  }
+}

--- a/json-schemas/interface-methods/records-filter.json
+++ b/json-schemas/interface-methods/records-filter.json
@@ -32,6 +32,9 @@
     "dataFormat": {
       "type": "string"
     },
+    "dataSize": {
+      "$ref": "https://identity.foundation/dwn/json-schemas/number-range-filter.json"
+    },
     "dateCreated": {
       "type": "object",
       "minProperties": 1,

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -4,6 +4,7 @@ import type { GeneralJws } from './jws-types.js';
 import type { GenericMessageReply } from '../core/message-reply.js';
 import type { KeyDerivationScheme } from '../utils/hd-key.js';
 import type { PublicJwk } from './jose-types.js';
+import type { RangeFilter } from './message-types.js';
 import type { Readable } from 'readable-stream';
 import type { AuthorizationModel, GenericMessage, GenericSignaturePayload, Pagination } from './message-types.js';
 import type { DwnInterfaceName, DwnMethodName } from '../core/message.js';
@@ -100,6 +101,7 @@ export type RecordsFilter = {
   recordId?: string;
   parentId?: string;
   dataFormat?: string;
+  dataSize?: RangeFilter;
   dateCreated?: RangeCriterion;
 };
 

--- a/tests/handlers/records-query.spec.ts
+++ b/tests/handlers/records-query.spec.ts
@@ -200,60 +200,60 @@ export function testRecordsQueryHandler(): void {
       });
 
       it('should be able to query with `dataSize` filter (half-open range)', async () => {
-          const alice = await DidKeyResolver.generate();
-          const write1 = await TestDataGenerator.generateRecordsWrite({ author: alice, data: TestDataGenerator.randomBytes(10) });
-          const write2 = await TestDataGenerator.generateRecordsWrite({ author: alice, data: TestDataGenerator.randomBytes(50) });
-          const write3 = await TestDataGenerator.generateRecordsWrite({ author: alice, data: TestDataGenerator.randomBytes(100) });
+        const alice = await DidKeyResolver.generate();
+        const write1 = await TestDataGenerator.generateRecordsWrite({ author: alice, data: TestDataGenerator.randomBytes(10) });
+        const write2 = await TestDataGenerator.generateRecordsWrite({ author: alice, data: TestDataGenerator.randomBytes(50) });
+        const write3 = await TestDataGenerator.generateRecordsWrite({ author: alice, data: TestDataGenerator.randomBytes(100) });
 
-          // insert data
-          const writeReply1 = await dwn.processMessage(alice.did, write1.message, write1.dataStream);
-          const writeReply2 = await dwn.processMessage(alice.did, write2.message, write2.dataStream);
-          const writeReply3 = await dwn.processMessage(alice.did, write3.message, write3.dataStream);
-          expect(writeReply1.status.code).to.equal(202);
-          expect(writeReply2.status.code).to.equal(202);
-          expect(writeReply3.status.code).to.equal(202);
+        // insert data
+        const writeReply1 = await dwn.processMessage(alice.did, write1.message, write1.dataStream);
+        const writeReply2 = await dwn.processMessage(alice.did, write2.message, write2.dataStream);
+        const writeReply3 = await dwn.processMessage(alice.did, write3.message, write3.dataStream);
+        expect(writeReply1.status.code).to.equal(202);
+        expect(writeReply2.status.code).to.equal(202);
+        expect(writeReply3.status.code).to.equal(202);
 
-          // testing gt
-          const recordsQuery1 = await TestDataGenerator.generateRecordsQuery({
-            author   : alice,
-            filter   : { dataSize: { gt: 10 } },
-          });
-          const reply1 = await dwn.processMessage(alice.did, recordsQuery1.message);
-          expect(reply1.entries?.length).to.equal(2);
-          expect(reply1.entries![0].encodedData).to.equal(Encoder.bytesToBase64Url(write2.dataBytes!));
-          expect(reply1.entries![1].encodedData).to.equal(Encoder.bytesToBase64Url(write3.dataBytes!));
+        // testing gt
+        const recordsQuery1 = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : { dataSize: { gt: 10 } },
+        });
+        const reply1 = await dwn.processMessage(alice.did, recordsQuery1.message);
+        expect(reply1.entries?.length).to.equal(2);
+        expect(reply1.entries![0].encodedData).to.equal(Encoder.bytesToBase64Url(write2.dataBytes!));
+        expect(reply1.entries![1].encodedData).to.equal(Encoder.bytesToBase64Url(write3.dataBytes!));
 
-          // testing lt
-          const recordsQuery2 = await TestDataGenerator.generateRecordsQuery({
-            author   : alice,
-            filter   : { dataSize: { lt: 100 } },
-          });
-          const reply2 = await dwn.processMessage(alice.did, recordsQuery2.message);
-          expect(reply2.entries?.length).to.equal(2);
-          expect(reply2.entries![0].encodedData).to.equal(Encoder.bytesToBase64Url(write1.dataBytes!));
-          expect(reply2.entries![1].encodedData).to.equal(Encoder.bytesToBase64Url(write2.dataBytes!));
+        // testing lt
+        const recordsQuery2 = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : { dataSize: { lt: 100 } },
+        });
+        const reply2 = await dwn.processMessage(alice.did, recordsQuery2.message);
+        expect(reply2.entries?.length).to.equal(2);
+        expect(reply2.entries![0].encodedData).to.equal(Encoder.bytesToBase64Url(write1.dataBytes!));
+        expect(reply2.entries![1].encodedData).to.equal(Encoder.bytesToBase64Url(write2.dataBytes!));
 
-          // testing gte
-          const recordsQuery3 = await TestDataGenerator.generateRecordsQuery({
-            author   : alice,
-            filter   : { dataSize: { gte: 10 } },
-          });
-          const reply3 = await dwn.processMessage(alice.did, recordsQuery3.message);
-          expect(reply3.entries?.length).to.equal(3);
-          expect(reply3.entries![0].encodedData).to.equal(Encoder.bytesToBase64Url(write1.dataBytes!));
-          expect(reply3.entries![1].encodedData).to.equal(Encoder.bytesToBase64Url(write2.dataBytes!));
-          expect(reply3.entries![2].encodedData).to.equal(Encoder.bytesToBase64Url(write3.dataBytes!));
+        // testing gte
+        const recordsQuery3 = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : { dataSize: { gte: 10 } },
+        });
+        const reply3 = await dwn.processMessage(alice.did, recordsQuery3.message);
+        expect(reply3.entries?.length).to.equal(3);
+        expect(reply3.entries![0].encodedData).to.equal(Encoder.bytesToBase64Url(write1.dataBytes!));
+        expect(reply3.entries![1].encodedData).to.equal(Encoder.bytesToBase64Url(write2.dataBytes!));
+        expect(reply3.entries![2].encodedData).to.equal(Encoder.bytesToBase64Url(write3.dataBytes!));
 
-          // testing lte
-          const recordsQuery4 = await TestDataGenerator.generateRecordsQuery({
-            author   : alice,
-            filter   : { dataSize: { lte: 100 } },
-          });
-          const reply4 = await dwn.processMessage(alice.did, recordsQuery4.message);
-          expect(reply4.entries?.length).to.equal(3);
-          expect(reply4.entries![0].encodedData).to.equal(Encoder.bytesToBase64Url(write1.dataBytes!));
-          expect(reply4.entries![1].encodedData).to.equal(Encoder.bytesToBase64Url(write2.dataBytes!));
-          expect(reply4.entries![2].encodedData).to.equal(Encoder.bytesToBase64Url(write3.dataBytes!));
+        // testing lte
+        const recordsQuery4 = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : { dataSize: { lte: 100 } },
+        });
+        const reply4 = await dwn.processMessage(alice.did, recordsQuery4.message);
+        expect(reply4.entries?.length).to.equal(3);
+        expect(reply4.entries![0].encodedData).to.equal(Encoder.bytesToBase64Url(write1.dataBytes!));
+        expect(reply4.entries![1].encodedData).to.equal(Encoder.bytesToBase64Url(write2.dataBytes!));
+        expect(reply4.entries![2].encodedData).to.equal(Encoder.bytesToBase64Url(write3.dataBytes!));
       });
 
       it('should be able to range query with `dataSize` filter (open & closed range)', async () => {
@@ -272,8 +272,8 @@ export function testRecordsQueryHandler(): void {
 
         // testing range using gt & lt
         const recordsQuery1 = await TestDataGenerator.generateRecordsQuery({
-          author   : alice,
-          filter   : { dataSize: { gt: 10, lt: 60 } },
+          author : alice,
+          filter : { dataSize: { gt: 10, lt: 60 } },
         });
         const reply1 = await dwn.processMessage(alice.did, recordsQuery1.message);
         expect(reply1.entries?.length).to.equal(1);
@@ -281,8 +281,8 @@ export function testRecordsQueryHandler(): void {
 
         // testing range using gte & lt
         const recordsQuery2 = await TestDataGenerator.generateRecordsQuery({
-          author   : alice,
-          filter   : { dataSize: { gte: 10, lt: 60 } },
+          author : alice,
+          filter : { dataSize: { gte: 10, lt: 60 } },
         });
         const reply2 = await dwn.processMessage(alice.did, recordsQuery2.message);
         expect(reply2.entries?.length).to.equal(2);
@@ -291,8 +291,8 @@ export function testRecordsQueryHandler(): void {
 
         // testing range using gt & lte
         const recordsQuery3 = await TestDataGenerator.generateRecordsQuery({
-          author   : alice,
-          filter   : { dataSize: { gt: 50, lte: 100 } },
+          author : alice,
+          filter : { dataSize: { gt: 50, lte: 100 } },
         });
         const reply3 = await dwn.processMessage(alice.did, recordsQuery3.message);
         expect(reply3.entries?.length).to.equal(1);
@@ -300,15 +300,15 @@ export function testRecordsQueryHandler(): void {
 
         // testing range using gte & lte
         const recordsQuery4 = await TestDataGenerator.generateRecordsQuery({
-          author   : alice,
-          filter   : { dataSize: { gte: 10, lte: 100 } },
+          author : alice,
+          filter : { dataSize: { gte: 10, lte: 100 } },
         });
         const reply4 = await dwn.processMessage(alice.did, recordsQuery4.message);
         expect(reply4.entries?.length).to.equal(3);
         expect(reply4.entries![0].encodedData).to.equal(Encoder.bytesToBase64Url(write1.dataBytes!));
         expect(reply4.entries![1].encodedData).to.equal(Encoder.bytesToBase64Url(write2.dataBytes!));
         expect(reply4.entries![2].encodedData).to.equal(Encoder.bytesToBase64Url(write3.dataBytes!));
-    });
+      });
 
       it('should be able to range query by `dateCreated`', async () => {
       // scenario: 3 records authored by alice, created on first of 2021, 2022, and 2023 respectively, only the first 2 records share the same schema

--- a/tests/handlers/records-query.spec.ts
+++ b/tests/handlers/records-query.spec.ts
@@ -199,6 +199,117 @@ export function testRecordsQueryHandler(): void {
         expect(reply3.entries?.length).to.equal(0);
       });
 
+      it('should be able to query with `dataSize` filter (half-open range)', async () => {
+          const alice = await DidKeyResolver.generate();
+          const write1 = await TestDataGenerator.generateRecordsWrite({ author: alice, data: TestDataGenerator.randomBytes(10) });
+          const write2 = await TestDataGenerator.generateRecordsWrite({ author: alice, data: TestDataGenerator.randomBytes(50) });
+          const write3 = await TestDataGenerator.generateRecordsWrite({ author: alice, data: TestDataGenerator.randomBytes(100) });
+
+          // insert data
+          const writeReply1 = await dwn.processMessage(alice.did, write1.message, write1.dataStream);
+          const writeReply2 = await dwn.processMessage(alice.did, write2.message, write2.dataStream);
+          const writeReply3 = await dwn.processMessage(alice.did, write3.message, write3.dataStream);
+          expect(writeReply1.status.code).to.equal(202);
+          expect(writeReply2.status.code).to.equal(202);
+          expect(writeReply3.status.code).to.equal(202);
+
+          // testing gt
+          const recordsQuery1 = await TestDataGenerator.generateRecordsQuery({
+            author   : alice,
+            filter   : { dataSize: { gt: 10 } },
+          });
+          const reply1 = await dwn.processMessage(alice.did, recordsQuery1.message);
+          expect(reply1.entries?.length).to.equal(2);
+          expect(reply1.entries![0].encodedData).to.equal(Encoder.bytesToBase64Url(write2.dataBytes!));
+          expect(reply1.entries![1].encodedData).to.equal(Encoder.bytesToBase64Url(write3.dataBytes!));
+
+          // testing lt
+          const recordsQuery2 = await TestDataGenerator.generateRecordsQuery({
+            author   : alice,
+            filter   : { dataSize: { lt: 100 } },
+          });
+          const reply2 = await dwn.processMessage(alice.did, recordsQuery2.message);
+          expect(reply2.entries?.length).to.equal(2);
+          expect(reply2.entries![0].encodedData).to.equal(Encoder.bytesToBase64Url(write1.dataBytes!));
+          expect(reply2.entries![1].encodedData).to.equal(Encoder.bytesToBase64Url(write2.dataBytes!));
+
+          // testing gte
+          const recordsQuery3 = await TestDataGenerator.generateRecordsQuery({
+            author   : alice,
+            filter   : { dataSize: { gte: 10 } },
+          });
+          const reply3 = await dwn.processMessage(alice.did, recordsQuery3.message);
+          expect(reply3.entries?.length).to.equal(3);
+          expect(reply3.entries![0].encodedData).to.equal(Encoder.bytesToBase64Url(write1.dataBytes!));
+          expect(reply3.entries![1].encodedData).to.equal(Encoder.bytesToBase64Url(write2.dataBytes!));
+          expect(reply3.entries![2].encodedData).to.equal(Encoder.bytesToBase64Url(write3.dataBytes!));
+
+          // testing lte
+          const recordsQuery4 = await TestDataGenerator.generateRecordsQuery({
+            author   : alice,
+            filter   : { dataSize: { lte: 100 } },
+          });
+          const reply4 = await dwn.processMessage(alice.did, recordsQuery4.message);
+          expect(reply4.entries?.length).to.equal(3);
+          expect(reply4.entries![0].encodedData).to.equal(Encoder.bytesToBase64Url(write1.dataBytes!));
+          expect(reply4.entries![1].encodedData).to.equal(Encoder.bytesToBase64Url(write2.dataBytes!));
+          expect(reply4.entries![2].encodedData).to.equal(Encoder.bytesToBase64Url(write3.dataBytes!));
+      });
+
+      it('should be able to range query with `dataSize` filter (open & closed range)', async () => {
+        const alice = await DidKeyResolver.generate();
+        const write1 = await TestDataGenerator.generateRecordsWrite({ author: alice, data: TestDataGenerator.randomBytes(10) });
+        const write2 = await TestDataGenerator.generateRecordsWrite({ author: alice, data: TestDataGenerator.randomBytes(50) });
+        const write3 = await TestDataGenerator.generateRecordsWrite({ author: alice, data: TestDataGenerator.randomBytes(100) });
+
+        // insert data
+        const writeReply1 = await dwn.processMessage(alice.did, write1.message, write1.dataStream);
+        const writeReply2 = await dwn.processMessage(alice.did, write2.message, write2.dataStream);
+        const writeReply3 = await dwn.processMessage(alice.did, write3.message, write3.dataStream);
+        expect(writeReply1.status.code).to.equal(202);
+        expect(writeReply2.status.code).to.equal(202);
+        expect(writeReply3.status.code).to.equal(202);
+
+        // testing range using gt & lt
+        const recordsQuery1 = await TestDataGenerator.generateRecordsQuery({
+          author   : alice,
+          filter   : { dataSize: { gt: 10, lt: 60 } },
+        });
+        const reply1 = await dwn.processMessage(alice.did, recordsQuery1.message);
+        expect(reply1.entries?.length).to.equal(1);
+        expect(reply1.entries![0].encodedData).to.equal(Encoder.bytesToBase64Url(write2.dataBytes!));
+
+        // testing range using gte & lt
+        const recordsQuery2 = await TestDataGenerator.generateRecordsQuery({
+          author   : alice,
+          filter   : { dataSize: { gte: 10, lt: 60 } },
+        });
+        const reply2 = await dwn.processMessage(alice.did, recordsQuery2.message);
+        expect(reply2.entries?.length).to.equal(2);
+        expect(reply2.entries![0].encodedData).to.equal(Encoder.bytesToBase64Url(write1.dataBytes!));
+        expect(reply2.entries![1].encodedData).to.equal(Encoder.bytesToBase64Url(write2.dataBytes!));
+
+        // testing range using gt & lte
+        const recordsQuery3 = await TestDataGenerator.generateRecordsQuery({
+          author   : alice,
+          filter   : { dataSize: { gt: 50, lte: 100 } },
+        });
+        const reply3 = await dwn.processMessage(alice.did, recordsQuery3.message);
+        expect(reply3.entries?.length).to.equal(1);
+        expect(reply3.entries![0].encodedData).to.equal(Encoder.bytesToBase64Url(write3.dataBytes!));
+
+        // testing range using gte & lte
+        const recordsQuery4 = await TestDataGenerator.generateRecordsQuery({
+          author   : alice,
+          filter   : { dataSize: { gte: 10, lte: 100 } },
+        });
+        const reply4 = await dwn.processMessage(alice.did, recordsQuery4.message);
+        expect(reply4.entries?.length).to.equal(3);
+        expect(reply4.entries![0].encodedData).to.equal(Encoder.bytesToBase64Url(write1.dataBytes!));
+        expect(reply4.entries![1].encodedData).to.equal(Encoder.bytesToBase64Url(write2.dataBytes!));
+        expect(reply4.entries![2].encodedData).to.equal(Encoder.bytesToBase64Url(write3.dataBytes!));
+    });
+
       it('should be able to range query by `dateCreated`', async () => {
       // scenario: 3 records authored by alice, created on first of 2021, 2022, and 2023 respectively, only the first 2 records share the same schema
         const firstDayOf2021 = createDateString(new Date(2021, 1, 1));


### PR DESCRIPTION
This commit fixes #525.  It adds `dataSize` optional property in RecordsFilter.

It adds a new json schema definition number-range-filter with properties gt, lt, gte, and lte.

Also adds new tests to cover half-open, open, and closed range queries.