### PR TITLE
Add protocol update action

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here's to a thrilling Hacktoberfest voyage with us! 🎉
 # Decentralized Web Node (DWN) SDK <!-- omit in toc -->
 
 Code Coverage
-![Statements](https://img.shields.io/badge/statements-98.47%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.61%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.68%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.47%25-brightgreen.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-98.47%25-brightgreen.svg?style=flat) ![Branches](https://img.shields.io/badge/branches-95.62%25-brightgreen.svg?style=flat) ![Functions](https://img.shields.io/badge/functions-95.7%25-brightgreen.svg?style=flat) ![Lines](https://img.shields.io/badge/lines-98.47%25-brightgreen.svg?style=flat)
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/json-schemas/interface-methods/protocol-rule-set.json
+++ b/json-schemas/interface-methods/protocol-rule-set.json
@@ -44,6 +44,7 @@
                 "type": "string",
                 "enum": [
                   "read",
+                  "update",
                   "write"
                 ]
               }
@@ -63,6 +64,7 @@
                 "type": "string",
                 "enum": [
                   "read",
+                  "update",
                   "write"
                 ]
               }

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -328,7 +328,10 @@ export class ProtocolAuthorization {
     }
   }
 
-  private static async getInboundMessageActions(
+  /**
+   * Returns a list of ProtocolAction(s) based on the incoming message, one of which must be allowed for the message to be authorized.
+   */
+  private static async getActionsSeekingARuleMatch(
     tenant: string,
     incomingMessage: RecordsRead | RecordsWrite,
     messageStore: MessageStore,
@@ -342,7 +345,7 @@ export class ProtocolAuthorization {
     if (await incomingRecordsWrite.isInitialWrite()) {
       // only 'write' allows initial RecordsWrites; 'update' only applies to subsequent RecordsWrites
       return [ProtocolAction.Write];
-    } else if (await incomingRecordsWrite.authoredByInitialRecordAuthor(tenant, messageStore)) {
+    } else if (await incomingRecordsWrite.isAuthoredByInitialRecordAuthor(tenant, messageStore)) {
       // Both 'update' and 'write' authorize the incoming message
       return [ProtocolAction.Write, ProtocolAction.Update];
     } else {
@@ -363,7 +366,7 @@ export class ProtocolAuthorization {
     messageStore: MessageStore,
   ): Promise<void> {
     const incomingMessageMethod = incomingMessage.message.descriptor.method;
-    const inboundMessageActions = await ProtocolAuthorization.getInboundMessageActions(tenant, incomingMessage, messageStore);
+    const inboundMessageActions = await ProtocolAuthorization.getActionsSeekingARuleMatch(tenant, incomingMessage, messageStore);
     const author = incomingMessage.author;
     const actionRules = inboundMessageRuleSet.$actions;
 

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -6,9 +6,8 @@ import type { ProtocolActionRule, ProtocolDefinition, ProtocolRuleSet, Protocols
 
 import { RecordsWrite } from '../interfaces/records-write.js';
 import { DwnError, DwnErrorCode } from './dwn-error.js';
-import { DwnInterfaceName, DwnMethodName, Message } from './message.js';
+import { DwnInterfaceName, DwnMethodName } from './message.js';
 import { ProtocolAction, ProtocolActor } from '../types/protocols-types.js';
-import type { RecordsDelete } from '../index.js';
 
 export class ProtocolAuthorization {
 

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -8,11 +8,7 @@ import { RecordsWrite } from '../interfaces/records-write.js';
 import { DwnError, DwnErrorCode } from './dwn-error.js';
 import { DwnInterfaceName, DwnMethodName, Message } from './message.js';
 import { ProtocolAction, ProtocolActor } from '../types/protocols-types.js';
-
-const methodToAllowedActionMap: Record<string, ProtocolAction> = {
-  [DwnMethodName.Write] : ProtocolAction.Write,
-  [DwnMethodName.Read]  : ProtocolAction.Read,
-};
+import type { RecordsDelete } from '../index.js';
 
 export class ProtocolAuthorization {
 
@@ -100,13 +96,12 @@ export class ProtocolAuthorization {
 
     // verify method invoked against the allowed actions
     await ProtocolAuthorization.verifyAllowedActions(
+      tenant,
       incomingMessage,
       inboundMessageRuleSet,
       ancestorMessageChain,
+      messageStore,
     );
-
-    // verify allowed condition of incoming message
-    await ProtocolAuthorization.verifyActionCondition(tenant, incomingMessage, messageStore);
   }
 
   /**
@@ -333,17 +328,42 @@ export class ProtocolAuthorization {
     }
   }
 
+  private static async getInboundMessageActions(
+    tenant: string,
+    incomingMessage: RecordsRead | RecordsWrite,
+    messageStore: MessageStore,
+  ): Promise<ProtocolAction[]> {
+    if (incomingMessage.message.descriptor.method === DwnMethodName.Read) {
+      return [ProtocolAction.Read];
+    }
+    // else 'Write'
+
+    const incomingRecordsWrite = incomingMessage as RecordsWrite;
+    if (await incomingRecordsWrite.isInitialWrite()) {
+      // only 'write' allows initial RecordsWrites; 'update' only applies to subsequent RecordsWrites
+      return [ProtocolAction.Write];
+    } else if (await incomingRecordsWrite.authoredByInitialRecordAuthor(tenant, messageStore)) {
+      // Both 'update' and 'write' authorize the incoming message
+      return [ProtocolAction.Write, ProtocolAction.Update];
+    } else {
+      // Actors other than the initial record author must be authorized to 'update' the message
+      return [ProtocolAction.Update];
+    }
+  }
+
   /**
    * Verifies the action (e.g. read/write) specified in the given message matches the allowed actions in the rule set.
    * @throws {Error} if action not allowed.
    */
   private static async verifyAllowedActions(
+    tenant: string,
     incomingMessage: RecordsRead | RecordsWrite,
     inboundMessageRuleSet: ProtocolRuleSet,
     ancestorMessageChain: RecordsWriteMessage[],
+    messageStore: MessageStore,
   ): Promise<void> {
     const incomingMessageMethod = incomingMessage.message.descriptor.method;
-    const inboundMessageAction = methodToAllowedActionMap[incomingMessageMethod];
+    const inboundMessageActions = await ProtocolAuthorization.getInboundMessageActions(tenant, incomingMessage, messageStore);
     const author = incomingMessage.author;
     const actionRules = inboundMessageRuleSet.$actions;
 
@@ -355,7 +375,7 @@ export class ProtocolAuthorization {
     const invokedRole = incomingMessage.authorSignaturePayload?.protocolRole;
 
     for (const actionRule of actionRules) {
-      if (actionRule.can !== inboundMessageAction) {
+      if (!inboundMessageActions.includes(actionRule.can as ProtocolAction)) {
         continue;
       }
 
@@ -380,7 +400,7 @@ export class ProtocolAuthorization {
     }
 
     // No action rules were satisfied, author is not authorized
-    throw new DwnError(DwnErrorCode.ProtocolAuthorizationActionNotAllowed, `inbound message action ${inboundMessageAction} not allowed for author`);
+    throw new DwnError(DwnErrorCode.ProtocolAuthorizationActionNotAllowed, `inbound message action not allowed for author`);
   }
 
   /**
@@ -434,33 +454,6 @@ export class ProtocolAuthorization {
           DwnErrorCode.ProtocolAuthorizationDuplicateContextRoleRecipient,
           `DID '${recipient}' is already recipient of a $contextRole record at protocol path '${protocolPath} in the same context`
         );
-      }
-    }
-  }
-
-  /**
-   * Verifies if the desired action can be taken.
-   * Currently the only check is: if the write is not the initial write, the author must be the same as the initial write
-   * @throws {Error} if fails verification
-   */
-  private static async verifyActionCondition(tenant: string, incomingMessage: RecordsRead | RecordsWrite, messageStore: MessageStore): Promise<void> {
-    // Currently no conditions for methods other than Write
-    if (incomingMessage.message.descriptor.method === DwnMethodName.Write) {
-      const recordsWrite = incomingMessage as RecordsWrite;
-      const isInitialWrite = await recordsWrite.isInitialWrite();
-      if (!isInitialWrite) {
-        // fetch the initialWrite
-        const query = {
-          entryId: recordsWrite.message.recordId
-        };
-        const { messages: result } = await messageStore.query(tenant, [ query ]);
-
-        // check the author of the initial write matches the author of the incoming message
-        const initialWrite = result[0] as RecordsWriteMessage;
-        const authorOfInitialWrite = Message.getAuthor(initialWrite);
-        if (recordsWrite.author !== authorOfInitialWrite) {
-          throw new Error(`author of incoming message '${recordsWrite.author}' must match to author of initial write '${authorOfInitialWrite}'`);
-        }
       }
     }
   }

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -604,7 +604,11 @@ export class RecordsWrite {
     return (entryId === this.message.recordId);
   }
 
-  public async authoredByInitialRecordAuthor(tenant: string, messageStore: MessageStore): Promise<boolean> {
+  /**
+   * Checks if the author of the RecordsWrite is the same as the author of the initial RecordsWrite for the record.
+   * Returns true if `this` is the initial RecordsWrite.
+   */
+  public async isAuthoredByInitialRecordAuthor(tenant: string, messageStore: MessageStore): Promise<boolean> {
     // fetch the initialWrite
     const query = {
       entryId: this.message.recordId

--- a/src/types/protocols-types.ts
+++ b/src/types/protocols-types.ts
@@ -39,6 +39,7 @@ export enum ProtocolActor {
 
 export enum ProtocolAction {
   Read = 'read',
+  Update = 'update',
   Write = 'write'
 }
 

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -47,7 +47,6 @@ import { TestStubGenerator } from '../utils/test-stub-generator.js';
 import { DwnConstant, KeyDerivationScheme, RecordsDelete } from '../../src/index.js';
 import { DwnInterfaceName, DwnMethodName, Message } from '../../src/core/message.js';
 import { Encryption, EncryptionAlgorithm } from '../../src/utils/encryption.js';
-import { ProtocolAuthorization } from '../../src/core/protocol-authorization.js';
 
 chai.use(chaiAsPromised);
 

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -135,6 +135,7 @@ export type GenerateFromRecordsWriteInput = {
   published?: boolean;
   messageTimestamp?: string;
   datePublished?: string;
+  protocolRole?: string;
 };
 
 export type GenerateFromRecordsWriteOut = {
@@ -574,6 +575,7 @@ export class TestDataGenerator {
       published,
       datePublished,
       messageTimestamp    : input.messageTimestamp,
+      protocolRole        : input.protocolRole,
       authorizationSigner : Jws.createSigner(input.author)
     };
 

--- a/tests/vectors/protocol-definitions/anyone-collaborate.json
+++ b/tests/vectors/protocol-definitions/anyone-collaborate.json
@@ -1,0 +1,21 @@
+{
+  "protocol": "http://anyone-collaborate-protocol.xyz",
+  "published": true,
+  "types": {
+    "doc": {}
+  },
+  "structure": {
+    "doc": {
+      "$actions": [
+        {
+          "who": "anyone",
+          "can": "update"
+        },
+        {
+          "who": "anyone",
+          "can": "read"
+        }
+      ]
+    }
+  }
+}

--- a/tests/vectors/protocol-definitions/author-update.json
+++ b/tests/vectors/protocol-definitions/author-update.json
@@ -1,5 +1,5 @@
 {
-  "protocol": "http://recipient-update-protocol.xyz",
+  "protocol": "http://author-update-protocol.xyz",
   "published": true,
   "types": {
     "post": {},

--- a/tests/vectors/protocol-definitions/author-update.json
+++ b/tests/vectors/protocol-definitions/author-update.json
@@ -1,0 +1,27 @@
+{
+  "protocol": "http://recipient-update-protocol.xyz",
+  "published": true,
+  "types": {
+    "post": {},
+    "comment": {}
+  },
+  "structure": {
+    "post": {
+      "$actions": [
+        {
+          "who": "anyone",
+          "can": "write"
+        }
+      ],
+      "comment": {
+        "$actions": [
+          {
+            "who": "author",
+            "of": "post",
+            "can": "update"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/vectors/protocol-definitions/friend-role.json
+++ b/tests/vectors/protocol-definitions/friend-role.json
@@ -3,9 +3,13 @@
   "published": false,
   "types": {
     "friend": {},
+    "admin": {},
     "chat": {}
   },
   "structure": {
+    "admin": {
+      "$globalRole": true
+    },
     "friend": {
       "$globalRole": true
     },
@@ -25,6 +29,10 @@
         {
           "role": "friend",
           "can": "read"
+        },
+        {
+          "role": "admin",
+          "can": "update"
         }
       ]
     }

--- a/tests/vectors/protocol-definitions/recipient-update.json
+++ b/tests/vectors/protocol-definitions/recipient-update.json
@@ -1,0 +1,21 @@
+{
+  "protocol": "http://recipient-update-protocol.xyz",
+  "published": true,
+  "types": {
+    "post": {},
+    "tag": {}
+  },
+  "structure": {
+    "post": {
+      "tag": {
+        "$actions": [
+          {
+            "who": "recipient",
+            "of": "post",
+            "can": "update"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/vectors/protocol-definitions/thread-role.json
+++ b/tests/vectors/protocol-definitions/thread-role.json
@@ -4,6 +4,7 @@
   "types": {
     "thread": {},
     "participant": {},
+    "admin": {},
     "chat": {}
   },
   "structure": {
@@ -14,6 +15,9 @@
           "can": "read"
         }
       ],
+      "admin": {
+        "$contextRole": true
+      },
       "participant": {
         "$contextRole": true,
         "$actions": [
@@ -36,6 +40,10 @@
           {
             "role": "thread/participant",
             "can": "write"
+          },
+          {
+            "role": "thread/admin",
+            "can": "update"
           }
         ]
       }


### PR DESCRIPTION
The `update` action allows an actor to update an existing record. This contrasts with the `write` action which allows only the creator of a record to update it. In other words:
1. `write` allows a DID to create a record and update the record they have created
2. `update` allows a DID to update a record, regardless of initial author