### PR TITLE
Add missing filters to RecordsQuery

### DIFF
--- a/json-schemas/interface-methods/records-filter.json
+++ b/json-schemas/interface-methods/records-filter.json
@@ -66,6 +66,19 @@
           "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
         }
       }
+    },
+    "dateUpdated": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "from": {
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+        },
+        "to": {
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+        }
+      }
     }
   }
 }

--- a/json-schemas/interface-methods/records-filter.json
+++ b/json-schemas/interface-methods/records-filter.json
@@ -29,11 +29,17 @@
     "parentId": {
       "type": "string"
     },
+    "published": {
+      "type": "boolean"
+    },
     "dataFormat": {
       "type": "string"
     },
     "dataSize": {
       "$ref": "https://identity.foundation/dwn/json-schemas/number-range-filter.json"
+    },
+    "dataCid": {
+      "type": "string"
     },
     "dateCreated": {
       "type": "object",

--- a/json-schemas/interface-methods/records-filter.json
+++ b/json-schemas/interface-methods/records-filter.json
@@ -80,5 +80,24 @@
         }
       }
     }
+  },
+  "dependencies": {
+    "datePublished": {
+      "oneOf": [
+        {
+          "properties": {
+            "published": {
+              "enum": [true]
+            }
+          },
+          "required": ["published"]
+        },
+        {
+          "not": {
+            "required": ["published"]
+          }
+        }
+      ]
+    }
   }
 }

--- a/json-schemas/interface-methods/records-filter.json
+++ b/json-schemas/interface-methods/records-filter.json
@@ -53,6 +53,19 @@
           "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
         }
       }
+    },
+    "datePublished": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "from": {
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+        },
+        "to": {
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+        }
+      }
     }
   }
 }

