### PR TITLE
Support protocol authorized RecordsDelete

### DIFF
--- a/json-schemas/interface-methods/protocol-rule-set.json
+++ b/json-schemas/interface-methods/protocol-rule-set.json
@@ -43,6 +43,7 @@
               "can": {
                 "type": "string",
                 "enum": [
+                  "delete",
                   "read",
                   "update",
                   "write"
@@ -63,6 +64,7 @@
               "can": {
                 "type": "string",
                 "enum": [
+                  "delete",
                   "query",
                   "read",
                   "update",

--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -61,6 +61,8 @@ export enum DwnErrorCode {
   ProtocolsConfigureUnauthorized = 'ProtocolsConfigureUnauthorized',
   ProtocolsQueryUnauthorized = 'ProtocolsQueryUnauthorized',
   RecordsDecryptNoMatchingKeyEncryptedFound = 'RecordsDecryptNoMatchingKeyEncryptedFound',
+  RecordsDeleteAuthorizationFailed = 'RecordsDeleteAuthorizationFailed',
+
   RecordsGrantAuthorizationConditionPublicationProhibited = 'RecordsGrantAuthorizationConditionPublicationProhibited',
   RecordsGrantAuthorizationConditionPublicationRequired = 'RecordsGrantAuthorizationConditionPublicationRequired',
   RecordsGrantAuthorizationScopeContextIdMismatch = 'RecordsGrantAuthorizationScopeContextIdMismatch',

--- a/src/interfaces/records-delete.ts
+++ b/src/interfaces/records-delete.ts
@@ -8,6 +8,7 @@ import { Message } from '../core/message.js';
 
 import { ProtocolAuthorization } from '../core/protocol-authorization.js';
 import { validateMessageSignatureIntegrity } from '../core/auth.js';
+import { DwnError, DwnErrorCode } from '../index.js';
 import { DwnInterfaceName, DwnMethodName } from '../core/message.js';
 
 export type RecordsDeleteOptions = {
@@ -60,7 +61,10 @@ export class RecordsDelete extends Message<RecordsDeleteMessage> {
     } else if (newestRecordsWrite.message.descriptor.protocol !== undefined) {
       await ProtocolAuthorization.authorizeDelete(tenant, this, newestRecordsWrite, messageStore);
     } else {
-      throw new Error('message failed authorization');
+      throw new DwnError(
+        DwnErrorCode.RecordsDeleteAuthorizationFailed,
+        'RecordsDelete message failed authorization'
+      );
     }
   }
 }

--- a/src/types/protocols-types.ts
+++ b/src/types/protocols-types.ts
@@ -38,6 +38,7 @@ export enum ProtocolActor {
 }
 
 export enum ProtocolAction {
+  Delete = 'delete',
   Query = 'query',
   Read = 'read',
   Update = 'update',

--- a/tests/handlers/records-delete.spec.ts
+++ b/tests/handlers/records-delete.spec.ts
@@ -1,12 +1,18 @@
 import type {
   DataStore,
   EventLog,
-  MessageStore
+  MessageStore,
+  ProtocolDefinition
 } from '../../src/index.js';
 
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
+
+import anyoneCollaborateProtocolDefinition from '../vectors/protocol-definitions/anyone-collaborate.json' assert { type: 'json' };
+import authorCanProtocolDefinition from '../vectors/protocol-definitions/author-can.json' assert { type: 'json' };
+import friendRoleProtocolDefinition from '../vectors/protocol-definitions/friend-role.json' assert { type: 'json' };
+import threadRoleProtocolDefinition from '../vectors/protocol-definitions/thread-role.json' assert { type: 'json' };
 
 import { ArrayUtility } from '../../src/utils/array.js';
 import { DidKeyResolver } from '../../src/did/did-key-resolver.js';
@@ -280,6 +286,208 @@ export function testRecordsDeleteHandler(): void {
         expect(aliceQueryWriteAfterAliceRewriteReply.status.code).to.equal(200);
         expect(aliceQueryWriteAfterAliceRewriteReply.entries?.length).to.equal(1);
         expect(aliceQueryWriteAfterAliceRewriteReply.entries![0].encodedData).to.equal(encodedData);
+      });
+
+      describe('protocol based deletes', () => {
+        it('should allow delete with allow-anyone rule', async () => {
+          // scenario: Alice creates a record in her DWN. Bob (anyone) is able to delete the record.
+
+          const protocolDefinition = anyoneCollaborateProtocolDefinition as ProtocolDefinition;
+          const alice = await TestDataGenerator.generatePersona();
+          const bob = await TestDataGenerator.generatePersona();
+
+          const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
+            author: alice,
+            protocolDefinition
+          });
+
+          // setting up a stub DID resolver
+          TestStubGenerator.stubDidResolver(didResolver, [alice, bob]);
+
+          const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message);
+          expect(protocolsConfigureReply.status.code).to.equal(202);
+
+          // Alice writes a record
+          const recordsWrite = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            protocol     : protocolDefinition.protocol,
+            protocolPath : 'doc',
+          });
+          const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, recordsWrite.dataStream);
+          expect(recordsWriteReply.status.code).to.eq(202);
+
+          // Bob (anyone) is able to delete the record
+          const recordsDelete = await TestDataGenerator.generateRecordsDelete({
+            author   : bob,
+            recordId : recordsWrite.message.recordId,
+          });
+          const recordsDeleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
+          expect(recordsDeleteReply.status.code).to.eq(202);
+        });
+
+        describe('recipient rules', () => {
+          it('should allow delete with ancestor recipient rule', async () => {
+            // scenario: Alice creates a record
+          });
+        });
+
+        describe('author action rules', () => {
+          it('allow author to delete with ancestor author rule', async () => {
+            // scenario: Bob writes a 'post' and Alice writes a 'post/comment' to her DWN. Bob deletes the comment
+            //           because author of post can delete.
+
+            const protocolDefinition = authorCanProtocolDefinition as ProtocolDefinition;
+            const alice = await TestDataGenerator.generatePersona();
+            const bob = await TestDataGenerator.generatePersona();
+
+            const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
+              author: alice,
+              protocolDefinition
+            });
+
+            // setting up a stub DID resolver
+            TestStubGenerator.stubDidResolver(didResolver, [alice, bob]);
+
+            const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message);
+            expect(protocolsConfigureReply.status.code).to.equal(202);
+
+            // Bob writes a post
+            const postRecordsWrite = await TestDataGenerator.generateRecordsWrite({
+              author       : bob,
+              protocol     : protocolDefinition.protocol,
+              protocolPath : 'post',
+            });
+            const postRecordsWriteReply = await dwn.processMessage(alice.did, postRecordsWrite.message, postRecordsWrite.dataStream);
+            expect(postRecordsWriteReply.status.code).to.eq(202);
+
+            // Alice writes a 'post/comment'
+            const commentRecordsWrite = await TestDataGenerator.generateRecordsWrite({
+              author       : alice,
+              protocol     : protocolDefinition.protocol,
+              protocolPath : 'post/comment',
+              contextId    : postRecordsWrite.message.contextId,
+              parentId     : postRecordsWrite.message.recordId,
+            });
+            const commentRecordsWriteReply = await dwn.processMessage(alice.did, commentRecordsWrite.message, commentRecordsWrite.dataStream);
+            expect(commentRecordsWriteReply.status.code).to.eq(202);
+
+            // Bob is able to delete the Alice's 'post/comment'
+            const recordsDelete = await TestDataGenerator.generateRecordsDelete({
+              author   : bob,
+              recordId : commentRecordsWrite.message.recordId,
+            });
+            const recordsDeleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
+            expect(recordsDeleteReply.status.code).to.eq(202);
+          });
+        });
+
+        describe('role based deletes', () => {
+          it('should allow deletes with $contextRole', async () => {
+            // scenario: Alice adds Bob as a 'thread/admin' $contextRole. She writes a 'thread/chat'.
+            //           Bob invokes his admin role to delete the 'thread/chat'.
+
+            const alice = await DidKeyResolver.generate();
+            const bob = await DidKeyResolver.generate();
+
+            const protocolDefinition = threadRoleProtocolDefinition;
+
+            const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
+              author: alice,
+              protocolDefinition
+            });
+            const protocolWriteReply = await dwn.processMessage(alice.did, protocolsConfig.message);
+            expect(protocolWriteReply.status.code).to.equal(202);
+
+            // Alice creates a thread
+            const threadRecord = await TestDataGenerator.generateRecordsWrite({
+              author       : alice,
+              recipient    : bob.did,
+              protocol     : protocolDefinition.protocol,
+              protocolPath : 'thread'
+            });
+            const threadRecordReply = await dwn.processMessage(alice.did, threadRecord.message, threadRecord.dataStream);
+            expect(threadRecordReply.status.code).to.equal(202);
+
+            // Alice adds Bob as a 'thread/admin' in that thread
+            const participantRecord = await TestDataGenerator.generateRecordsWrite({
+              author       : alice,
+              recipient    : bob.did,
+              protocol     : protocolDefinition.protocol,
+              protocolPath : 'thread/admin',
+              contextId    : threadRecord.message.contextId,
+              parentId     : threadRecord.message.recordId,
+            });
+            const participantRecordReply = await dwn.processMessage(alice.did, participantRecord.message, participantRecord.dataStream);
+            expect(participantRecordReply.status.code).to.equal(202);
+
+            // Alice writes a chat message in that thread
+            const chatRecord = await TestDataGenerator.generateRecordsWrite({
+              author       : alice,
+              recipient    : alice.did,
+              protocol     : protocolDefinition.protocol,
+              protocolPath : 'thread/chat',
+              contextId    : threadRecord.message.contextId,
+              parentId     : threadRecord.message.recordId,
+            });
+            const chatRecordReply = await dwn.processMessage(alice.did, chatRecord.message, chatRecord.dataStream);
+            expect(chatRecordReply.status.code).to.equal(202);
+
+            // Bob invokes the role to delete the chat message
+            const chatDelete = await TestDataGenerator.generateRecordsDelete({
+              author       : bob,
+              recordId     : chatRecord.message.recordId,
+              protocolRole : 'thread/admin',
+            });
+            const chatDeleteReply = await dwn.processMessage(alice.did, chatDelete.message);
+            expect(chatDeleteReply.status.code).to.equal(202);
+          });
+
+          it('should allow delete with $globalRole', async () => {
+            // scenario: Alice adds Bob as an 'admin' $globalRole. She writes a 'chat'.
+            //           Bob invokes his admin role to delete the 'chat'.
+
+            const alice = await DidKeyResolver.generate();
+            const bob = await DidKeyResolver.generate();
+
+            const protocolDefinition = friendRoleProtocolDefinition;
+
+            const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
+              author: alice,
+              protocolDefinition
+            });
+            const protocolWriteReply = await dwn.processMessage(alice.did, protocolsConfig.message);
+            expect(protocolWriteReply.status.code).to.equal(202);
+
+            // Alice adds Bob as a 'thread/admin' in that thread
+            const participantRecord = await TestDataGenerator.generateRecordsWrite({
+              author       : alice,
+              recipient    : bob.did,
+              protocol     : protocolDefinition.protocol,
+              protocolPath : 'admin',
+            });
+            const participantRecordReply = await dwn.processMessage(alice.did, participantRecord.message, participantRecord.dataStream);
+            expect(participantRecordReply.status.code).to.equal(202);
+
+            // Alice writes a chat message in that thread
+            const chatRecord = await TestDataGenerator.generateRecordsWrite({
+              author       : alice,
+              recipient    : alice.did,
+              protocol     : protocolDefinition.protocol,
+              protocolPath : 'chat',
+            });
+            const chatRecordReply = await dwn.processMessage(alice.did, chatRecord.message, chatRecord.dataStream);
+            expect(chatRecordReply.status.code).to.equal(202);
+
+            // Bob invokes the role to delete the chat message
+            const chatDelete = await TestDataGenerator.generateRecordsDelete({
+              author       : bob,
+              recordId     : chatRecord.message.recordId,
+              protocolRole : 'admin',
+            });
+            const chatDeleteReply = await dwn.processMessage(alice.did, chatDelete.message);
+            expect(chatDeleteReply.status.code).to.equal(202);
+          });
+        });
       });
 
       describe('event log', () => {

--- a/tests/handlers/records-delete.spec.ts
+++ b/tests/handlers/records-delete.spec.ts
@@ -503,8 +503,8 @@ export function testRecordsDeleteHandler(): void {
         expect(recordsWriteReply.status.code).to.equal(202);
 
         const recordsDelete = await TestDataGenerator.generateRecordsDelete({
-          author: bob,
-          recordId: recordsWrite.message.recordId,
+          author   : bob,
+          recordId : recordsWrite.message.recordId,
         });
         const recordsDeleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
         expect(recordsDeleteReply.status.code).to.equal(401);

--- a/tests/handlers/records-delete.spec.ts
+++ b/tests/handlers/records-delete.spec.ts
@@ -560,8 +560,8 @@ export function testRecordsDeleteHandler(): void {
 
             // Carol is unable to delete the chat message
             const chatDeleteCarol = await TestDataGenerator.generateRecordsDelete({
-              author       : carol,
-              recordId     : chatRecord.message.recordId,
+              author   : carol,
+              recordId : chatRecord.message.recordId,
             });
             const chatDeleteCarolReply = await dwn.processMessage(alice.did, chatDeleteCarol.message);
             expect(chatDeleteCarolReply.status.code).to.equal(401);

--- a/tests/handlers/records-delete.spec.ts
+++ b/tests/handlers/records-delete.spec.ts
@@ -597,7 +597,7 @@ export function testRecordsDeleteHandler(): void {
         });
         const recordsDeleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
         expect(recordsDeleteReply.status.code).to.equal(401);
-        expect(recordsDeleteReply.status.detail).to.contain('message failed authorization');
+        expect(recordsDeleteReply.status.detail).to.contain(DwnErrorCode.RecordsDeleteAuthorizationFailed);
       });
 
       describe('event log', () => {

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -16,7 +16,7 @@ import friendRoleProtocolDefinition from '../vectors/protocol-definitions/friend
 import messageProtocolDefinition from '../vectors/protocol-definitions/message.json' assert { type: 'json' };
 import minimalProtocolDefinition from '../vectors/protocol-definitions/minimal.json' assert { type: 'json' };
 import privateProtocol from '../vectors/protocol-definitions/private-protocol.json' assert { type: 'json' };
-import recipientUpdateProtocol from '../vectors/protocol-definitions/recipient-update.json' assert { type: 'json' };
+import recipientCanProtocol from '../vectors/protocol-definitions/recipient-can.json' assert { type: 'json' };
 import sinon from 'sinon';
 import socialMediaProtocolDefinition from '../vectors/protocol-definitions/social-media.json' assert { type: 'json' };
 import threadRoleProtocolDefinition from '../vectors/protocol-definitions/thread-role.json' assert { type: 'json' };
@@ -1179,7 +1179,7 @@ export function testRecordsWriteHandler(): void {
             const alice = await DidKeyResolver.generate();
             const bob = await DidKeyResolver.generate();
 
-            const protocolDefinition = recipientUpdateProtocol;
+            const protocolDefinition = recipientCanProtocol;
 
             const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
               author: alice,

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -7,7 +7,7 @@ import type { RecordsWriteMessageWithOptionalEncodedData } from '../../src/store
 import type { DataStore, EventLog, MessageStore } from '../../src/index.js';
 
 import anyoneCollaborateProtocolDefinition from '../vectors/protocol-definitions/anyone-collaborate.json' assert { type: 'json' };
-import authorUpdateProtocolDefinition from '../vectors/protocol-definitions/author-update.json' assert { type: 'json' };
+import authorCanProtocolDefinition from '../vectors/protocol-definitions/author-can.json' assert { type: 'json' };
 import chaiAsPromised from 'chai-as-promised';
 import credentialIssuanceProtocolDefinition from '../vectors/protocol-definitions/credential-issuance.json' assert { type: 'json' };
 import dexProtocolDefinition from '../vectors/protocol-definitions/dex.json' assert { type: 'json' };
@@ -1321,7 +1321,7 @@ export function testRecordsWriteHandler(): void {
             const alice = await DidKeyResolver.generate();
             const bob = await DidKeyResolver.generate();
 
-            const protocolDefinition = authorUpdateProtocolDefinition;
+            const protocolDefinition = authorCanProtocolDefinition;
 
             const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
               author: alice,

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -176,6 +176,7 @@ export type GenerateRecordsQueryOutput = {
 export type GenerateRecordsDeleteInput = {
   author?: Persona;
   recordId?: string;
+  protocolRole?: string;
 };
 
 export type GenerateRecordsDeleteOutput = {
@@ -637,6 +638,7 @@ export class TestDataGenerator {
 
     const recordsDelete = await RecordsDelete.create({
       recordId            : input?.recordId ?? await TestDataGenerator.randomCborSha256Cid(),
+      protocolRole        : input?.protocolRole,
       authorizationSigner : Jws.createSigner(author)
     });
 

--- a/tests/vectors/protocol-definitions/author-can.json
+++ b/tests/vectors/protocol-definitions/author-can.json
@@ -1,5 +1,5 @@
 {
-  "protocol": "http://author-update-protocol.xyz",
+  "protocol": "http://author-can-protocol.xyz",
   "published": true,
   "types": {
     "post": {},
@@ -19,6 +19,11 @@
             "who": "author",
             "of": "post",
             "can": "update"
+          },
+          {
+            "who": "author",
+            "of": "post",
+            "can": "delete"
           }
         ]
       }

--- a/tests/vectors/protocol-definitions/free-for-all.json
+++ b/tests/vectors/protocol-definitions/free-for-all.json
@@ -1,23 +1,28 @@
 {
-  "protocol": "http://anyone-collaborate-protocol.xyz",
+  "protocol": "http://free-for-all-protocol.xyz",
   "published": true,
   "types": {
-    "doc": {}
+    "post": {
+      "schema": "eph",
+      "dataFormats": [
+        "application/json"
+      ]
+    }
   },
   "structure": {
-    "doc": {
+    "post": {
       "$actions": [
         {
           "who": "anyone",
-          "can": "update"
-        },
-        {
-          "who": "anyone",
-          "can": "read"
+          "can": "write"
         },
         {
           "who": "anyone",
           "can": "delete"
+        },
+        {
+          "who": "anyone",
+          "can": "read"
         }
       ]
     }

--- a/tests/vectors/protocol-definitions/friend-role.json
+++ b/tests/vectors/protocol-definitions/friend-role.json
@@ -37,6 +37,10 @@
         {
           "role": "admin",
           "can": "update"
+        },
+        {
+          "role": "admin",
+          "can": "delete"
         }
       ]
     }

--- a/tests/vectors/protocol-definitions/post-comment.json
+++ b/tests/vectors/protocol-definitions/post-comment.json
@@ -1,0 +1,45 @@
+{
+  "protocol": "http://post-comment-protocol.xyz",
+  "published": true,
+  "types": {
+    "post": {
+      "schema": "post",
+      "dataFormats": [
+        "application/json"
+      ]
+    },
+    "comment": {
+      "schema": "comment",
+      "dataFormats": [
+        "application/json"
+      ]
+    }
+  },
+  "structure": {
+    "post": {
+      "$actions": [
+        {
+          "who": "anyone",
+          "can": "read"
+        }
+      ],
+      "comment": {
+        "$actions": [
+          {
+            "who": "anyone",
+            "can": "read"
+          },
+          {
+            "who": "anyone",
+            "can": "write"
+          },
+          {
+            "who": "author",
+            "of": "post",
+            "can": "delete"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/vectors/protocol-definitions/recipient-can.json
+++ b/tests/vectors/protocol-definitions/recipient-can.json
@@ -1,5 +1,5 @@
 {
-  "protocol": "http://recipient-update-protocol.xyz",
+  "protocol": "http://recipient-can-protocol.xyz",
   "published": true,
   "types": {
     "post": {},
@@ -13,6 +13,11 @@
             "who": "recipient",
             "of": "post",
             "can": "update"
+          },
+          {
+            "who": "recipient",
+            "of": "post",
+            "can": "delete"
           }
         ]
       }

--- a/tests/vectors/protocol-definitions/thread-role.json
+++ b/tests/vectors/protocol-definitions/thread-role.json
@@ -48,6 +48,10 @@
           {
             "role": "thread/admin",
             "can": "update"
+          },
+          {
+            "role": "thread/admin",
+            "can": "delete"
           }
         ]
       }


### PR DESCRIPTION
Addresses #557. Support protocol authorized deletes for both actors (`author`, `recipient`, `anyone`) and roles (`$globalRole`, `$contextRole`).