### PR TITLE
#564 - Renamed author signature for consistency

### DIFF
--- a/json-schemas/authorization-owner.json
+++ b/json-schemas/authorization-owner.json
@@ -4,7 +4,7 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "authorSignature": {
+    "signature": {
       "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
     },
     "authorDelegatedGrant": {
@@ -14,10 +14,10 @@
       "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
     }
   },
-  "description": "`authorSignature` can exist by itself. But if `ownerSignature` is present, then `authorSignature` must also exist",
+  "description": "`signature` can exist by itself. But if `ownerSignature` is present, then `signature` must also exist",
   "dependencies": {
     "ownerSignature": [
-      "authorSignature"
+      "signature"
     ]
   }
 }

--- a/json-schemas/authorization.json
+++ b/json-schemas/authorization.json
@@ -4,7 +4,7 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "authorSignature": {
+    "signature": {
       "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
     }
   }

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -52,8 +52,8 @@ export async function authenticate(authorizationModel: AuthorizationModel | unde
     throw new DwnError(DwnErrorCode.AuthenticateJwsMissing, 'Missing JWS.');
   }
 
-  const authorSignatureVerifier = new GeneralJwsVerifier(authorizationModel.authorSignature);
-  await authorSignatureVerifier.verify(didResolver);
+  const signatureVerifier = new GeneralJwsVerifier(authorizationModel.signature);
+  await signatureVerifier.verify(didResolver);
 
   if (authorizationModel.ownerSignature !== undefined) {
     const ownerSignatureVerifier = new GeneralJwsVerifier(authorizationModel.ownerSignature);
@@ -61,10 +61,10 @@ export async function authenticate(authorizationModel: AuthorizationModel | unde
   }
 
   if (authorizationModel.authorDelegatedGrant !== undefined) {
-    // verify the signature of the author delegated grant
+    // verify the signature of the grantor of the delegated grant
     const authorDelegatedGrant = await PermissionsGrant.parse(authorizationModel.authorDelegatedGrant);
-    const grantedByAuthorSignatureVerifier = new GeneralJwsVerifier(authorDelegatedGrant.message.authorization.authorSignature);
-    await grantedByAuthorSignatureVerifier.verify(didResolver);
+    const grantedBySignatureVerifier = new GeneralJwsVerifier(authorDelegatedGrant.message.authorization.signature);
+    await grantedBySignatureVerifier.verify(didResolver);
   }
 }
 