--- a/src/handlers/records-query.ts
+++ b/src/handlers/records-query.ts
@@ -30,7 +30,7 @@ export class RecordsQueryHandler implements MethodHandler {
 
     let recordsWrites: RecordsWriteMessageWithOptionalEncodedData[];
     let paginationMessageCid: string|undefined;
-    // if this is an anonymous query and there is no explicit published filter set to false, query only published records
+    // if this is an anonymous query and the filters support published records, query only published records
     if (RecordsQueryHandler.filtersForPublishedRecords(recordsQuery) && recordsQuery.author === undefined) {
       const results = await this.fetchPublishedRecords(tenant, recordsQuery);
       recordsWrites = results.messages as RecordsWriteMessageWithOptionalEncodedData[];
@@ -215,11 +215,19 @@ export class RecordsQueryHandler implements MethodHandler {
     return recordsQuery.authorSignaturePayload!.protocolRole !== undefined;
   }
 
+  /**
+   * Does the recordQuery filter explicitly for published records.
+   * Checks that there is either an explicit datePublished filter, or published is explicitly not set to false.
+   */
   private static filtersForPublishedRecords(recordsQuery: RecordsQuery): boolean {
     const { filter } = recordsQuery.message.descriptor;
-    return filter.published !== false || filter.datePublished !== undefined;
+    return filter.datePublished !== undefined || filter.published !== false;
   }
 
+  /**
+   * Does the recordQuery filter explicitly for unpublished records.
+   * Checks that published is not explicitly set to true, and datePublished is explicitly undefined.
+   */
   private static filtersForUnpublishedRecords(recordsQuery: RecordsQuery): boolean {
     const { filter } = recordsQuery.message.descriptor;
     return filter.published !== true && filter.datePublished === undefined;

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -105,6 +105,7 @@ export type RecordsFilter = {
   dataSize?: RangeFilter;
   dataCid?: string;
   dateCreated?: RangeCriterion;
+  datePublished?: RangeCriterion;
 };
 
 export type RangeCriterion = {

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -106,6 +106,7 @@ export type RecordsFilter = {
   dataCid?: string;
   dateCreated?: RangeCriterion;
   datePublished?: RangeCriterion;
+  dateUpdated?: RangeCriterion;
 };
 
 export type RangeCriterion = {

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -96,12 +96,14 @@ export type RecordsFilter = {
   recipient?: string;
   protocol?: string;
   protocolPath?: string;
+  published?: boolean;
   contextId?: string;
   schema?: string;
   recordId?: string;
   parentId?: string;
   dataFormat?: string;
   dataSize?: RangeFilter;
+  dataCid?: string;
   dateCreated?: RangeCriterion;
 };
 

--- a/src/utils/records.ts
+++ b/src/utils/records.ts
@@ -257,6 +257,7 @@ export class Records {
 
     const datePublishedFilter = datePublished ? this.convertRangeCriterion(datePublished): undefined;
     if (datePublishedFilter) {
+      // only return published records when filtering with a datePublished range.
       filterCopy.published = true;
       filterCopy.datePublished = datePublishedFilter;
     }

--- a/src/utils/records.ts
+++ b/src/utils/records.ts
@@ -257,6 +257,7 @@ export class Records {
 
     const datePublishedFilter = datePublished ? this.convertRangeCriterion(datePublished): undefined;
     if (datePublishedFilter) {
+      filterCopy.published = true;
       filterCopy.datePublished = datePublishedFilter;
     }
 

--- a/src/utils/records.ts
+++ b/src/utils/records.ts
@@ -249,7 +249,7 @@ export class Records {
   public static convertFilter(filter: RecordsFilter): Filter {
     const filterCopy = { ...filter } as Filter;
 
-    const { dateCreated, datePublished } = filter;
+    const { dateCreated, datePublished, dateUpdated } = filter;
     const dateCreatedFilter = dateCreated ? this.convertRangeCriterion(dateCreated) : undefined;
     if (dateCreatedFilter) {
       filterCopy.dateCreated = dateCreatedFilter;
@@ -260,6 +260,11 @@ export class Records {
       filterCopy.datePublished = datePublishedFilter;
     }
 
+    const messageTimestampFilter = dateUpdated ? this.convertRangeCriterion(dateUpdated) : undefined;
+    if (messageTimestampFilter) {
+      filterCopy.messageTimestamp = messageTimestampFilter;
+      delete filterCopy.dateUpdated;
+    }
     return filterCopy as Filter;
   }
 

--- a/src/utils/records.ts
+++ b/src/utils/records.ts
@@ -1,7 +1,7 @@
 import type { DerivedPrivateJwk } from './hd-key.js';
 import type { Readable } from 'readable-stream';
 import type { Filter, RangeFilter } from '../types/message-types.js';
-import type { RecordsFilter, RecordsWriteDescriptor, RecordsWriteMessage } from '../types/records-types.js';
+import type { RangeCriterion, RecordsFilter, RecordsWriteDescriptor, RecordsWriteMessage } from '../types/records-types.js';
 
 import { Encoder } from './encoder.js';
 import { Encryption } from './encryption.js';
@@ -247,31 +247,38 @@ export class Records {
    * @returns {Filter} a generic Filter able to be used with MessageStore.
    */
   public static convertFilter(filter: RecordsFilter): Filter {
-    const filterCopy = { ...filter };
-    const { dateCreated } = filterCopy;
+    const filterCopy = { ...filter } as Filter;
 
-    let rangeFilter: RangeFilter | undefined = undefined;
-    if (dateCreated !== undefined) {
-      if (dateCreated.to !== undefined && dateCreated.from !== undefined) {
-        rangeFilter = {
-          gte : dateCreated.from,
-          lt  : dateCreated.to,
-        };
-      } else if (dateCreated.to !== undefined) {
-        rangeFilter = {
-          lt: dateCreated.to,
-        };
-      } else if (dateCreated.from !== undefined) {
-        rangeFilter = {
-          gte: dateCreated.from,
-        };
-      }
+    const { dateCreated, datePublished } = filter;
+    const dateCreatedFilter = dateCreated ? this.convertRangeCriterion(dateCreated) : undefined;
+    if (dateCreatedFilter) {
+      filterCopy.dateCreated = dateCreatedFilter;
     }
 
-    if (rangeFilter) {
-      (filterCopy as Filter).dateCreated = rangeFilter;
+    const datePublishedFilter = datePublished ? this.convertRangeCriterion(datePublished): undefined;
+    if (datePublishedFilter) {
+      filterCopy.datePublished = datePublishedFilter;
     }
 
     return filterCopy as Filter;
+  }
+
+  private static convertRangeCriterion(inputFilter: RangeCriterion): RangeFilter | undefined {
+    let rangeFilter: RangeFilter | undefined;
+    if (inputFilter.to !== undefined && inputFilter.from !== undefined) {
+      rangeFilter = {
+        gte : inputFilter.from,
+        lt  : inputFilter.to,
+      };
+    } else if (inputFilter.to !== undefined) {
+      rangeFilter = {
+        lt: inputFilter.to,
+      };
+    } else if (inputFilter.from !== undefined) {
+      rangeFilter = {
+        gte: inputFilter.from,
+      };
+    }
+    return rangeFilter;
   }
 }

--- a/tests/handlers/records-query.spec.ts
+++ b/tests/handlers/records-query.spec.ts
@@ -270,6 +270,22 @@ export function testRecordsQueryHandler(): void {
         expect(anonymousReturnedRecordIds).to.have.members([ publishedWrite.message.recordId, draftWrite.message.recordId ]);
       });
 
+      it('should return 400 if published is set to false and a datePublished range is provided', async () => {
+        const firstDayOf2021 = createDateString(new Date(2021, 1, 1));
+        const alice = await DidKeyResolver.generate();
+        // set to true so create does not fail
+        const recordQuery = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : { datePublished: { from: firstDayOf2021 }, published: true }
+        });
+
+        // set to false
+        recordQuery.message.descriptor.filter.published = false;
+        const queryResponse = await dwn.processMessage(alice.did, recordQuery.message);
+        expect(queryResponse.status.code).to.equal(400);
+        expect(queryResponse.status.detail).to.contain('descriptor/filter/published: must be equal to one of the allowed values');
+      });
+
       it('should return 401 for anonymous queries that filter explicitly for unpublished records', async () => {
         const alice = await DidKeyResolver.generate();
 

--- a/tests/handlers/records-query.spec.ts
+++ b/tests/handlers/records-query.spec.ts
@@ -1607,7 +1607,7 @@ export function testRecordsQueryHandler(): void {
 
       describe('protocol based queries', () => {
         it('does not try protocol authorization if protocolRole is not invoked', async () => {
-          // scenario: Alice creates a thread and writes some chat messages writes a chat message. Alice addresses
+          // scenario: Alice creates a thread and writes some chat messages. Alice addresses
           //           only one chat message to Bob. Bob queries by protocol URI without invoking a protocolRole,
           //           and he is able to receive the message addressed to him.
 

--- a/tests/interfaces/records-query.spec.ts
+++ b/tests/interfaces/records-query.spec.ts
@@ -13,6 +13,21 @@ chai.use(chaiAsPromised);
 
 describe('RecordsQuery', () => {
   describe('create()', () => {
+    it('should not allow published to be set to false with a datePublished filter also set', async () => {
+      // test control
+      const randomDate = TestDataGenerator.randomTimestamp();
+      const recordQueryControl = TestDataGenerator.generateRecordsQuery({
+        filter: { datePublished: { from: randomDate, }, published: true }
+      });
+
+      await expect(recordQueryControl).to.eventually.not.be.rejected;
+
+      const recordQueryRejected = TestDataGenerator.generateRecordsQuery({
+        filter: { datePublished: { from: randomDate }, published: false }
+      });
+      await expect(recordQueryRejected).to.eventually.be.rejectedWith('descriptor/filter/published: must be equal to one of the allowed values');
+    });
+
     it('should use `messageTimestamp` as is if given', async () => {
       const alice = await TestDataGenerator.generatePersona();
 


### PR DESCRIPTION
Added the following filters to RecordsQuery:
`published`
`dataCid`
`datePublished`
`dateUpdated` (messageTimestamp)