### PR TITLE
More refactoring & renaming on signing related methods and properties for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ DWN SDK includes a polyfilled distribution that can imported in a `module` scrip
       schema: 'yeeter/post',  // Specify a schema for the data.
       signer: Jws.createSigner(didKey) // Sign the data using the generated DID key.
     });
-    });
 
     // Create a readable stream from the data to be stored.
     const dataStream = DataStream.fromBytes(data);

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ DWN SDK includes a polyfilled distribution that can imported in a `module` scrip
       dataFormat: 'application/json',
       published: true,
       schema: 'yeeter/post',  // Specify a schema for the data.
-      authorizationSigner: Jws.createSigner(didKey) // Sign the data using the generated DID key.
+      signer: Jws.createSigner(didKey) // Sign the data using the generated DID key.
     });
     });
 
@@ -208,7 +208,7 @@ const recordsWrite = await RecordsWrite.create({
   dataFormat: 'application/json',
   published: true, // Mark the data as published.
   schema: 'yeeter/post', // Specify a schema for the data.
-  authorizationSigner: Jws.createSigner(didKey) // Sign the data using the generated DID key.
+  signer: Jws.createSigner(didKey) // Sign the data using the generated DID key.
 });
 
 // Create a readable stream from the data to be stored.
@@ -272,12 +272,12 @@ class CustomSigner implements Signer {
 }
 
 // Create an instance of the custom signer for authorization.
-const authorizationSigner = new CustomSigner();
+const signer = new CustomSigner();
 
 // Define options for creating a RecordsWrite message.
 const options: RecordsWriteOptions = {
   ...
-  authorizationSigner // Use the custom signer for authorization.
+  signer // Use the custom signer for authorization.
 };
 
 // Create a RecordsWrite message with the specified options.