--- a/src/core/message.ts
+++ b/src/core/message.ts
@@ -33,14 +33,14 @@ export enum DwnMethodName {
 
 export abstract class Message<M extends GenericMessage> {
   readonly message: M;
-  readonly signerSignaturePayload: GenericSignaturePayload | undefined;
+  readonly signaturePayload: GenericSignaturePayload | undefined;
   readonly author: string | undefined;
 
   constructor(message: M) {
     this.message = message;
 
     if (message.authorization !== undefined) {
-      this.signerSignaturePayload = Jws.decodePlainObjectPayload(message.authorization.authorSignature);
+      this.signaturePayload = Jws.decodePlainObjectPayload(message.authorization.signature);
       this.author = Message.getSigner(message as GenericMessage);
     }
   }
@@ -73,7 +73,7 @@ export abstract class Message<M extends GenericMessage> {
       return undefined;
     }
 
-    const signer = Jws.getSignerDid(message.authorization.authorSignature.signatures[0]);
+    const signer = Jws.getSignerDid(message.authorization.signature.signatures[0]);
     return signer;
   }
 
@@ -117,9 +117,9 @@ export abstract class Message<M extends GenericMessage> {
     signer: Signer,
     additionalPayloadProperties?: { permissionsGrantId?: string, protocolRole?: string }
   ): Promise<AuthorizationModel> {
-    const authorSignature = await Message.createSignature(descriptor, signer, additionalPayloadProperties);
+    const signature = await Message.createSignature(descriptor, signer, additionalPayloadProperties);
 
-    const authorization = { authorSignature };
+    const authorization = { signature };
     return authorization;
   }
 

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -427,7 +427,7 @@ export class ProtocolAuthorization {
     protocolDefinition: ProtocolDefinition,
     messageStore: MessageStore,
   ): Promise<void> {
-    const protocolRole = incomingMessage.signerSignaturePayload?.protocolRole;
+    const protocolRole = incomingMessage.signaturePayload?.protocolRole;
 
     // Only verify role if there is a role being invoked
     if (protocolRole === undefined) {
@@ -529,7 +529,7 @@ export class ProtocolAuthorization {
       throw new Error(`no action rule defined for ${incomingMessageMethod}, ${author} is unauthorized`);
     }
 
-    const invokedRole = incomingMessage.signerSignaturePayload?.protocolRole;
+    const invokedRole = incomingMessage.signaturePayload?.protocolRole;
 
     for (const actionRule of actionRules) {
       if (!inboundMessageActions.includes(actionRule.can as ProtocolAction)) {

--- a/src/core/records-grant-authorization.ts
+++ b/src/core/records-grant-authorization.ts
@@ -21,7 +21,7 @@ export class RecordsGrantAuthorization {
       tenant,
       incomingMessage,
       author,
-      incomingMessage.signerSignaturePayload!.permissionsGrantId!,
+      incomingMessage.signaturePayload!.permissionsGrantId!,
       messageStore
     );
 
@@ -44,7 +44,7 @@ export class RecordsGrantAuthorization {
       tenant,
       incomingMessage,
       author,
-      incomingMessage.signerSignaturePayload!.permissionsGrantId!,
+      incomingMessage.signaturePayload!.permissionsGrantId!,
       messageStore
     );
 

--- a/src/handlers/records-query.ts
+++ b/src/handlers/records-query.ts
@@ -226,7 +226,7 @@ export class RecordsQueryHandler implements MethodHandler {
    * Determines if ProtocolAuthorization.authorizeQuery should be run and if the corresponding filter should be used.
    */
   private static shouldProtocolAuthorizeQuery(recordsQuery: RecordsQuery): boolean {
-    return recordsQuery.signerSignaturePayload!.protocolRole !== undefined;
+    return recordsQuery.signaturePayload!.protocolRole !== undefined;
   }
 
   /**

--- a/src/interfaces/events-get.ts
+++ b/src/interfaces/events-get.ts
@@ -15,7 +15,7 @@ export class EventsGet extends Message<EventsGetMessage> {
 
   public static async parse(message: EventsGetMessage): Promise<EventsGet> {
     Message.validateJsonSchema(message);
-    await validateMessageSignatureIntegrity(message.authorization.authorSignature, message.descriptor);
+    await validateMessageSignatureIntegrity(message.authorization.signature, message.descriptor);
     validateTimestamp(message.descriptor.messageTimestamp);
 
     return new EventsGet(message);

--- a/src/interfaces/messages-get.ts
+++ b/src/interfaces/messages-get.ts
@@ -17,7 +17,7 @@ export class MessagesGet extends Message<MessagesGetMessage> {
     Message.validateJsonSchema(message);
     this.validateMessageCids(message.descriptor.messageCids);
 
-    await validateMessageSignatureIntegrity(message.authorization.authorSignature, message.descriptor);
+    await validateMessageSignatureIntegrity(message.authorization.signature, message.descriptor);
     validateTimestamp(message.descriptor.messageTimestamp);
 
     return new MessagesGet(message);

--- a/src/interfaces/permissions-grant.ts
+++ b/src/interfaces/permissions-grant.ts
@@ -37,7 +37,7 @@ export type CreateFromPermissionsRequestOverrides = {
 export class PermissionsGrant extends Message<PermissionsGrantMessage> {
 
   public static async parse(message: PermissionsGrantMessage): Promise<PermissionsGrant> {
-    await validateMessageSignatureIntegrity(message.authorization.authorSignature, message.descriptor);
+    await validateMessageSignatureIntegrity(message.authorization.signature, message.descriptor);
     PermissionsGrant.validateScope(message);
     validateTimestamp(message.descriptor.messageTimestamp);
     validateTimestamp(message.descriptor.dateExpires);

--- a/src/interfaces/permissions-request.ts
+++ b/src/interfaces/permissions-request.ts
@@ -21,7 +21,7 @@ export type PermissionsRequestOptions = {
 export class PermissionsRequest extends Message<PermissionsRequestMessage> {
 
   public static async parse(message: PermissionsRequestMessage): Promise<PermissionsRequest> {
-    await validateMessageSignatureIntegrity(message.authorization.authorSignature, message.descriptor);
+    await validateMessageSignatureIntegrity(message.authorization.signature, message.descriptor);
     validateTimestamp(message.descriptor.messageTimestamp);
 
     return new PermissionsRequest(message);

--- a/src/interfaces/permissions-revoke.ts
+++ b/src/interfaces/permissions-revoke.ts
@@ -14,7 +14,7 @@ export type PermissionsRevokeOptions = {
 
 export class PermissionsRevoke extends Message<PermissionsRevokeMessage> {
   public static async parse(message: PermissionsRevokeMessage): Promise<PermissionsRevoke> {
-    await validateMessageSignatureIntegrity(message.authorization.authorSignature, message.descriptor);
+    await validateMessageSignatureIntegrity(message.authorization.signature, message.descriptor);
     validateTimestamp(message.descriptor.messageTimestamp);
 
     return new PermissionsRevoke(message);

--- a/src/interfaces/protocols-configure.ts
+++ b/src/interfaces/protocols-configure.ts
@@ -21,7 +21,7 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
   public static async parse(message: ProtocolsConfigureMessage): Promise<ProtocolsConfigure> {
     Message.validateJsonSchema(message);
     ProtocolsConfigure.validateProtocolDefinition(message.descriptor.definition);
-    await validateMessageSignatureIntegrity(message.authorization.authorSignature, message.descriptor);
+    await validateMessageSignatureIntegrity(message.authorization.signature, message.descriptor);
     validateTimestamp(message.descriptor.messageTimestamp);
 
     return new ProtocolsConfigure(message);

--- a/src/interfaces/protocols-query.ts
+++ b/src/interfaces/protocols-query.ts
@@ -23,7 +23,7 @@ export class ProtocolsQuery extends Message<ProtocolsQueryMessage> {
 
   public static async parse(message: ProtocolsQueryMessage): Promise<ProtocolsQuery> {
     if (message.authorization !== undefined) {
-      await validateMessageSignatureIntegrity(message.authorization.authorSignature, message.descriptor);
+      await validateMessageSignatureIntegrity(message.authorization.signature, message.descriptor);
     }
 
     if (message.descriptor.filter !== undefined) {
@@ -79,12 +79,12 @@ export class ProtocolsQuery extends Message<ProtocolsQueryMessage> {
     // if author is the same as the target tenant, we can directly grant access
     if (this.author === tenant) {
       return;
-    } else if (this.author !== undefined && this.signerSignaturePayload!.permissionsGrantId) {
+    } else if (this.author !== undefined && this.signaturePayload!.permissionsGrantId) {
       await GrantAuthorization.authorizeGenericMessage(
         tenant,
         this,
         this.author,
-        this.signerSignaturePayload!.permissionsGrantId,
+        this.signaturePayload!.permissionsGrantId,
         messageStore
       );
     } else {

--- a/src/interfaces/records-delete.ts
+++ b/src/interfaces/records-delete.ts
@@ -21,7 +21,7 @@ export type RecordsDeleteOptions = {
 export class RecordsDelete extends Message<RecordsDeleteMessage> {
 
   public static async parse(message: RecordsDeleteMessage): Promise<RecordsDelete> {
-    await validateMessageSignatureIntegrity(message.authorization.authorSignature, message.descriptor);
+    await validateMessageSignatureIntegrity(message.authorization.signature, message.descriptor);
     validateTimestamp(message.descriptor.messageTimestamp);
 
     const recordsDelete = new RecordsDelete(message);

--- a/src/interfaces/records-query.ts
+++ b/src/interfaces/records-query.ts
@@ -32,7 +32,7 @@ export class RecordsQuery extends Message<RecordsQueryMessage> {
   public static async parse(message: RecordsQueryMessage): Promise<RecordsQuery> {
     let authorizationPayload;
     if (message.authorization !== undefined) {
-      authorizationPayload = await validateMessageSignatureIntegrity(message.authorization.authorSignature, message.descriptor);
+      authorizationPayload = await validateMessageSignatureIntegrity(message.authorization.signature, message.descriptor);
     }
 
     if (authorizationPayload?.protocolRole !== undefined) {

--- a/src/interfaces/records-read.ts
+++ b/src/interfaces/records-read.ts
@@ -28,7 +28,7 @@ export class RecordsRead extends Message<RecordsReadMessage> {
 
   public static async parse(message: RecordsReadMessage): Promise<RecordsRead> {
     if (message.authorization !== undefined) {
-      await validateMessageSignatureIntegrity(message.authorization.authorSignature, message.descriptor);
+      await validateMessageSignatureIntegrity(message.authorization.signature, message.descriptor);
     }
     validateTimestamp(message.descriptor.messageTimestamp);
 
@@ -80,7 +80,7 @@ export class RecordsRead extends Message<RecordsReadMessage> {
     } else if (this.author !== undefined && this.author === descriptor.recipient) {
       // The recipient of a message may always read it
       return;
-    } else if (this.author !== undefined && this.signerSignaturePayload!.permissionsGrantId !== undefined) {
+    } else if (this.author !== undefined && this.signaturePayload!.permissionsGrantId !== undefined) {
       await RecordsGrantAuthorization.authorizeRead(tenant, this, newestRecordsWrite, this.author, messageStore);
     } else if (descriptor.protocol !== undefined) {
       await ProtocolAuthorization.authorizeRead(tenant, this, newestRecordsWrite, messageStore);

--- a/src/types/message-types.ts
+++ b/src/types/message-types.ts
@@ -13,10 +13,20 @@ export type GenericMessage = {
  * The data model for the `authorization` property in a DWN message.
  */
 export type AuthorizationModel = {
-  // NOTE: deferring the rename to signerSignature to a follow up PR to not pollute this PR with further distractions
-  // because it touches a lot of places!
-  authorSignature: GeneralJws;
+  /**
+   * The signature of the message signer.
+   * NOTE: the signer is not necessarily the logical author of the message (e.g. signer is a delegate).
+   */
+  signature: GeneralJws;
+
+  /**
+   * The optional signature of a DWN owner wishing store a message authored by another entity.
+   */
   ownerSignature?: GeneralJws;
+
+  /**
+   * The delegated grant invoked by a delegate, if the message is signed by a delegate.
+   */
   authorDelegatedGrant?: DelegatedGrantMessage;
 };
 

--- a/tests/handlers/protocols-configure.spec.ts
+++ b/tests/handlers/protocols-configure.spec.ts
@@ -83,10 +83,10 @@ export function testProtocolsConfigureHandler(): void {
         const signer1 = Jws.createSigner(author);
         const signer2 = Jws.createSigner(extraRandomPersona);
 
-        const signerSignaturePayloadBytes = Encoder.objectToBytes(protocolsConfigure.signerSignaturePayload!);
+        const signaturePayloadBytes = Encoder.objectToBytes(protocolsConfigure.signaturePayload!);
 
-        const jwsBuilder = await GeneralJwsBuilder.create(signerSignaturePayloadBytes, [signer1, signer2]);
-        message.authorization = { authorSignature: jwsBuilder.getJws() };
+        const jwsBuilder = await GeneralJwsBuilder.create(signaturePayloadBytes, [signer1, signer2]);
+        message.authorization = { signature: jwsBuilder.getJws() };
 
         TestStubGenerator.stubDidResolver(didResolver, [author]);
 

--- a/tests/handlers/protocols-query.spec.ts
+++ b/tests/handlers/protocols-query.spec.ts
@@ -160,18 +160,18 @@ export function testProtocolsQueryHandler(): void {
       expect(reply.status.detail).to.contain(DwnErrorCode.UrlProtocolNotNormalized);
       });
 
-      it('should fail with 400 if signer signature payload is referencing a different message (`descriptorCid`)', async () => {
+      it('should fail with 400 if signature payload is referencing a different message (`descriptorCid`)', async () => {
         const { author, message, protocolsQuery } = await TestDataGenerator.generateProtocolsQuery();
         const tenant = author.did;
 
-        // replace signer signature with incorrect `descriptorCid`, even though signature is still valid
+        // replace signature with incorrect `descriptorCid`, even though signature is still valid
         const incorrectDescriptorCid = await TestDataGenerator.randomCborSha256Cid();
-        const signerSignaturePayload = { ...protocolsQuery.signerSignaturePayload };
-        signerSignaturePayload.descriptorCid = incorrectDescriptorCid;
-        const signerSignaturePayloadBytes = Encoder.objectToBytes(signerSignaturePayload);
+        const signaturePayload = { ...protocolsQuery.signaturePayload };
+        signaturePayload.descriptorCid = incorrectDescriptorCid;
+        const signaturePayloadBytes = Encoder.objectToBytes(signaturePayload);
         const signer = Jws.createSigner(author);
-        const jwsBuilder = await GeneralJwsBuilder.create(signerSignaturePayloadBytes, [signer]);
-        message.authorization = { authorSignature: jwsBuilder.getJws() };
+        const jwsBuilder = await GeneralJwsBuilder.create(signaturePayloadBytes, [signer]);
+        message.authorization = { signature: jwsBuilder.getJws() };
 
         const reply = await dwn.processMessage(tenant, message);
 

--- a/tests/interfaces/records-write.spec.ts
+++ b/tests/interfaces/records-write.spec.ts
@@ -223,7 +223,7 @@ describe('RecordsWrite', () => {
 
       const recordsWrite = await RecordsWrite.create(options);
 
-      expect(recordsWrite.message.authorization!.authorSignature.signatures[0].signature).to.equal(Encoder.bytesToBase64Url(hardCodedSignature));
+      expect(recordsWrite.message.authorization!.signature.signatures[0].signature).to.equal(Encoder.bytesToBase64Url(hardCodedSignature));
     });
 
     it('should throw if attempting to use `protocols` key derivation encryption scheme on non-protocol-based record', async () => {
@@ -324,7 +324,7 @@ describe('RecordsWrite', () => {
   });
 
   describe('parse()', () => {
-    it('should throw if signer signs over a delegated grant ID but the delegated grant is not given', async () => {
+    it('should throw if a delegate invokes a delegated grant (ID) but the delegated grant is not given', async () => {
       const alice = await TestDataGenerator.generatePersona();
       const bob = await TestDataGenerator.generatePersona();
 
@@ -385,7 +385,7 @@ describe('RecordsWrite', () => {
       const recordsWrite = await RecordsWrite.create(options);
 
       expect(recordsWrite.author).to.not.exist;
-      expect(recordsWrite.signerSignaturePayload).to.not.exist;
+      expect(recordsWrite.signaturePayload).to.not.exist;
 
       const alice = await DidKeyResolver.generate();
       await expect(recordsWrite.signAsOwner(Jws.createSigner(alice))).to.rejectedWith(DwnErrorCode.RecordsWriteSignAsOwnerUnknownAuthor);
@@ -406,7 +406,7 @@ describe('RecordsWrite', () => {
       const recordsWrite = await RecordsWrite.create(options);
 
       expect(recordsWrite.author).to.not.exist;
-      expect(recordsWrite.signerSignaturePayload).to.not.exist;
+      expect(recordsWrite.signaturePayload).to.not.exist;
 
       expect(() => recordsWrite.message).to.throw(DwnErrorCode.RecordsWriteMissingAuthorizationSigner);
     });

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -767,7 +767,7 @@ export class TestDataGenerator {
    */
   public static generateAuthorization(): AuthorizationModel {
     return {
-      authorSignature: TestDataGenerator.generateAuthorizationSignature()
+      signature: TestDataGenerator.generateAuthorizationSignature()
     };
   }
 


### PR DESCRIPTION
This was a deferred PR from previous PR to reduce noise.

I have opted for `signature` over `signerSignature` as the name for the canonical/default term as the message signature. Let me know if you have a better term, but `authorSignature` is definitely logically incorrect.