--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -82,7 +82,7 @@ export enum DwnErrorCode {
   RecordsWriteDataCidMismatch = 'RecordsWriteDataCidMismatch',
   RecordsWriteDataSizeMismatch = 'RecordsWriteDataSizeMismatch',
   RecordsWriteGetEntryIdUndefinedAuthor = 'RecordsWriteGetEntryIdUndefinedAuthor',
-  RecordsWriteMissingAuthorizationSigner = 'RecordsWriteMissingAuthorizationSigner',
+  RecordsWriteMissingSigner = 'RecordsWriteMissingSigner',
   RecordsWriteMissingDataInPrevious = 'RecordsWriteMissingDataInPrevious',
   RecordsWriteMissingDataAssociation = 'RecordsWriteMissingDataAssociation',
   RecordsWriteMissingDataStream = 'RecordsWriteMissingDataStream',

--- a/src/core/message.ts
+++ b/src/core/message.ts
@@ -108,11 +108,11 @@ export abstract class Message<M extends GenericMessage> {
   }
 
   /**
-   * Creates the `authorization` as the author to be used in a DWN message.
-   * @param signer Signer as the author
+   * Creates the `authorization` property to be included in a DWN message.
+   * @param signer Message signer.
    * @returns {AuthorizationModel} used as an `authorization` property.
    */
-  public static async createAuthorizationAsAuthor(
+  public static async createAuthorization(
     descriptor: Descriptor,
     signer: Signer,
     additionalPayloadProperties?: { permissionsGrantId?: string, protocolRole?: string }

--- a/src/interfaces/events-get.ts
+++ b/src/interfaces/events-get.ts
@@ -32,7 +32,7 @@ export class EventsGet extends Message<EventsGetMessage> {
       descriptor.watermark = options.watermark;
     }
 
-    const authorization = await Message.createAuthorizationAsAuthor(descriptor, options.authorizationSigner);
+    const authorization = await Message.createAuthorization(descriptor, options.authorizationSigner);
     const message = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/events-get.ts
+++ b/src/interfaces/events-get.ts
@@ -7,7 +7,7 @@ import { getCurrentTimeInHighPrecision, validateTimestamp } from '../utils/time.
 
 export type EventsGetOptions = {
   watermark?: string;
-  authorizationSigner: Signer;
+  signer: Signer;
   messageTimestamp?: string;
 };
 
@@ -32,7 +32,7 @@ export class EventsGet extends Message<EventsGetMessage> {
       descriptor.watermark = options.watermark;
     }
 
-    const authorization = await Message.createAuthorization(descriptor, options.authorizationSigner);
+    const authorization = await Message.createAuthorization(descriptor, options.signer);
     const message = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/messages-get.ts
+++ b/src/interfaces/messages-get.ts
@@ -8,7 +8,7 @@ import { getCurrentTimeInHighPrecision, validateTimestamp } from '../utils/time.
 
 export type MessagesGetOptions = {
   messageCids: string[];
-  authorizationSigner: Signer;
+  signer: Signer;
   messageTimestamp?: string;
 };
 
@@ -31,7 +31,7 @@ export class MessagesGet extends Message<MessagesGetMessage> {
       messageTimestamp : options?.messageTimestamp ?? getCurrentTimeInHighPrecision(),
     };
 
-    const authorization = await Message.createAuthorization(descriptor, options.authorizationSigner);
+    const authorization = await Message.createAuthorization(descriptor, options.signer);
     const message = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/messages-get.ts
+++ b/src/interfaces/messages-get.ts
@@ -31,7 +31,7 @@ export class MessagesGet extends Message<MessagesGetMessage> {
       messageTimestamp : options?.messageTimestamp ?? getCurrentTimeInHighPrecision(),
     };
 
-    const authorization = await Message.createAuthorizationAsAuthor(descriptor, options.authorizationSigner);
+    const authorization = await Message.createAuthorization(descriptor, options.authorizationSigner);
     const message = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/permissions-grant.ts
+++ b/src/interfaces/permissions-grant.ts
@@ -69,7 +69,7 @@ export class PermissionsGrant extends Message<PermissionsGrantMessage> {
     // Error: `undefined` is not supported by the IPLD Data Model and cannot be encoded
     removeUndefinedProperties(descriptor);
 
-    const authorization = await Message.createAuthorizationAsAuthor(descriptor, options.authorizationSigner);
+    const authorization = await Message.createAuthorization(descriptor, options.authorizationSigner);
     const message: PermissionsGrantMessage = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/permissions-grant.ts
+++ b/src/interfaces/permissions-grant.ts
@@ -21,7 +21,7 @@ export type PermissionsGrantOptions = {
   permissionsRequestId?: string;
   scope: PermissionScope;
   conditions?: PermissionConditions;
-  authorizationSigner: Signer;
+  signer: Signer;
 };
 
 export type CreateFromPermissionsRequestOverrides = {
@@ -69,7 +69,7 @@ export class PermissionsGrant extends Message<PermissionsGrantMessage> {
     // Error: `undefined` is not supported by the IPLD Data Model and cannot be encoded
     removeUndefinedProperties(descriptor);
 
-    const authorization = await Message.createAuthorization(descriptor, options.authorizationSigner);
+    const authorization = await Message.createAuthorization(descriptor, options.signer);
     const message: PermissionsGrantMessage = { descriptor, authorization };
 
     Message.validateJsonSchema(message);
@@ -105,12 +105,12 @@ export class PermissionsGrant extends Message<PermissionsGrantMessage> {
   /**
    * generates a PermissionsGrant using the provided PermissionsRequest
    * @param permissionsRequest
-   * @param authorizationSigner - the private key and additional signature material of the grantor
+   * @param signer - the private key and additional signature material of the grantor
    * @param overrides - overrides that will be used instead of the properties in `permissionsRequest`
    */
   public static async createFromPermissionsRequest(
     permissionsRequest: PermissionsRequest,
-    authorizationSigner: Signer,
+    signer: Signer,
     overrides: CreateFromPermissionsRequestOverrides,
   ): Promise<PermissionsGrant> {
     const descriptor = permissionsRequest.message.descriptor;
@@ -123,7 +123,7 @@ export class PermissionsGrant extends Message<PermissionsGrantMessage> {
       permissionsRequestId : await Message.getCid(permissionsRequest.message),
       scope                : overrides.scope ?? descriptor.scope,
       conditions           : overrides.conditions ?? descriptor.conditions,
-      authorizationSigner,
+      signer,
     });
   }
 

--- a/src/interfaces/permissions-request.ts
+++ b/src/interfaces/permissions-request.ts
@@ -44,7 +44,7 @@ export class PermissionsRequest extends Message<PermissionsRequestMessage> {
     // Error: `undefined` is not supported by the IPLD Data Model and cannot be encoded
     removeUndefinedProperties(descriptor);
 
-    const auth = await Message.createAuthorizationAsAuthor(descriptor, options.authorizationSigner);
+    const auth = await Message.createAuthorization(descriptor, options.authorizationSigner);
     const message: PermissionsRequestMessage = { descriptor, authorization: auth };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/permissions-request.ts
+++ b/src/interfaces/permissions-request.ts
@@ -15,7 +15,7 @@ export type PermissionsRequestOptions = {
   grantedFor: string;
   scope: PermissionScope;
   conditions?: PermissionConditions;
-  authorizationSigner: Signer;
+  signer: Signer;
 };
 
 export class PermissionsRequest extends Message<PermissionsRequestMessage> {
@@ -44,7 +44,7 @@ export class PermissionsRequest extends Message<PermissionsRequestMessage> {
     // Error: `undefined` is not supported by the IPLD Data Model and cannot be encoded
     removeUndefinedProperties(descriptor);
 
-    const auth = await Message.createAuthorization(descriptor, options.authorizationSigner);
+    const auth = await Message.createAuthorization(descriptor, options.signer);
     const message: PermissionsRequestMessage = { descriptor, authorization: auth };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/permissions-revoke.ts
+++ b/src/interfaces/permissions-revoke.ts
@@ -28,7 +28,7 @@ export class PermissionsRevoke extends Message<PermissionsRevokeMessage> {
       permissionsGrantId : options.permissionsGrantId,
     };
 
-    const authorization = await Message.createAuthorizationAsAuthor(descriptor, options.authorizationSigner);
+    const authorization = await Message.createAuthorization(descriptor, options.authorizationSigner);
     const message: PermissionsRevokeMessage = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/permissions-revoke.ts
+++ b/src/interfaces/permissions-revoke.ts
@@ -9,7 +9,7 @@ import { getCurrentTimeInHighPrecision, validateTimestamp } from '../utils/time.
 export type PermissionsRevokeOptions = {
   messageTimestamp?: string;
   permissionsGrantId: string;
-  authorizationSigner: Signer;
+  signer: Signer;
 };
 
 export class PermissionsRevoke extends Message<PermissionsRevokeMessage> {
@@ -28,7 +28,7 @@ export class PermissionsRevoke extends Message<PermissionsRevokeMessage> {
       permissionsGrantId : options.permissionsGrantId,
     };
 
-    const authorization = await Message.createAuthorization(descriptor, options.authorizationSigner);
+    const authorization = await Message.createAuthorization(descriptor, options.signer);
     const message: PermissionsRevokeMessage = { descriptor, authorization };
 
     Message.validateJsonSchema(message);

--- a/src/interfaces/protocols-configure.ts
+++ b/src/interfaces/protocols-configure.ts
@@ -35,7 +35,7 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
       definition       : ProtocolsConfigure.normalizeDefinition(options.definition)
     };
 
-    const authorization = await Message.createAuthorizationAsAuthor(
+    const authorization = await Message.createAuthorization(
       descriptor,
       options.authorizationSigner,
       { permissionsGrantId: options.permissionsGrantId }

--- a/src/interfaces/protocols-configure.ts
+++ b/src/interfaces/protocols-configure.ts
@@ -10,7 +10,7 @@ import { normalizeProtocolUrl, normalizeSchemaUrl, validateProtocolUrlNormalized
 export type ProtocolsConfigureOptions = {
   messageTimestamp?: string;
   definition: ProtocolDefinition;
-  authorizationSigner: Signer;
+  signer: Signer;
   permissionsGrantId?: string;
 };
 
@@ -37,7 +37,7 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
 
     const authorization = await Message.createAuthorization(
       descriptor,
-      options.authorizationSigner,
+      options.signer,
       { permissionsGrantId: options.permissionsGrantId }
     );
     const message = { descriptor, authorization };

--- a/src/interfaces/protocols-query.ts
+++ b/src/interfaces/protocols-query.ts
@@ -15,7 +15,7 @@ import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 export type ProtocolsQueryOptions = {
   messageTimestamp?: string;
   filter?: ProtocolsQueryFilter,
-  authorizationSigner?: Signer;
+  signer?: Signer;
   permissionsGrantId?: string;
 };
 
@@ -48,10 +48,10 @@ export class ProtocolsQuery extends Message<ProtocolsQueryMessage> {
 
     // only generate the `authorization` property if signature input is given
     let authorization: AuthorizationModel | undefined;
-    if (options.authorizationSigner !== undefined) {
+    if (options.signer !== undefined) {
       authorization = await Message.createAuthorization(
         descriptor,
-        options.authorizationSigner,
+        options.signer,
         { permissionsGrantId: options.permissionsGrantId }
       );
     }

--- a/src/interfaces/protocols-query.ts
+++ b/src/interfaces/protocols-query.ts
@@ -49,7 +49,7 @@ export class ProtocolsQuery extends Message<ProtocolsQueryMessage> {
     // only generate the `authorization` property if signature input is given
     let authorization: AuthorizationModel | undefined;
     if (options.authorizationSigner !== undefined) {
-      authorization = await Message.createAuthorizationAsAuthor(
+      authorization = await Message.createAuthorization(
         descriptor,
         options.authorizationSigner,
         { permissionsGrantId: options.permissionsGrantId }

--- a/src/interfaces/records-delete.ts
+++ b/src/interfaces/records-delete.ts
@@ -15,7 +15,7 @@ export type RecordsDeleteOptions = {
   recordId: string;
   messageTimestamp?: string;
   protocolRole?: string;
-  authorizationSigner: Signer;
+  signer: Signer;
 };
 
 export class RecordsDelete extends Message<RecordsDeleteMessage> {
@@ -46,7 +46,7 @@ export class RecordsDelete extends Message<RecordsDeleteMessage> {
 
     const authorization = await Message.createAuthorization(
       descriptor,
-      options.authorizationSigner,
+      options.signer,
       { protocolRole: options.protocolRole },
     );
     const message: RecordsDeleteMessage = { descriptor, authorization };

--- a/src/interfaces/records-delete.ts
+++ b/src/interfaces/records-delete.ts
@@ -44,7 +44,7 @@ export class RecordsDelete extends Message<RecordsDeleteMessage> {
       messageTimestamp : options.messageTimestamp ?? currentTime
     };
 
-    const authorization = await Message.createAuthorizationAsAuthor(
+    const authorization = await Message.createAuthorization(
       descriptor,
       options.authorizationSigner,
       { protocolRole: options.protocolRole },

--- a/src/interfaces/records-query.ts
+++ b/src/interfaces/records-query.ts
@@ -72,7 +72,7 @@ export class RecordsQuery extends Message<RecordsQueryMessage> {
     const authorizationSigner = options.authorizationSigner;
     let authorization;
     if (authorizationSigner) {
-      authorization = await Message.createAuthorizationAsAuthor(descriptor, authorizationSigner, { protocolRole: options.protocolRole });
+      authorization = await Message.createAuthorization(descriptor, authorizationSigner, { protocolRole: options.protocolRole });
     }
     const message = { descriptor, authorization };
 

--- a/src/interfaces/records-query.ts
+++ b/src/interfaces/records-query.ts
@@ -23,7 +23,7 @@ export type RecordsQueryOptions = {
   filter: RecordsFilter;
   dateSort?: DateSort;
   pagination?: Pagination;
-  authorizationSigner?: Signer;
+  signer?: Signer;
   protocolRole?: string;
 };
 
@@ -69,10 +69,10 @@ export class RecordsQuery extends Message<RecordsQueryMessage> {
     removeUndefinedProperties(descriptor);
 
     // only generate the `authorization` property if signature input is given
-    const authorizationSigner = options.authorizationSigner;
+    const signer = options.signer;
     let authorization;
-    if (authorizationSigner) {
-      authorization = await Message.createAuthorization(descriptor, authorizationSigner, { protocolRole: options.protocolRole });
+    if (signer) {
+      authorization = await Message.createAuthorization(descriptor, signer, { protocolRole: options.protocolRole });
     }
     const message = { descriptor, authorization };
 

--- a/src/interfaces/records-read.ts
+++ b/src/interfaces/records-read.ts
@@ -15,7 +15,7 @@ import { getCurrentTimeInHighPrecision, validateTimestamp } from '../utils/time.
 export type RecordsReadOptions = {
   filter: RecordsFilter;
   messageTimestamp?: string;
-  authorizationSigner?: Signer;
+  signer?: Signer;
   permissionsGrantId?: string;
   /**
    * Used when authorizing protocol records.
@@ -44,7 +44,7 @@ export class RecordsRead extends Message<RecordsReadMessage> {
    * @throws {DwnError} when a combination of required RecordsReadOptions are missing
    */
   public static async create(options: RecordsReadOptions): Promise<RecordsRead> {
-    const { filter, authorizationSigner, permissionsGrantId, protocolRole } = options;
+    const { filter, signer, permissionsGrantId, protocolRole } = options;
     const currentTime = getCurrentTimeInHighPrecision();
 
     const descriptor: RecordsReadDescriptor = {
@@ -58,8 +58,8 @@ export class RecordsRead extends Message<RecordsReadMessage> {
 
     // only generate the `authorization` property if signature input is given
     let authorization = undefined;
-    if (authorizationSigner !== undefined) {
-      authorization = await Message.createAuthorization(descriptor, authorizationSigner, { permissionsGrantId, protocolRole });
+    if (signer !== undefined) {
+      authorization = await Message.createAuthorization(descriptor, signer, { permissionsGrantId, protocolRole });
     }
     const message: RecordsReadMessage = { descriptor, authorization };
 

--- a/src/interfaces/records-read.ts
+++ b/src/interfaces/records-read.ts
@@ -59,7 +59,7 @@ export class RecordsRead extends Message<RecordsReadMessage> {
     // only generate the `authorization` property if signature input is given
     let authorization = undefined;
     if (authorizationSigner !== undefined) {
-      authorization = await Message.createAuthorizationAsAuthor(descriptor, authorizationSigner, { permissionsGrantId, protocolRole });
+      authorization = await Message.createAuthorization(descriptor, authorizationSigner, { permissionsGrantId, protocolRole });
     }
     const message: RecordsReadMessage = { descriptor, authorization };
 

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -143,12 +143,12 @@ export class RecordsWrite {
   private _message: InternalRecordsWriteMessage;
   /**
    * Valid JSON message representing this RecordsWrite.
-   * @throws `DwnErrorCode.RecordsWriteMissingAuthorizationSigner` if the message is not signed yet.
+   * @throws `DwnErrorCode.RecordsWriteMissingSigner` if the message is not signed yet.
    */
   public get message(): RecordsWriteMessage {
     if (this._message.authorization === undefined) {
       throw new DwnError(
-        DwnErrorCode.RecordsWriteMissingAuthorizationSigner,
+        DwnErrorCode.RecordsWriteMissingSigner,
         'This RecordsWrite is not yet signed, JSON message cannot be generated from an incomplete state.'
       );
     }

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -458,21 +458,18 @@ export class RecordsWrite {
       this._message.contextId = await RecordsWrite.getEntryId(authorDid, descriptor);
     }
 
-    // `signerSignature` generation
-    const additionalPropertiesToSign = {
+    // `signature` generation
+    const signature = await RecordsWrite.createSignerSignature({
+      recordId    : this._message.recordId,
+      contextId   : this._message.contextId,
+      descriptorCid,
+      attestation : this._message.attestation,
+      encryption  : this._message.encryption,
+      signer,
       delegatedGrantId,
       permissionsGrantId,
       protocolRole
-    };
-    const signature = await RecordsWrite.createSignerSignature(
-      this._message.recordId,
-      this._message.contextId,
-      descriptorCid,
-      this._message.attestation,
-      this._message.encryption,
-      signer,
-      additionalPropertiesToSign
-    );
+    });
 
     this._message.authorization = { signature };
 
@@ -825,17 +822,21 @@ export class RecordsWrite {
   }
 
   /**
-   * Creates the `signerSignature` property in the `authorization` of a `RecordsWrite` message.
+   * Creates the `signature` property in the `authorization` of a `RecordsWrite` message.
    */
-  public static async createSignerSignature(
+  public static async createSignerSignature(input: {
     recordId: string,
     contextId: string | undefined,
     descriptorCid: string,
     attestation: GeneralJws | undefined,
     encryption: EncryptionProperty | undefined,
     signer: Signer,
-    additionalProperties?: { delegatedGrantId?: string, permissionsGrantId?: string, protocolRole?: string },
-  ): Promise<GeneralJws> {
+    delegatedGrantId?: string,
+    permissionsGrantId?: string,
+    protocolRole?: string
+  }): Promise<GeneralJws> {
+    const { recordId, contextId, descriptorCid, attestation, encryption, signer, delegatedGrantId, permissionsGrantId, protocolRole } = input;
+
     const attestationCid = attestation ? await Cid.computeCid(attestation) : undefined;
     const encryptionCid = encryption ? await Cid.computeCid(encryption) : undefined;
 
@@ -845,9 +846,9 @@ export class RecordsWrite {
       contextId,
       attestationCid,
       encryptionCid,
-      delegatedGrantId   : additionalProperties?.delegatedGrantId,
-      permissionsGrantId : additionalProperties?.permissionsGrantId,
-      protocolRole       : additionalProperties?.protocolRole
+      delegatedGrantId,
+      permissionsGrantId,
+      protocolRole
     };
     removeUndefinedProperties(signaturePayload);
 

--- a/tests/end-to-end-tests.spec.ts
+++ b/tests/end-to-end-tests.spec.ts
@@ -173,8 +173,8 @@ export function testEndToEndScenarios(): void {
       // Test that Bob is able to read his 'participant' role to obtain the context-derived private key for message decryption.
       // He doesn't need to invoke the role because recipients of a record are always authorized to read it
       const participantRead = await RecordsRead.create({
-        authorizationSigner : Jws.createSigner(bob),
-        filter              : {
+        signer : Jws.createSigner(bob),
+        filter : {
           protocolPath : 'thread/participant',
           recipient    : bob.did,
           contextId    : threadRecord.message.contextId
@@ -185,8 +185,8 @@ export function testEndToEndScenarios(): void {
 
       // Test that Bob is able to read the thread root record
       const threadRead = await RecordsRead.create({
-        authorizationSigner : Jws.createSigner(bob),
-        filter              : {
+        signer : Jws.createSigner(bob),
+        filter : {
           protocolPath : 'thread',
           contextId    : threadRecord.message.contextId
         },
@@ -199,8 +199,8 @@ export function testEndToEndScenarios(): void {
       // Test Bob can invoke his 'participant' role to read the chat message
       // TODO: #555 - We currently lack role-authorized RecordsQuery for a realistic scenario (https://github.com/TBD54566975/dwn-sdk-js/issues/555)
       const chatRead = await RecordsRead.create({
-        authorizationSigner : Jws.createSigner(bob),
-        filter              : {
+        signer : Jws.createSigner(bob),
+        filter : {
           protocolPath : 'thread/chat',
           contextId    : threadRecord.message.contextId
         },

--- a/tests/handlers/permissions-grant.spec.ts
+++ b/tests/handlers/permissions-grant.spec.ts
@@ -169,7 +169,7 @@ export function testPermissionsGrantHandler(): void {
             schema    : 'some-schema',
             protocol  : 'some-protocol'
           };
-          schemaAndProtocolGrant.message.authorization = await Message.createAuthorizationAsAuthor(
+          schemaAndProtocolGrant.message.authorization = await Message.createAuthorization(
             schemaAndProtocolGrant.message.descriptor,
             Jws.createSigner(alice)
           );
@@ -187,7 +187,7 @@ export function testPermissionsGrantHandler(): void {
             schema    : 'some-schema',
             contextId : 'some-context-id'
           };
-          schemaAndContextIdGrant.message.authorization = await Message.createAuthorizationAsAuthor(
+          schemaAndContextIdGrant.message.authorization = await Message.createAuthorization(
             schemaAndContextIdGrant.message.descriptor,
             Jws.createSigner(alice)
           );
@@ -205,7 +205,7 @@ export function testPermissionsGrantHandler(): void {
             schema       : 'some-schema',
             protocolPath : 'some-protocol-path'
           };
-          schemaAndProtocolPathGrant.message.authorization = await Message.createAuthorizationAsAuthor(
+          schemaAndProtocolPathGrant.message.authorization = await Message.createAuthorization(
             schemaAndProtocolPathGrant.message.descriptor,
             Jws.createSigner(alice)
           );
@@ -237,7 +237,7 @@ export function testPermissionsGrantHandler(): void {
             contextId    : 'some-context-id',
             protocolPath : 'some-protocol-path',
           };
-          contextIdAndProtocolPathGrant.message.authorization = await Message.createAuthorizationAsAuthor(
+          contextIdAndProtocolPathGrant.message.authorization = await Message.createAuthorization(
             contextIdAndProtocolPathGrant.message.descriptor,
             Jws.createSigner(alice)
           );

--- a/tests/handlers/protocols-configure.spec.ts
+++ b/tests/handlers/protocols-configure.spec.ts
@@ -231,7 +231,7 @@ export function testProtocolsConfigureHandler(): void {
         protocolsConfig.message.descriptor.definition.protocol = 'example.com/';
 
         // Re-create auth because we altered the descriptor after signing
-        protocolsConfig.message.authorization = await Message.createAuthorizationAsAuthor(
+        protocolsConfig.message.authorization = await Message.createAuthorization(
           protocolsConfig.message.descriptor,
           Jws.createSigner(alice)
         );
@@ -255,7 +255,7 @@ export function testProtocolsConfigureHandler(): void {
         protocolsConfig.message.descriptor.definition.types.ask.schema = 'ask';
 
         // Re-create auth because we altered the descriptor after signing
-        protocolsConfig.message.authorization = await Message.createAuthorizationAsAuthor(
+        protocolsConfig.message.authorization = await Message.createAuthorization(
           protocolsConfig.message.descriptor,
           Jws.createSigner(alice)
         );

--- a/tests/handlers/protocols-query.spec.ts
+++ b/tests/handlers/protocols-query.spec.ts
@@ -149,7 +149,7 @@ export function testProtocolsQueryHandler(): void {
       protocolsQuery.message.descriptor.filter!.protocol = 'example.com/';
 
       // Re-create auth because we altered the descriptor after signing
-      protocolsQuery.message.authorization = await Message.createAuthorizationAsAuthor(
+      protocolsQuery.message.authorization = await Message.createAuthorization(
         protocolsQuery.message.descriptor,
         Jws.createSigner(alice)
       );

--- a/tests/handlers/records-delete.spec.ts
+++ b/tests/handlers/records-delete.spec.ts
@@ -87,8 +87,8 @@ export function testRecordsDeleteHandler(): void {
 
         // testing delete
         const recordsDelete = await RecordsDelete.create({
-          recordId            : message.recordId,
-          authorizationSigner : Jws.createSigner(alice)
+          recordId : message.recordId,
+          signer   : Jws.createSigner(alice)
         });
 
         const deleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
@@ -101,8 +101,8 @@ export function testRecordsDeleteHandler(): void {
 
         // testing deleting a deleted record
         const recordsDelete2 = await RecordsDelete.create({
-          recordId            : message.recordId,
-          authorizationSigner : Jws.createSigner(alice)
+          recordId : message.recordId,
+          signer   : Jws.createSigner(alice)
         });
 
         const recordsDelete2Reply = await dwn.processMessage(alice.did, recordsDelete2.message);
@@ -147,7 +147,7 @@ export function testRecordsDeleteHandler(): void {
           filter: {
             recordId: aliceAssociateData.message.recordId,
           },
-          authorizationSigner: Jws.createSigner(alice)
+          signer: Jws.createSigner(alice)
         });
 
         const aliceRead1Reply = await dwn.processMessage(alice.did, aliceRead1.message);
@@ -173,7 +173,7 @@ export function testRecordsDeleteHandler(): void {
           filter: {
             recordId: bobAssociateData.message.recordId,
           },
-          authorizationSigner: Jws.createSigner(bob)
+          signer: Jws.createSigner(bob)
         });
 
         const bobRead1Reply = await dwn.processMessage(bob.did, bobRead1.message);
@@ -188,8 +188,8 @@ export function testRecordsDeleteHandler(): void {
 
         // testing deleting a non-existent record
         const recordsDelete = await RecordsDelete.create({
-          recordId            : 'nonExistentRecordId',
-          authorizationSigner : Jws.createSigner(alice)
+          recordId : 'nonExistentRecordId',
+          signer   : Jws.createSigner(alice)
         });
 
         const deleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
@@ -207,8 +207,8 @@ export function testRecordsDeleteHandler(): void {
         // generate subsequent write and delete with the delete having an earlier timestamp
         // NOTE: creating RecordsDelete first ensures it has an earlier `messageTimestamp` time
         const recordsDelete = await RecordsDelete.create({
-          recordId            : initialWriteData.message.recordId,
-          authorizationSigner : Jws.createSigner(alice)
+          recordId : initialWriteData.message.recordId,
+          signer   : Jws.createSigner(alice)
         });
         await minimalSleep();
         const subsequentWriteData = await TestDataGenerator.generateFromRecordsWrite({
@@ -609,8 +609,8 @@ export function testRecordsDeleteHandler(): void {
           expect(writeReply.status.code).to.equal(202);
 
           const recordsDelete = await RecordsDelete.create({
-            recordId            : message.recordId,
-            authorizationSigner : Jws.createSigner(alice)
+            recordId : message.recordId,
+            signer   : Jws.createSigner(alice)
           });
 
           const deleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
@@ -647,8 +647,8 @@ export function testRecordsDeleteHandler(): void {
           expect(newWriteReply.status.code).to.equal(202);
 
           const recordsDelete = await RecordsDelete.create({
-            recordId            : message.recordId,
-            authorizationSigner : Jws.createSigner(author)
+            recordId : message.recordId,
+            signer   : Jws.createSigner(author)
           });
 
           const deleteReply = await dwn.processMessage(author.did, recordsDelete.message);

--- a/tests/handlers/records-query.spec.ts
+++ b/tests/handlers/records-query.spec.ts
@@ -1572,7 +1572,7 @@ export function testRecordsQueryHandler(): void {
         recordsQuery.message.descriptor.filter.protocol = 'example.com/';
 
         // Re-create auth because we altered the descriptor after signing
-        recordsQuery.message.authorization = await Message.createAuthorizationAsAuthor(
+        recordsQuery.message.authorization = await Message.createAuthorization(
           recordsQuery.message.descriptor,
           Jws.createSigner(alice)
         );
@@ -1596,7 +1596,7 @@ export function testRecordsQueryHandler(): void {
         recordsQuery.message.descriptor.filter.schema = 'example.com/';
 
         // Re-create auth because we altered the descriptor after signing
-        recordsQuery.message.authorization = await Message.createAuthorizationAsAuthor(
+        recordsQuery.message.authorization = await Message.createAuthorization(
           recordsQuery.message.descriptor,
           Jws.createSigner(alice)
         );

--- a/tests/handlers/records-read.spec.ts
+++ b/tests/handlers/records-read.spec.ts
@@ -84,7 +84,7 @@ export function testRecordsReadHandler(): void {
           filter: {
             recordId: message.recordId,
           },
-          authorizationSigner: Jws.createSigner(alice)
+          signer: Jws.createSigner(alice)
         });
 
         const readReply = await dwn.processMessage(alice.did, recordsRead.message);
@@ -112,7 +112,7 @@ export function testRecordsReadHandler(): void {
           filter: {
             recordId: message.recordId,
           },
-          authorizationSigner: Jws.createSigner(bob)
+          signer: Jws.createSigner(bob)
         });
 
         const readReply = await dwn.processMessage(alice.did, recordsRead.message);
@@ -157,7 +157,7 @@ export function testRecordsReadHandler(): void {
           filter: {
             recordId: message.recordId,
           },
-          authorizationSigner: Jws.createSigner(bob)
+          signer: Jws.createSigner(bob)
         });
 
         const readReply = await dwn.processMessage(alice.did, recordsRead.message);
@@ -184,7 +184,7 @@ export function testRecordsReadHandler(): void {
           filter: {
             recordId: message.recordId,
           },
-          authorizationSigner: Jws.createSigner(bob)
+          signer: Jws.createSigner(bob)
         });
 
         const readReply = await dwn.processMessage(alice.did, recordsRead.message);
@@ -232,7 +232,7 @@ export function testRecordsReadHandler(): void {
             filter: {
               recordId: imageRecordsWrite.message.recordId,
             },
-            authorizationSigner: Jws.createSigner(bob)
+            signer: Jws.createSigner(bob)
           });
           const imageReadReply = await dwn.processMessage(alice.did, imageRecordsRead.message);
           expect(imageReadReply.status.code).to.equal(200);
@@ -316,7 +316,7 @@ export function testRecordsReadHandler(): void {
               filter: {
                 recordId: emailRecordsWrite.message.recordId,
               },
-              authorizationSigner: Jws.createSigner(bob)
+              signer: Jws.createSigner(bob)
             });
             const bobReadReply = await dwn.processMessage(alice.did, bobRecordsRead.message);
             expect(bobReadReply.status.code).to.equal(200);
@@ -326,7 +326,7 @@ export function testRecordsReadHandler(): void {
               filter: {
                 recordId: emailRecordsWrite.message.recordId,
               },
-              authorizationSigner: Jws.createSigner(imposterBob)
+              signer: Jws.createSigner(imposterBob)
             });
             const imposterReadReply = await dwn.processMessage(alice.did, imposterRecordsRead.message);
             expect(imposterReadReply.status.code).to.equal(401);
@@ -371,7 +371,7 @@ export function testRecordsReadHandler(): void {
               filter: {
                 recordId: emailRecordsWrite.message.recordId,
               },
-              authorizationSigner: Jws.createSigner(bob)
+              signer: Jws.createSigner(bob)
             });
             const bobReadReply = await dwn.processMessage(alice.did, bobRecordsRead.message);
             expect(bobReadReply.status.code).to.equal(200);
@@ -381,7 +381,7 @@ export function testRecordsReadHandler(): void {
               filter: {
                 recordId: emailRecordsWrite.message.recordId,
               },
-              authorizationSigner: Jws.createSigner(imposterBob)
+              signer: Jws.createSigner(imposterBob)
             });
             const imposterReadReply = await dwn.processMessage(alice.did, imposterRecordsRead.message);
             expect(imposterReadReply.status.code).to.equal(401);
@@ -418,7 +418,7 @@ export function testRecordsReadHandler(): void {
                 protocol     : protocolDefinition.protocol,
                 protocolPath : 'foo',
               },
-              authorizationSigner: Jws.createSigner(alice),
+              signer: Jws.createSigner(alice),
             });
 
             const fooPathReply = await dwn.processMessage(alice.did, fooPathRead.message);
@@ -467,7 +467,7 @@ export function testRecordsReadHandler(): void {
                 protocol     : protocolDefinition.protocol,
                 protocolPath : 'foo',
               },
-              authorizationSigner: Jws.createSigner(alice),
+              signer: Jws.createSigner(alice),
             });
             const fooPathReply = await dwn.processMessage(alice.did, fooPathRead.message);
             expect(fooPathReply.status.code).to.equal(400);
@@ -516,8 +516,8 @@ export function testRecordsReadHandler(): void {
 
             // Bob reads Alice's chat record
             const readChatRecord = await RecordsRead.create({
-              authorizationSigner : Jws.createSigner(bob),
-              filter              : {
+              signer : Jws.createSigner(bob),
+              filter : {
                 recordId: chatRecord.message.recordId,
 
               },
@@ -556,8 +556,8 @@ export function testRecordsReadHandler(): void {
 
             // Bob tries to invoke a 'chat' role but 'chat' is not a role
             const readChatRecord = await RecordsRead.create({
-              authorizationSigner : Jws.createSigner(bob),
-              filter              : {
+              signer : Jws.createSigner(bob),
+              filter : {
                 recordId: chatRecord.message.recordId,
               },
               protocolRole: 'chat'
@@ -596,8 +596,8 @@ export function testRecordsReadHandler(): void {
 
             // Bob tries to invoke a 'friend' role but he is not a 'friend'
             const readChatRecord = await RecordsRead.create({
-              authorizationSigner : Jws.createSigner(bob),
-              filter              : {
+              signer : Jws.createSigner(bob),
+              filter : {
                 recordId: chatRecord.message.recordId,
               },
               protocolRole: 'friend',
@@ -659,8 +659,8 @@ export function testRecordsReadHandler(): void {
             // Bob is able to read his own 'participant' role
             // He doesn't need to invoke the role because recipients of a record are always authorized to read it
             const participantRead = await RecordsRead.create({
-              authorizationSigner : Jws.createSigner(bob),
-              filter              : {
+              signer : Jws.createSigner(bob),
+              filter : {
                 protocolPath : 'thread/participant',
                 recipient    : bob.did,
                 contextId    : threadRecord.message.contextId
@@ -671,8 +671,8 @@ export function testRecordsReadHandler(): void {
 
             // Bob is able to read the thread root record
             const threadRead = await RecordsRead.create({
-              authorizationSigner : Jws.createSigner(bob),
-              filter              : {
+              signer : Jws.createSigner(bob),
+              filter : {
                 recordId: participantReadReply.record!.descriptor.parentId,
               },
               protocolRole: 'thread/participant'
@@ -682,8 +682,8 @@ export function testRecordsReadHandler(): void {
 
             // Bob invokes his 'participant' role to read the chat message
             const chatRead = await RecordsRead.create({
-              authorizationSigner : Jws.createSigner(bob),
-              filter              : {
+              signer : Jws.createSigner(bob),
+              filter : {
                 recordId: chatRecord.message.recordId,
               },
               protocolRole: 'thread/participant'
@@ -753,8 +753,8 @@ export function testRecordsReadHandler(): void {
 
             // Bob invokes his 'participant' role to read the chat message
             const chatRead = await RecordsRead.create({
-              authorizationSigner : Jws.createSigner(bob),
-              filter              : {
+              signer : Jws.createSigner(bob),
+              filter : {
                 recordId: chatRecord.message.recordId,
               },
               protocolRole: 'thread/participant'
@@ -799,8 +799,8 @@ export function testRecordsReadHandler(): void {
             filter: {
               recordId: recordsWrite.message.recordId,
             },
-            authorizationSigner : Jws.createSigner(bob),
-            permissionsGrantId  : await Message.getCid(permissionsGrant.message),
+            signer             : Jws.createSigner(bob),
+            permissionsGrantId : await Message.getCid(permissionsGrant.message),
           });
           const recordsReadReply = await dwn.processMessage(alice.did, recordsRead.message);
           expect(recordsReadReply.status.code).to.equal(401);
@@ -841,8 +841,8 @@ export function testRecordsReadHandler(): void {
             filter: {
               recordId: message.recordId,
             },
-            authorizationSigner : Jws.createSigner(bob),
-            permissionsGrantId  : await Message.getCid(permissionsGrant.message),
+            signer             : Jws.createSigner(bob),
+            permissionsGrantId : await Message.getCid(permissionsGrant.message),
           });
           const readReply = await dwn.processMessage(alice.did, recordsRead.message);
           expect(readReply.status.code).to.equal(200);
@@ -895,7 +895,7 @@ export function testRecordsReadHandler(): void {
 
                 recordId: recordsWrite.message.recordId,
               },
-              authorizationSigner: Jws.createSigner(bob),
+              signer: Jws.createSigner(bob),
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(401);
@@ -906,8 +906,8 @@ export function testRecordsReadHandler(): void {
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
-              authorizationSigner : Jws.createSigner(bob),
-              permissionsGrantId  : await Message.getCid(permissionsGrant.message),
+              signer             : Jws.createSigner(bob),
+              permissionsGrantId : await Message.getCid(permissionsGrant.message),
             });
             const recordsReadWithGrantReply = await dwn.processMessage(alice.did, recordsReadWithGrant.message);
             expect(recordsReadWithGrantReply.status.code).to.equal(200);
@@ -959,7 +959,7 @@ export function testRecordsReadHandler(): void {
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
-              authorizationSigner: Jws.createSigner(bob),
+              signer: Jws.createSigner(bob),
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(401);
@@ -970,8 +970,8 @@ export function testRecordsReadHandler(): void {
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
-              authorizationSigner : Jws.createSigner(bob),
-              permissionsGrantId  : await Message.getCid(permissionsGrant.message),
+              signer             : Jws.createSigner(bob),
+              permissionsGrantId : await Message.getCid(permissionsGrant.message),
             });
             const recordsReadWithGrantReply = await dwn.processMessage(alice.did, recordsReadWithGrant.message);
             expect(recordsReadWithGrantReply.status.code).to.equal(200);
@@ -1023,8 +1023,8 @@ export function testRecordsReadHandler(): void {
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
-              authorizationSigner : Jws.createSigner(bob),
-              permissionsGrantId  : await Message.getCid(permissionsGrant.message),
+              signer             : Jws.createSigner(bob),
+              permissionsGrantId : await Message.getCid(permissionsGrant.message),
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(401);
@@ -1077,8 +1077,8 @@ export function testRecordsReadHandler(): void {
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
-              authorizationSigner : Jws.createSigner(bob),
-              permissionsGrantId  : await Message.getCid(permissionsGrant.message),
+              signer             : Jws.createSigner(bob),
+              permissionsGrantId : await Message.getCid(permissionsGrant.message),
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(401);
@@ -1131,8 +1131,8 @@ export function testRecordsReadHandler(): void {
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
-              authorizationSigner : Jws.createSigner(bob),
-              permissionsGrantId  : await Message.getCid(permissionsGrant.message),
+              signer             : Jws.createSigner(bob),
+              permissionsGrantId : await Message.getCid(permissionsGrant.message),
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(200);
@@ -1184,8 +1184,8 @@ export function testRecordsReadHandler(): void {
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
-              authorizationSigner : Jws.createSigner(bob),
-              permissionsGrantId  : await Message.getCid(permissionsGrant.message),
+              signer             : Jws.createSigner(bob),
+              permissionsGrantId : await Message.getCid(permissionsGrant.message),
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(401);
@@ -1238,8 +1238,8 @@ export function testRecordsReadHandler(): void {
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
-              authorizationSigner : Jws.createSigner(bob),
-              permissionsGrantId  : await Message.getCid(permissionsGrant.message),
+              signer             : Jws.createSigner(bob),
+              permissionsGrantId : await Message.getCid(permissionsGrant.message),
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(200);
@@ -1291,8 +1291,8 @@ export function testRecordsReadHandler(): void {
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
-              authorizationSigner : Jws.createSigner(bob),
-              permissionsGrantId  : await Message.getCid(permissionsGrant.message),
+              signer             : Jws.createSigner(bob),
+              permissionsGrantId : await Message.getCid(permissionsGrant.message),
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(401);
@@ -1336,8 +1336,8 @@ export function testRecordsReadHandler(): void {
               filter: {
                 recordId: message.recordId,
               },
-              authorizationSigner : Jws.createSigner(bob),
-              permissionsGrantId  : await Message.getCid(permissionsGrant.message),
+              signer             : Jws.createSigner(bob),
+              permissionsGrantId : await Message.getCid(permissionsGrant.message),
             });
             const readReply = await dwn.processMessage(alice.did, recordsRead.message);
             expect(readReply.status.code).to.equal(200);
@@ -1380,8 +1380,8 @@ export function testRecordsReadHandler(): void {
               filter: {
                 recordId: message.recordId,
               },
-              authorizationSigner : Jws.createSigner(bob),
-              permissionsGrantId  : await Message.getCid(permissionsGrant.message),
+              signer             : Jws.createSigner(bob),
+              permissionsGrantId : await Message.getCid(permissionsGrant.message),
             });
             const readReply = await dwn.processMessage(alice.did, recordsRead.message);
             expect(readReply.status.code).to.equal(401);
@@ -1397,7 +1397,7 @@ export function testRecordsReadHandler(): void {
           filter: {
             recordId: `non-existent-record-id`,
           },
-          authorizationSigner: Jws.createSigner(alice)
+          signer: Jws.createSigner(alice)
         });
 
         const readReply = await dwn.processMessage(alice.did, recordsRead.message);
@@ -1424,8 +1424,8 @@ export function testRecordsReadHandler(): void {
 
         // RecordsDelete
         const recordsDelete = await RecordsDelete.create({
-          recordId            : message.recordId,
-          authorizationSigner : Jws.createSigner(alice)
+          recordId : message.recordId,
+          signer   : Jws.createSigner(alice)
         });
 
         const deleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
@@ -1436,7 +1436,7 @@ export function testRecordsReadHandler(): void {
           filter: {
             recordId: message.recordId,
           },
-          authorizationSigner: Jws.createSigner(alice)
+          signer: Jws.createSigner(alice)
         });
 
         const readReply = await dwn.processMessage(alice.did, recordsRead.message);
@@ -1461,7 +1461,7 @@ export function testRecordsReadHandler(): void {
           filter: {
             recordId: message.recordId,
           },
-          authorizationSigner: Jws.createSigner(alice)
+          signer: Jws.createSigner(alice)
         });
 
         const readReply = await dwn.processMessage(alice.did, recordsRead.message);
@@ -1485,7 +1485,7 @@ export function testRecordsReadHandler(): void {
             filter: {
               recordId: message.recordId,
             },
-            authorizationSigner: Jws.createSigner(alice)
+            signer: Jws.createSigner(alice)
           });
 
           const dataStoreGet = sinon.spy(dataStore, 'get');
@@ -1516,7 +1516,7 @@ export function testRecordsReadHandler(): void {
             filter: {
               recordId: message.recordId,
             },
-            authorizationSigner: Jws.createSigner(alice)
+            signer: Jws.createSigner(alice)
           });
 
           const dataStoreGet = sinon.spy(dataStore, 'get');
@@ -1600,7 +1600,7 @@ export function testRecordsReadHandler(): void {
             filter: {
               recordId: message.recordId,
             },
-            authorizationSigner: Jws.createSigner(alice)
+            signer: Jws.createSigner(alice)
           });
 
           // test able to derive correct key using `schemas` scheme from root key to decrypt the message
@@ -1688,7 +1688,7 @@ export function testRecordsReadHandler(): void {
             filter: {
               recordId: recordsWrite.message.recordId,
             },
-            authorizationSigner: Jws.createSigner(alice)
+            signer: Jws.createSigner(alice)
           });
 
 
@@ -1807,7 +1807,7 @@ export function testRecordsReadHandler(): void {
             filter: {
               recordId: message.recordId,
             },
-            authorizationSigner: Jws.createSigner(alice)
+            signer: Jws.createSigner(alice)
           });
           const readReply = await dwn.processMessage(alice.did, recordsRead.message);
           expect(readReply.status.code).to.equal(200);
@@ -1851,7 +1851,7 @@ export function testRecordsReadHandler(): void {
             filter: {
               recordId: recordsWriteToBob.message.recordId,
             },
-            authorizationSigner: Jws.createSigner(bob)
+            signer: Jws.createSigner(bob)
           });
           const readByBobReply = await dwn.processMessage(bob.did, recordsReadByBob.message);
           expect(readByBobReply.status.code).to.equal(200);
@@ -1942,7 +1942,7 @@ export function testRecordsReadHandler(): void {
             filter: {
               recordId: message.recordId,
             },
-            authorizationSigner: Jws.createSigner(alice)
+            signer: Jws.createSigner(alice)
           });
           const readReply = await dwn.processMessage(alice.did, recordsRead.message);
           expect(readReply.status.code).to.equal(200);
@@ -2010,7 +2010,7 @@ export function testRecordsReadHandler(): void {
         filter: {
           recordId: 'any-id',
         },
-        authorizationSigner: Jws.createSigner(alice)
+        signer: Jws.createSigner(alice)
       });
 
       // setting up a stub did resolver & message store
@@ -2031,7 +2031,7 @@ export function testRecordsReadHandler(): void {
         filter: {
           recordId: 'any-id',
         },
-        authorizationSigner: Jws.createSigner(alice)
+        signer: Jws.createSigner(alice)
       });
 
       // setting up a stub method resolver & message store

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -328,8 +328,8 @@ export function testRecordsWriteHandler(): void {
 
           // Alice fetches the message from Bob's DWN
           const recordsRead = await RecordsRead.create({
-            filter              : { recordId: message.recordId },
-            authorizationSigner : Jws.createSigner(alice)
+            filter : { recordId: message.recordId },
+            signer : Jws.createSigner(alice)
           });
 
           const readReply = await dwn.processMessage(bob.did, recordsRead.message);
@@ -395,8 +395,8 @@ export function testRecordsWriteHandler(): void {
 
           // Test that Bob's message can be read from Alice's DWN
           const recordsRead = await RecordsRead.create({
-            filter              : { recordId: bobRecordsWrite.message.recordId },
-            authorizationSigner : Jws.createSigner(alice)
+            filter : { recordId: bobRecordsWrite.message.recordId },
+            signer : Jws.createSigner(alice)
           });
           const readReply = await dwn.processMessage(alice.did, recordsRead.message);
           expect(readReply.status.code).to.equal(200);
@@ -506,25 +506,25 @@ export function testRecordsWriteHandler(): void {
           };
 
           const deviceXGrant = await PermissionsGrant.create({
-            delegated           : true, // this is a delegated grant
-            dateExpires         : createOffsetTimestamp({ seconds: 100 }),
-            description         : 'Allow to write to message protocol',
-            grantedBy           : alice.did,
-            grantedTo           : deviceX.did,
-            grantedFor          : alice.did,
-            scope               : scope,
-            authorizationSigner : Jws.createSigner(alice)
+            delegated   : true, // this is a delegated grant
+            dateExpires : createOffsetTimestamp({ seconds: 100 }),
+            description : 'Allow to write to message protocol',
+            grantedBy   : alice.did,
+            grantedTo   : deviceX.did,
+            grantedFor  : alice.did,
+            scope       : scope,
+            signer      : Jws.createSigner(alice)
           });
 
           const deviceYGrant = await PermissionsGrant.create({
-            delegated           : true, // this is a delegated grant
-            dateExpires         : createOffsetTimestamp({ seconds: 100 }),
-            description         : 'Allow to write to message protocol',
-            grantedBy           : alice.did,
-            grantedTo           : deviceY.did,
-            grantedFor          : alice.did,
-            scope               : scope,
-            authorizationSigner : Jws.createSigner(alice)
+            delegated   : true, // this is a delegated grant
+            dateExpires : createOffsetTimestamp({ seconds: 100 }),
+            description : 'Allow to write to message protocol',
+            grantedBy   : alice.did,
+            grantedTo   : deviceY.did,
+            grantedFor  : alice.did,
+            scope       : scope,
+            signer      : Jws.createSigner(alice)
           });
 
           // generate a `RecordsWrite` message from device X and write to Bob's DWN
@@ -655,14 +655,14 @@ export function testRecordsWriteHandler(): void {
           };
 
           const grantToBob = await PermissionsGrant.create({
-            delegated           : true, // this is a delegated grant
-            dateExpires         : createOffsetTimestamp({ seconds: 100 }),
-            description         : 'Allow to Bob write as me in chat protocol',
-            grantedBy           : alice.did,
-            grantedTo           : bob.did,
-            grantedFor          : alice.did,
-            scope               : scope,
-            authorizationSigner : Jws.createSigner(alice)
+            delegated   : true, // this is a delegated grant
+            dateExpires : createOffsetTimestamp({ seconds: 100 }),
+            description : 'Allow to Bob write as me in chat protocol',
+            grantedBy   : alice.did,
+            grantedTo   : bob.did,
+            grantedFor  : alice.did,
+            scope       : scope,
+            signer      : Jws.createSigner(alice)
           });
 
           // Sanity check that Bob can write a chat message as Alice by invoking the delegated grant
@@ -928,8 +928,8 @@ export function testRecordsWriteHandler(): void {
         expect(initialWriteReply.status.code).to.equal(202);
 
         const recordsDelete = await RecordsDelete.create({
-          recordId            : message.recordId,
-          authorizationSigner : Jws.createSigner(author),
+          recordId : message.recordId,
+          signer   : Jws.createSigner(author),
         });
         const deleteReply = await dwn.processMessage(tenant, recordsDelete.message);
         expect(deleteReply.status.code).to.equal(202);
@@ -960,8 +960,8 @@ export function testRecordsWriteHandler(): void {
         expect(initialWriteReply.status.code).to.equal(202);
 
         const recordsDelete = await RecordsDelete.create({
-          recordId            : message.recordId,
-          authorizationSigner : Jws.createSigner(author),
+          recordId : message.recordId,
+          signer   : Jws.createSigner(author),
         });
         const deleteReply = await dwn.processMessage(tenant, recordsDelete.message);
         expect(deleteReply.status.code).to.equal(202);
@@ -1095,7 +1095,7 @@ export function testRecordsWriteHandler(): void {
           filter: {
             recordId: write2.message.recordId,
           },
-          authorizationSigner: Jws.createSigner(alice)
+          signer: Jws.createSigner(alice)
         });
 
         const readReply = await dwn.processMessage(alice.did, read.message);
@@ -3206,7 +3206,7 @@ export function testRecordsWriteHandler(): void {
             filter: {
               recordId: imageRecordsWrite.message.recordId,
             },
-            authorizationSigner: Jws.createSigner(bob)
+            signer: Jws.createSigner(bob)
           });
 
           const bobRecordsReadReply = await dwn.processMessage(alice.did, bobRecordsReadData.message);

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -815,7 +815,14 @@ export function testRecordsWriteHandler(): void {
           const descriptorCid = await Cid.computeCid(message.descriptor);
           const recordId = await RecordsWrite.getEntryId(alice.did, message.descriptor);
           const signer = Jws.createSigner(alice);
-          const signature = await RecordsWrite['createSignerSignature'](recordId, message.contextId, descriptorCid, message.attestation, message.encryption, signer, undefined);
+          const signature = await RecordsWrite.createSignerSignature({
+            recordId,
+            contextId   : message.contextId,
+            descriptorCid,
+            attestation : message.attestation,
+            encryption  : message.encryption,
+            signer
+          });
           message.recordId = recordId;
           message.authorization = { signature };
 
@@ -836,7 +843,14 @@ export function testRecordsWriteHandler(): void {
           const descriptorCid = await Cid.computeCid(message.descriptor);
           const recordId = await RecordsWrite.getEntryId(alice.did, message.descriptor);
           const signer = Jws.createSigner(alice);
-          const signature = await RecordsWrite['createSignerSignature'](recordId, message.contextId, descriptorCid, message.attestation, message.encryption, signer, undefined);
+          const signature = await RecordsWrite.createSignerSignature({
+            recordId,
+            contextId   : message.contextId,
+            descriptorCid,
+            attestation : message.attestation,
+            encryption  : message.encryption,
+            signer
+          });
           message.recordId = recordId;
           message.authorization = { signature };
 
@@ -857,7 +871,14 @@ export function testRecordsWriteHandler(): void {
           const descriptorCid = await Cid.computeCid(message.descriptor);
           const recordId = await RecordsWrite.getEntryId(alice.did, message.descriptor);
           const signer = Jws.createSigner(alice);
-          const signature = await RecordsWrite['createSignerSignature'](recordId, message.contextId, descriptorCid, message.attestation, message.encryption, signer, undefined);
+          const signature = await RecordsWrite.createSignerSignature({
+            recordId,
+            contextId   : message.contextId,
+            descriptorCid,
+            attestation : message.attestation,
+            encryption  : message.encryption,
+            signer
+          });
           message.recordId = recordId;
           message.authorization = { signature };
 
@@ -877,7 +898,14 @@ export function testRecordsWriteHandler(): void {
           const descriptorCid = await Cid.computeCid(message.descriptor);
           const recordId = await RecordsWrite.getEntryId(alice.did, message.descriptor);
           const signer = Jws.createSigner(alice);
-          const signature = await RecordsWrite['createSignerSignature'](recordId, message.contextId, descriptorCid, message.attestation, message.encryption, signer, undefined);
+          const signature = await RecordsWrite.createSignerSignature({
+            recordId,
+            contextId   : message.contextId,
+            descriptorCid,
+            attestation : message.attestation,
+            encryption  : message.encryption,
+            signer
+          });
           message.recordId = recordId;
           message.authorization = { signature };
 
@@ -3108,15 +3136,14 @@ export function testRecordsWriteHandler(): void {
           // Re-create auth because we altered the descriptor after signing
           const descriptorCid = await Cid.computeCid(recordsWrite.message.descriptor);
           const attestation = await RecordsWrite.createAttestation(descriptorCid);
-          const signature = await RecordsWrite.createSignerSignature(
-            recordsWrite.message.recordId,
-            recordsWrite.message.contextId,
+          const signature = await RecordsWrite.createSignerSignature({
+            recordId   : recordsWrite.message.recordId,
+            contextId  : recordsWrite.message.contextId,
             descriptorCid,
             attestation,
-            recordsWrite.message.encryption,
-            Jws.createSigner(alice),
-            undefined
-          );
+            encryption : recordsWrite.message.encryption,
+            signer     : Jws.createSigner(alice)
+          });
           recordsWrite.message = {
             ...recordsWrite.message,
             attestation,

--- a/tests/interfaces/events-get.spec.ts
+++ b/tests/interfaces/events-get.spec.ts
@@ -10,8 +10,8 @@ describe('EventsGet Message', () => {
     it('creates an EventsGet message', async () => {
       const alice = await TestDataGenerator.generatePersona();
       const eventsGet = await EventsGet.create({
-        watermark           : 'yolo',
-        authorizationSigner : await Jws.createSigner(alice)
+        watermark : 'yolo',
+        signer    : await Jws.createSigner(alice)
       });
 
       const { message } = eventsGet;
@@ -20,10 +20,10 @@ describe('EventsGet Message', () => {
       expect(message.authorization).to.exist;
     });
 
-    it('doesnt require a watermark', async () => {
+    it('does not require a watermark', async () => {
       const alice = await TestDataGenerator.generatePersona();
       const eventsGet = await EventsGet.create({
-        authorizationSigner: await Jws.createSigner(alice)
+        signer: await Jws.createSigner(alice)
       });
 
       const message = eventsGet.message;
@@ -37,8 +37,8 @@ describe('EventsGet Message', () => {
     it('parses a message into an EventsGet instance', async () => {
       const alice = await TestDataGenerator.generatePersona();
       const eventsGet = await EventsGet.create({
-        watermark           : 'yolo',
-        authorizationSigner : await Jws.createSigner(alice)
+        watermark : 'yolo',
+        signer    : await Jws.createSigner(alice)
       });
 
       const parsed = await EventsGet.parse(eventsGet.message);
@@ -53,8 +53,8 @@ describe('EventsGet Message', () => {
     it('throws an exception if message is not a valid EventsGet message', async () => {
       const alice = await TestDataGenerator.generatePersona();
       const eventsGet = await EventsGet.create({
-        watermark           : 'yolo',
-        authorizationSigner : await Jws.createSigner(alice)
+        watermark : 'yolo',
+        signer    : await Jws.createSigner(alice)
       });
 
       const { message } = eventsGet;

--- a/tests/interfaces/messages-get.spec.ts
+++ b/tests/interfaces/messages-get.spec.ts
@@ -13,8 +13,8 @@ describe('MessagesGet Message', () => {
       const messageCid = await Message.getCid(message);
 
       const messagesGet = await MessagesGet.create({
-        authorizationSigner : await Jws.createSigner(author),
-        messageCids         : [messageCid]
+        signer      : await Jws.createSigner(author),
+        messageCids : [messageCid]
       });
 
       expect(messagesGet.message.authorization).to.exist;
@@ -29,8 +29,8 @@ describe('MessagesGet Message', () => {
 
       try {
         await MessagesGet.create({
-          authorizationSigner : await Jws.createSigner(alice),
-          messageCids         : []
+          signer      : await Jws.createSigner(alice),
+          messageCids : []
         });
 
         expect.fail();
@@ -45,8 +45,8 @@ describe('MessagesGet Message', () => {
 
       try {
         await MessagesGet.create({
-          authorizationSigner : await Jws.createSigner(alice),
-          messageCids         : ['abcd']
+          signer      : await Jws.createSigner(alice),
+          messageCids : ['abcd']
         });
 
         expect.fail();
@@ -62,8 +62,8 @@ describe('MessagesGet Message', () => {
       let messageCid = await Message.getCid(message);
 
       const messagesGet = await MessagesGet.create({
-        authorizationSigner : await Jws.createSigner(author),
-        messageCids         : [messageCid]
+        signer      : await Jws.createSigner(author),
+        messageCids : [messageCid]
       });
 
       const parsed = await MessagesGet.parse(messagesGet.message);
@@ -80,8 +80,8 @@ describe('MessagesGet Message', () => {
       const messageCid = await Message.getCid(recordsWriteMessage);
 
       const messagesGet = await MessagesGet.create({
-        authorizationSigner : await Jws.createSigner(author),
-        messageCids         : [messageCid]
+        signer      : await Jws.createSigner(author),
+        messageCids : [messageCid]
       });
 
       const message = messagesGet.toJSON() as MessagesGetMessage;

--- a/tests/interfaces/permissions-grant.spec.ts
+++ b/tests/interfaces/permissions-grant.spec.ts
@@ -17,7 +17,7 @@ describe('PermissionsGrant', () => {
   describe('create()', async () => {
     it('creates a PermissionsGrant message', async () => {
       const { privateJwk } = await Secp256k1.generateKeyPair();
-      const authorizationSigner = new PrivateKeySigner({ privateJwk, keyId: 'did:jank:bob' });
+      const signer = new PrivateKeySigner({ privateJwk, keyId: 'did:jank:bob' });
 
       const { message } = await PermissionsGrant.create({
         dateExpires : getCurrentTimeInHighPrecision(),
@@ -26,7 +26,7 @@ describe('PermissionsGrant', () => {
         grantedTo   : 'did:jank:alice',
         grantedFor  : 'did:jank:bob',
         scope       : { interface: DwnInterfaceName.Records, method: DwnMethodName.Write },
-        authorizationSigner
+        signer
       });
 
       expect(message.descriptor.grantedTo).to.equal('did:jank:alice');
@@ -39,7 +39,7 @@ describe('PermissionsGrant', () => {
     describe('scope property normalizations', async () => {
       it('ensures that `schema` is normalized', async () => {
         const { privateJwk } = await Secp256k1.generateKeyPair();
-        const authorizationSigner = new PrivateKeySigner({ privateJwk, keyId: 'did:jank:bob' });
+        const signer = new PrivateKeySigner({ privateJwk, keyId: 'did:jank:bob' });
 
         const scope: PermissionScope = {
           interface : DwnInterfaceName.Records,
@@ -54,7 +54,7 @@ describe('PermissionsGrant', () => {
           grantedTo   : 'did:jank:alice',
           grantedFor  : 'did:jank:bob',
           scope       : scope,
-          authorizationSigner
+          signer
         });
 
 
@@ -63,7 +63,7 @@ describe('PermissionsGrant', () => {
 
       it('ensures that `protocol` is normalized', async () => {
         const { privateJwk } = await Secp256k1.generateKeyPair();
-        const authorizationSigner = new PrivateKeySigner({ privateJwk, keyId: 'did:jank:bob' });
+        const signer = new PrivateKeySigner({ privateJwk, keyId: 'did:jank:bob' });
 
         const scope: PermissionScope = {
           interface : DwnInterfaceName.Records,
@@ -78,7 +78,7 @@ describe('PermissionsGrant', () => {
           grantedTo   : 'did:jank:alice',
           grantedFor  : 'did:jank:bob',
           scope       : scope,
-          authorizationSigner
+          signer
         });
 
 
@@ -89,14 +89,14 @@ describe('PermissionsGrant', () => {
     describe('scope validations', () => {
       it('ensures that `schema` and protocol related fields `protocol`, `contextId` or `protocolPath`', async () => {
         const { privateJwk } = await Secp256k1.generateKeyPair();
-        const authorizationSigner = new PrivateKeySigner({ privateJwk, keyId: 'did:jank:bob' });
+        const signer = new PrivateKeySigner({ privateJwk, keyId: 'did:jank:bob' });
 
         const permissionsGrantOptions = {
           dateExpires : getCurrentTimeInHighPrecision(),
           grantedBy   : 'did:jank:bob',
           grantedTo   : 'did:jank:alice',
           grantedFor  : 'did:jank:bob',
-          authorizationSigner
+          signer
         };
 
         // Reject when `schema` and `protocol` are both present
@@ -132,14 +132,14 @@ describe('PermissionsGrant', () => {
 
       it('ensures that `contextId` and `protocolPath` are not both present', async () => {
         const { privateJwk } = await Secp256k1.generateKeyPair();
-        const authorizationSigner = new PrivateKeySigner({ privateJwk, keyId: 'did:jank:bob' });
+        const signer = new PrivateKeySigner({ privateJwk, keyId: 'did:jank:bob' });
 
         const permissionsGrantOptions = {
           dateExpires : getCurrentTimeInHighPrecision(),
           grantedBy   : 'did:jank:bob',
           grantedTo   : 'did:jank:alice',
           grantedFor  : 'did:jank:bob',
-          authorizationSigner
+          signer
         };
 
         // Allow when `context to be present ` and `protocol` are both present
@@ -162,7 +162,7 @@ describe('PermissionsGrant', () => {
       const bob = await TestDataGenerator.generatePersona();
 
       const { privateJwk } = await Secp256k1.generateKeyPair();
-      const authorizationSigner = new PrivateKeySigner({ privateJwk, keyId: alice.did });
+      const signer = new PrivateKeySigner({ privateJwk, keyId: alice.did });
 
       const { permissionsRequest } = await TestDataGenerator.generatePermissionsRequest({
         author      : bob,
@@ -173,7 +173,7 @@ describe('PermissionsGrant', () => {
       });
 
       const dateExpires = Temporal.Now.instant().add({ hours: 24 }).toString({ smallestUnit: 'microseconds' });
-      const permissionsGrant = await PermissionsGrant.createFromPermissionsRequest(permissionsRequest, authorizationSigner, { dateExpires });
+      const permissionsGrant = await PermissionsGrant.createFromPermissionsRequest(permissionsRequest, signer, { dateExpires });
 
       expect(permissionsGrant.author).to.eq(alice.did);
       expect(permissionsGrant.message.descriptor.description).to.eq(permissionsRequest.message.descriptor.description);
@@ -191,7 +191,7 @@ describe('PermissionsGrant', () => {
       const carol = await DidKeyResolver.generate();
 
       const { privateJwk } = await Secp256k1.generateKeyPair();
-      const authorizationSigner = new PrivateKeySigner({ privateJwk, keyId: `${alice.did}#key1` });
+      const signer = new PrivateKeySigner({ privateJwk, keyId: `${alice.did}#key1` });
 
       const { permissionsRequest } = await TestDataGenerator.generatePermissionsRequest();
 
@@ -212,7 +212,7 @@ describe('PermissionsGrant', () => {
         }
       };
 
-      const permissionsGrant = await PermissionsGrant.createFromPermissionsRequest(permissionsRequest, authorizationSigner, overrides);
+      const permissionsGrant = await PermissionsGrant.createFromPermissionsRequest(permissionsRequest, signer, overrides);
 
       expect(permissionsGrant.author).to.eq(alice.did);
       expect(permissionsGrant.message.descriptor.description).to.eq(description);
@@ -230,12 +230,12 @@ describe('PermissionsGrant', () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const { message } = await PermissionsGrant.create({
-        dateExpires         : getCurrentTimeInHighPrecision(),
-        grantedBy           : alice.did,
-        grantedTo           : 'did:example:bob',
-        grantedFor          : alice.did,
-        scope               : { interface: DwnInterfaceName.Records, method: DwnMethodName.Write },
-        authorizationSigner : Jws.createSigner(alice)
+        dateExpires : getCurrentTimeInHighPrecision(),
+        grantedBy   : alice.did,
+        grantedTo   : 'did:example:bob',
+        grantedFor  : alice.did,
+        scope       : { interface: DwnInterfaceName.Records, method: DwnMethodName.Write },
+        signer      : Jws.createSigner(alice)
       });
 
       expect(() => PermissionsGrant.asDelegatedGrant(message)).to.throw(DwnErrorCode.PermissionsGrantNotADelegatedGrant);

--- a/tests/interfaces/permissions-request.spec.ts
+++ b/tests/interfaces/permissions-request.spec.ts
@@ -12,7 +12,7 @@ describe('PermissionsRequest', () => {
   describe('create', () => {
     it('creates a PermissionsRequest message', async () => {
       const { privateJwk } = await Secp256k1.generateKeyPair();
-      const authorizationSigner = new PrivateKeySigner({ privateJwk, keyId: 'did:jank:bob' });
+      const signer = new PrivateKeySigner({ privateJwk, keyId: 'did:jank:bob' });
 
       const { message } = await PermissionsRequest.create({
         description : 'drugs',
@@ -24,7 +24,7 @@ describe('PermissionsRequest', () => {
           method    : DwnMethodName.Write,
           protocol  : 'some-protocol',
         },
-        authorizationSigner
+        signer
       });
 
       expect(message.descriptor.grantedTo).to.equal('did:jank:alice');

--- a/tests/interfaces/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols-configure.spec.ts
@@ -20,9 +20,9 @@ describe('ProtocolsConfigure', () => {
       const currentTime = getCurrentTimeInHighPrecision();
       const definition = { ...dexProtocolDefinition };
       const protocolsConfigure = await ProtocolsConfigure.create({
-        messageTimestamp    : currentTime,
+        messageTimestamp : currentTime,
         definition,
-        authorizationSigner : Jws.createSigner(alice),
+        signer           : Jws.createSigner(alice),
       });
 
       expect(protocolsConfigure.message.descriptor.messageTimestamp).to.equal(currentTime);
@@ -33,10 +33,10 @@ describe('ProtocolsConfigure', () => {
 
       const definition = { ...dexProtocolDefinition, protocol: 'example.com/' };
       const options = {
-        recipient           : alice.did,
-        data                : TestDataGenerator.randomBytes(10),
-        dataFormat          : 'application/json',
-        authorizationSigner : Jws.createSigner(alice),
+        recipient  : alice.did,
+        data       : TestDataGenerator.randomBytes(10),
+        dataFormat : 'application/json',
+        signer     : Jws.createSigner(alice),
         definition,
       };
       const protocolsConfig = await ProtocolsConfigure.create(options);
@@ -53,12 +53,12 @@ describe('ProtocolsConfigure', () => {
       nonnormalizedDexProtocol.types.ask.schema = 'ask';
 
       const options = {
-        recipient           : alice.did,
-        data                : TestDataGenerator.randomBytes(10),
-        dataFormat          : 'application/json',
-        authorizationSigner : Jws.createSigner(alice),
-        protocol            : 'example.com/',
-        definition          : nonnormalizedDexProtocol
+        recipient  : alice.did,
+        data       : TestDataGenerator.randomBytes(10),
+        dataFormat : 'application/json',
+        signer     : Jws.createSigner(alice),
+        protocol   : 'example.com/',
+        definition : nonnormalizedDexProtocol
       };
       const protocolsConfig = await ProtocolsConfigure.create(options);
 
@@ -98,7 +98,7 @@ describe('ProtocolsConfigure', () => {
         const alice = await TestDataGenerator.generatePersona();
 
         const protocolsConfigure = await ProtocolsConfigure.create({
-          authorizationSigner: Jws.createSigner(alice),
+          signer: Jws.createSigner(alice),
           definition
         });
 
@@ -132,7 +132,7 @@ describe('ProtocolsConfigure', () => {
         const alice = await TestDataGenerator.generatePersona();
 
         const protocolsConfigure = await ProtocolsConfigure.create({
-          authorizationSigner: Jws.createSigner(alice),
+          signer: Jws.createSigner(alice),
           definition
         });
 
@@ -160,7 +160,7 @@ describe('ProtocolsConfigure', () => {
         const alice = await TestDataGenerator.generatePersona();
 
         const createProtocolsConfigurePromise = ProtocolsConfigure.create({
-          authorizationSigner: Jws.createSigner(alice),
+          signer: Jws.createSigner(alice),
           definition
         });
 
@@ -188,8 +188,8 @@ describe('ProtocolsConfigure', () => {
         };
 
         const createProtocolsConfigurePromise = ProtocolsConfigure.create({
-          authorizationSigner : Jws.createSigner(alice),
-          definition          : definitionRootContextRole
+          signer     : Jws.createSigner(alice),
+          definition : definitionRootContextRole
         });
 
         await expect(createProtocolsConfigurePromise)
@@ -216,8 +216,8 @@ describe('ProtocolsConfigure', () => {
         };
 
         const createProtocolsConfigurePromise2 = ProtocolsConfigure.create({
-          authorizationSigner : Jws.createSigner(alice),
-          definition          : definitionTooNestedContextRole
+          signer     : Jws.createSigner(alice),
+          definition : definitionTooNestedContextRole
         });
 
         await expect(createProtocolsConfigurePromise2)
@@ -248,7 +248,7 @@ describe('ProtocolsConfigure', () => {
         const alice = await TestDataGenerator.generatePersona();
 
         const createProtocolsConfigurePromise = ProtocolsConfigure.create({
-          authorizationSigner: Jws.createSigner(alice),
+          signer: Jws.createSigner(alice),
           definition
         });
 
@@ -277,7 +277,7 @@ describe('ProtocolsConfigure', () => {
         const alice = await TestDataGenerator.generatePersona();
 
         const createProtocolsConfigurePromise = ProtocolsConfigure.create({
-          authorizationSigner: Jws.createSigner(alice),
+          signer: Jws.createSigner(alice),
           definition
         });
 
@@ -306,7 +306,7 @@ describe('ProtocolsConfigure', () => {
         const alice = await TestDataGenerator.generatePersona();
 
         const createProtocolsConfigurePromise = ProtocolsConfigure.create({
-          authorizationSigner: Jws.createSigner(alice),
+          signer: Jws.createSigner(alice),
           definition
         });
 
@@ -335,7 +335,7 @@ describe('ProtocolsConfigure', () => {
         const alice = await TestDataGenerator.generatePersona();
 
         const createProtocolsConfigurePromise = ProtocolsConfigure.create({
-          authorizationSigner: Jws.createSigner(alice),
+          signer: Jws.createSigner(alice),
           definition
         });
 

--- a/tests/interfaces/protocols-query.spec.ts
+++ b/tests/interfaces/protocols-query.spec.ts
@@ -18,9 +18,9 @@ describe('ProtocolsQuery', () => {
 
       const currentTime = getCurrentTimeInHighPrecision();
       const protocolsQuery = await ProtocolsQuery.create({
-        filter              : { protocol: 'anyValue' },
-        messageTimestamp    : currentTime,
-        authorizationSigner : Jws.createSigner(alice),
+        filter           : { protocol: 'anyValue' },
+        messageTimestamp : currentTime,
+        signer           : Jws.createSigner(alice),
       });
 
       expect(protocolsQuery.message.descriptor.messageTimestamp).to.equal(currentTime);
@@ -31,12 +31,12 @@ describe('ProtocolsQuery', () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const options = {
-        recipient           : alice.did,
-        data                : TestDataGenerator.randomBytes(10),
-        dataFormat          : 'application/json',
-        authorizationSigner : Jws.createSigner(alice),
-        filter              : { protocol: 'example.com/' },
-        definition          : dexProtocolDefinition
+        recipient  : alice.did,
+        data       : TestDataGenerator.randomBytes(10),
+        dataFormat : 'application/json',
+        signer     : Jws.createSigner(alice),
+        filter     : { protocol: 'example.com/' },
+        definition : dexProtocolDefinition
       };
       const protocolsConfig = await ProtocolsQuery.create(options);
 

--- a/tests/interfaces/records-delete.spec.ts
+++ b/tests/interfaces/records-delete.spec.ts
@@ -15,9 +15,9 @@ describe('RecordsDelete', () => {
 
       const currentTime = getCurrentTimeInHighPrecision();
       const recordsDelete = await RecordsDelete.create({
-        recordId            : 'anything',
-        authorizationSigner : Jws.createSigner(alice),
-        messageTimestamp    : currentTime
+        recordId         : 'anything',
+        signer           : Jws.createSigner(alice),
+        messageTimestamp : currentTime
       });
 
       expect(recordsDelete.message.descriptor.messageTimestamp).to.equal(currentTime);
@@ -27,8 +27,8 @@ describe('RecordsDelete', () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const recordsDelete = await RecordsDelete.create({
-        recordId            : 'anything',
-        authorizationSigner : Jws.createSigner(alice)
+        recordId : 'anything',
+        signer   : Jws.createSigner(alice)
       });
 
       expect(recordsDelete.message.descriptor.messageTimestamp).to.exist;

--- a/tests/interfaces/records-query.spec.ts
+++ b/tests/interfaces/records-query.spec.ts
@@ -33,9 +33,9 @@ describe('RecordsQuery', () => {
 
       const currentTime = getCurrentTimeInHighPrecision();
       const recordsQuery = await RecordsQuery.create({
-        filter              : { schema: 'anything' },
-        messageTimestamp    : currentTime,
-        authorizationSigner : Jws.createSigner(alice),
+        filter           : { schema: 'anything' },
+        messageTimestamp : currentTime,
+        signer           : Jws.createSigner(alice),
       });
 
       expect(recordsQuery.message.descriptor.messageTimestamp).to.equal(currentTime);
@@ -45,12 +45,12 @@ describe('RecordsQuery', () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const options = {
-        recipient           : alice.did,
-        data                : TestDataGenerator.randomBytes(10),
-        dataFormat          : 'application/json',
-        authorizationSigner : Jws.createSigner(alice),
-        filter              : { protocol: 'example.com/' },
-        definition          : dexProtocolDefinition
+        recipient  : alice.did,
+        data       : TestDataGenerator.randomBytes(10),
+        dataFormat : 'application/json',
+        signer     : Jws.createSigner(alice),
+        filter     : { protocol: 'example.com/' },
+        definition : dexProtocolDefinition
       };
       const recordsQuery = await RecordsQuery.create(options);
 
@@ -63,12 +63,12 @@ describe('RecordsQuery', () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const options = {
-        recipient           : alice.did,
-        data                : TestDataGenerator.randomBytes(10),
-        dataFormat          : 'application/json',
-        authorizationSigner : Jws.createSigner(alice),
-        filter              : { schema: 'example.com/' },
-        definition          : dexProtocolDefinition
+        recipient  : alice.did,
+        data       : TestDataGenerator.randomBytes(10),
+        dataFormat : 'application/json',
+        signer     : Jws.createSigner(alice),
+        filter     : { schema: 'example.com/' },
+        definition : dexProtocolDefinition
       };
       const recordsQuery = await RecordsQuery.create(options);
 

--- a/tests/interfaces/records-read.spec.ts
+++ b/tests/interfaces/records-read.spec.ts
@@ -21,8 +21,8 @@ describe('RecordsRead', () => {
         filter: {
           recordId: 'anything',
         },
-        authorizationSigner : Jws.createSigner(alice),
-        messageTimestamp    : currentTime
+        signer           : Jws.createSigner(alice),
+        messageTimestamp : currentTime
       });
 
       expect(recordsRead.message.descriptor.messageTimestamp).to.equal(currentTime);
@@ -32,12 +32,12 @@ describe('RecordsRead', () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const options = {
-        recipient           : alice.did,
-        data                : TestDataGenerator.randomBytes(10),
-        dataFormat          : 'application/json',
-        authorizationSigner : Jws.createSigner(alice),
-        filter              : { protocol: 'example.com/' },
-        definition          : dexProtocolDefinition
+        recipient  : alice.did,
+        data       : TestDataGenerator.randomBytes(10),
+        dataFormat : 'application/json',
+        signer     : Jws.createSigner(alice),
+        filter     : { protocol: 'example.com/' },
+        definition : dexProtocolDefinition
       };
       const recordsQuery = await RecordsRead.create(options);
 
@@ -50,12 +50,12 @@ describe('RecordsRead', () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const options = {
-        recipient           : alice.did,
-        data                : TestDataGenerator.randomBytes(10),
-        dataFormat          : 'application/json',
-        authorizationSigner : Jws.createSigner(alice),
-        filter              : { schema: 'example.com/' },
-        definition          : dexProtocolDefinition
+        recipient  : alice.did,
+        data       : TestDataGenerator.randomBytes(10),
+        dataFormat : 'application/json',
+        signer     : Jws.createSigner(alice),
+        filter     : { schema: 'example.com/' },
+        definition : dexProtocolDefinition
       };
       const recordsQuery = await RecordsRead.create(options);
 

--- a/tests/interfaces/records-write.spec.ts
+++ b/tests/interfaces/records-write.spec.ts
@@ -66,13 +66,13 @@ describe('RecordsWrite', () => {
 
       // testing `data` and `dataCid` both defined
       const options1 = {
-        recipient           : alice.did,
-        data                : TestDataGenerator.randomBytes(10),
-        dataCid             : await TestDataGenerator.randomCborSha256Cid(),
-        dataFormat          : 'application/json',
-        recordId            : await TestDataGenerator.randomCborSha256Cid(),
-        published           : true,
-        authorizationSigner : Jws.createSigner(alice)
+        recipient  : alice.did,
+        data       : TestDataGenerator.randomBytes(10),
+        dataCid    : await TestDataGenerator.randomCborSha256Cid(),
+        dataFormat : 'application/json',
+        recordId   : await TestDataGenerator.randomCborSha256Cid(),
+        published  : true,
+        signer     : Jws.createSigner(alice)
       };
       const createPromise1 = RecordsWrite.create(options1);
 
@@ -80,14 +80,14 @@ describe('RecordsWrite', () => {
 
       // testing `data` and `dataCid` both undefined
       const options2 = {
-        recipient           : alice.did,
+        recipient  : alice.did,
         // intentionally showing both `data` and `dataCid` are undefined
         // data                        : TestDataGenerator.randomBytes(10),
         // dataCid                     : await TestDataGenerator.randomCborSha256Cid(),
-        dataFormat          : 'application/json',
-        recordId            : await TestDataGenerator.randomCborSha256Cid(),
-        published           : true,
-        authorizationSigner : Jws.createSigner(alice)
+        dataFormat : 'application/json',
+        recordId   : await TestDataGenerator.randomCborSha256Cid(),
+        published  : true,
+        signer     : Jws.createSigner(alice)
       };
       const createPromise2 = RecordsWrite.create(options2);
 
@@ -98,27 +98,27 @@ describe('RecordsWrite', () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const options1 = {
-        recipient           : alice.did,
-        dataCid             : await TestDataGenerator.randomCborSha256Cid(),
+        recipient  : alice.did,
+        dataCid    : await TestDataGenerator.randomCborSha256Cid(),
         // dataSize                  : 123, // intentionally missing
-        dataFormat          : 'application/json',
-        recordId            : await TestDataGenerator.randomCborSha256Cid(),
-        published           : true,
-        authorizationSigner : Jws.createSigner(alice)
+        dataFormat : 'application/json',
+        recordId   : await TestDataGenerator.randomCborSha256Cid(),
+        published  : true,
+        signer     : Jws.createSigner(alice)
       };
       const createPromise1 = RecordsWrite.create(options1);
 
       await expect(createPromise1).to.be.rejectedWith('`dataCid` and `dataSize` must both be defined or undefined at the same time');
 
       const options2 = {
-        recipient           : alice.did,
-        data                : TestDataGenerator.randomBytes(10),
+        recipient  : alice.did,
+        data       : TestDataGenerator.randomBytes(10),
         // dataCid                   : await TestDataGenerator.randomCborSha256Cid(), // intentionally missing
-        dataSize            : 123,
-        dataFormat          : 'application/json',
-        recordId            : await TestDataGenerator.randomCborSha256Cid(),
-        published           : true,
-        authorizationSigner : Jws.createSigner(alice)
+        dataSize   : 123,
+        dataFormat : 'application/json',
+        recordId   : await TestDataGenerator.randomCborSha256Cid(),
+        published  : true,
+        signer     : Jws.createSigner(alice)
       };
       const createPromise2 = RecordsWrite.create(options2);
 
@@ -148,29 +148,29 @@ describe('RecordsWrite', () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const options1 = {
-        recipient           : alice.did,
-        protocol            : 'http://example.com',
+        recipient  : alice.did,
+        protocol   : 'http://example.com',
         // protocolPath                : 'foo/bar', // intentionally missing
-        dataCid             : await TestDataGenerator.randomCborSha256Cid(),
-        dataSize            : 123,
-        dataFormat          : 'application/json',
-        recordId            : await TestDataGenerator.randomCborSha256Cid(),
-        authorizationSigner : Jws.createSigner(alice)
+        dataCid    : await TestDataGenerator.randomCborSha256Cid(),
+        dataSize   : 123,
+        dataFormat : 'application/json',
+        recordId   : await TestDataGenerator.randomCborSha256Cid(),
+        signer     : Jws.createSigner(alice)
       };
       const createPromise1 = RecordsWrite.create(options1);
 
       await expect(createPromise1).to.be.rejectedWith('`protocol` and `protocolPath` must both be defined or undefined at the same time');
 
       const options2 = {
-        recipient           : alice.did,
+        recipient    : alice.did,
         // protocol                    : 'http://example.com', // intentionally missing
-        protocolPath        : 'foo/bar',
-        data                : TestDataGenerator.randomBytes(10),
-        dataCid             : await TestDataGenerator.randomCborSha256Cid(),
-        dataSize            : 123,
-        dataFormat          : 'application/json',
-        recordId            : await TestDataGenerator.randomCborSha256Cid(),
-        authorizationSigner : Jws.createSigner(alice)
+        protocolPath : 'foo/bar',
+        data         : TestDataGenerator.randomBytes(10),
+        dataCid      : await TestDataGenerator.randomCborSha256Cid(),
+        dataSize     : 123,
+        dataFormat   : 'application/json',
+        recordId     : await TestDataGenerator.randomCborSha256Cid(),
+        signer       : Jws.createSigner(alice)
       };
       const createPromise2 = RecordsWrite.create(options2);
 
@@ -287,14 +287,14 @@ describe('RecordsWrite', () => {
         method    : DwnMethodName.Write
       };
       const grantToBob = await PermissionsGrant.create({
-        delegated           : true, // this is a delegated grant
-        dateExpires         : createOffsetTimestamp({ seconds: 100 }),
-        description         : 'Allow to Bob write as me in chat protocol',
-        grantedBy           : alice.did,
-        grantedTo           : bob.did,
-        grantedFor          : alice.did,
+        delegated   : true, // this is a delegated grant
+        dateExpires : createOffsetTimestamp({ seconds: 100 }),
+        description : 'Allow to Bob write as me in chat protocol',
+        grantedBy   : alice.did,
+        grantedTo   : bob.did,
+        grantedFor  : alice.did,
         scope,
-        authorizationSigner : Jws.createSigner(alice)
+        signer      : Jws.createSigner(alice)
       });
 
       const createPromise = RecordsWrite.create({
@@ -333,14 +333,14 @@ describe('RecordsWrite', () => {
         method    : DwnMethodName.Write
       };
       const grantToBob = await PermissionsGrant.create({
-        delegated           : true, // this is a delegated grant
-        dateExpires         : createOffsetTimestamp({ seconds: 100 }),
-        description         : 'Allow to Bob write as me in chat protocol',
-        grantedBy           : alice.did,
-        grantedTo           : bob.did,
-        grantedFor          : alice.did,
+        delegated   : true, // this is a delegated grant
+        dateExpires : createOffsetTimestamp({ seconds: 100 }),
+        description : 'Allow to Bob write as me in chat protocol',
+        grantedBy   : alice.did,
+        grantedTo   : bob.did,
+        grantedFor  : alice.did,
         scope,
-        authorizationSigner : Jws.createSigner(alice)
+        signer      : Jws.createSigner(alice)
       });
 
       const recordsWrite = await RecordsWrite.create({
@@ -408,7 +408,7 @@ describe('RecordsWrite', () => {
       expect(recordsWrite.author).to.not.exist;
       expect(recordsWrite.signaturePayload).to.not.exist;
 
-      expect(() => recordsWrite.message).to.throw(DwnErrorCode.RecordsWriteMissingAuthorizationSigner);
+      expect(() => recordsWrite.message).to.throw(DwnErrorCode.RecordsWriteMissingSigner);
     });
   });
 });

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -316,12 +316,12 @@ export class TestDataGenerator {
       definition.structure[generatedLabel] = {};
     }
 
-    const authorizationSigner = Jws.createSigner(author);
+    const signer = Jws.createSigner(author);
 
     const options: ProtocolsConfigureOptions = {
       messageTimestamp   : input?.messageTimestamp,
       definition,
-      authorizationSigner,
+      signer,
       permissionsGrantId : input?.permissionsGrantId
     };
 
@@ -341,12 +341,12 @@ export class TestDataGenerator {
     // generate author persona if not given
     const author = input?.author ?? await TestDataGenerator.generatePersona();
 
-    const authorizationSigner = Jws.createSigner(author);
+    const signer = Jws.createSigner(author);
 
     const options: ProtocolsQueryOptions = {
       messageTimestamp   : input?.messageTimestamp,
       filter             : input?.filter,
-      authorizationSigner,
+      signer,
       permissionsGrantId : input?.permissionsGrantId,
     };
     removeUndefinedProperties(options);
@@ -608,14 +608,14 @@ export class TestDataGenerator {
       author = await TestDataGenerator.generatePersona();
     }
 
-    let authorizationSigner = undefined;
+    let signer = undefined;
     if (author !== undefined) {
-      authorizationSigner = Jws.createSigner(author);
+      signer = Jws.createSigner(author);
     }
 
     const options: RecordsQueryOptions = {
       messageTimestamp : input?.messageTimestamp,
-      authorizationSigner,
+      signer,
       filter           : input?.filter ?? { schema: TestDataGenerator.randomString(10) }, // must have one filter property if no filter is given
       dateSort         : input?.dateSort,
       pagination       : input?.pagination,
@@ -639,9 +639,9 @@ export class TestDataGenerator {
     const author = input?.author ?? await DidKeyResolver.generate();
 
     const recordsDelete = await RecordsDelete.create({
-      recordId            : input?.recordId ?? await TestDataGenerator.randomCborSha256Cid(),
-      protocolRole        : input?.protocolRole,
-      authorizationSigner : Jws.createSigner(author)
+      recordId     : input?.recordId ?? await TestDataGenerator.randomCborSha256Cid(),
+      protocolRole : input?.protocolRole,
+      signer       : Jws.createSigner(author)
     });
 
     return {
@@ -666,8 +666,8 @@ export class TestDataGenerator {
         interface : DwnInterfaceName.Records,
         method    : DwnMethodName.Write
       },
-      conditions          : input?.conditions,
-      authorizationSigner : Jws.createSigner(author)
+      conditions : input?.conditions,
+      signer     : Jws.createSigner(author)
     });
 
     return {
@@ -695,8 +695,8 @@ export class TestDataGenerator {
         interface : DwnInterfaceName.Records,
         method    : DwnMethodName.Write
       },
-      conditions          : input?.conditions,
-      authorizationSigner : Jws.createSigner(author)
+      conditions : input?.conditions,
+      signer     : Jws.createSigner(author)
     });
 
     return {
@@ -711,10 +711,10 @@ export class TestDataGenerator {
    */
   public static async generatePermissionsRevoke(input?: GeneratePermissionsRevokeInput): Promise<GeneratePermissionsRevokeOutput> {
     const author = input?.author ?? await TestDataGenerator.generatePersona();
-    const authorizationSigner = Jws.createSigner(author);
+    const signer = Jws.createSigner(author);
 
     const permissionsRevoke = await PermissionsRevoke.create({
-      authorizationSigner,
+      signer,
       permissionsGrantId : input?.permissionsGrantId ?? await TestDataGenerator.randomCborSha256Cid(),
       messageTimestamp   : input?.dateCreated
     });
@@ -728,9 +728,9 @@ export class TestDataGenerator {
 
   public static async generateEventsGet(input?: GenerateEventsGetInput): Promise<GenerateEventsGetOutput> {
     const author = input?.author ?? await TestDataGenerator.generatePersona();
-    const authorizationSigner = Jws.createSigner(author);
+    const signer = Jws.createSigner(author);
 
-    const options: EventsGetOptions = { authorizationSigner };
+    const options: EventsGetOptions = { signer };
     if (input?.watermark) {
       options.watermark = input.watermark;
     }
@@ -746,10 +746,10 @@ export class TestDataGenerator {
 
   public static async generateMessagesGet(input: GenerateMessagesGetInput): Promise<GenerateMessagesGetOutput> {
     const author = input?.author ?? await TestDataGenerator.generatePersona();
-    const authorizationSigner = Jws.createSigner(author);
+    const signer = Jws.createSigner(author);
 
     const options: MessagesGetOptions = {
-      authorizationSigner,
+      signer,
       messageCids: input.messageCids
     };
 


### PR DESCRIPTION
More backlog refactoring and renaming from the PR that introduced delegation in #582

1. Improved `createSignerSignature()` method signature
1. Renamed `createAuthorizationAsAuthor()` -> `createAuthorization()`
1. Renamed `authorizationSigner` -> `signer`