### PR TITLE
Fixed bug on usage of `GeneralJwsVerifier` and improved its usability

### DIFF
--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -14,8 +14,8 @@ export class DwnError extends Error {
  */
 export enum DwnErrorCode {
   AuthenticateJwsMissing = 'AuthenticateJwsMissing',
-  AuthenticateMoreThanOneAuthoriation = 'AuthenticateMoreThanOneAuthoriation',
   AuthenticateDescriptorCidMismatch = 'AuthenticateDescriptorCidMismatch',
+  AuthenticationMoreThanOneSignatureNotSupported = 'AuthenticationMoreThanOneSignatureNotSupported',
   AuthorizationUnknownAuthor = 'AuthorizationUnknownAuthor',
   AuthorizationNotGrantedToAuthor = 'AuthorizationNotGrantedToAuthor',
   ComputeCidCodecNotSupported = 'ComputeCidCodecNotSupported',
@@ -25,6 +25,7 @@ export enum DwnErrorCode {
   DidNotValid = 'DidNotValid',
   DidResolutionFailed = 'DidResolutionFailed',
   Ed25519InvalidJwk = 'Ed25519InvalidJwk',
+  GeneralJwsVerifierGetPublicKeyNotFound = 'GeneralJwsVerifierGetPublicKeyNotFound',
   GeneralJwsVerifierInvalidSignature = 'GeneralJwsVerifierInvalidSignature',
   GrantAuthorizationGrantExpired = 'GrantAuthorizationGrantExpired',
   GrantAuthorizationGrantMissing = 'GrantAuthorizationGrantMissing',
@@ -76,7 +77,6 @@ export enum DwnErrorCode {
   ProtocolsQueryUnauthorized = 'ProtocolsQueryUnauthorized',
   RecordsDecryptNoMatchingKeyEncryptedFound = 'RecordsDecryptNoMatchingKeyEncryptedFound',
   RecordsDeleteAuthorizationFailed = 'RecordsDeleteAuthorizationFailed',
-
   RecordsGrantAuthorizationConditionPublicationProhibited = 'RecordsGrantAuthorizationConditionPublicationProhibited',
   RecordsGrantAuthorizationConditionPublicationRequired = 'RecordsGrantAuthorizationConditionPublicationRequired',
   RecordsGrantAuthorizationScopeContextIdMismatch = 'RecordsGrantAuthorizationScopeContextIdMismatch',
@@ -131,5 +131,4 @@ export enum DwnErrorCode {
   UrlProtocolNotNormalizable = 'UrlProtocolNotNormalizable',
   UrlSchemaNotNormalized = 'UrlSchemaNotNormalized',
   UrlSchemaNotNormalizable = 'UrlSchemaNotNormalizable',
-  VerifierValidPublicKeyNotFound = 'VerifierValidPublicKeyNotFound',
 };

--- a/src/utils/jws.ts
+++ b/src/utils/jws.ts
@@ -8,7 +8,7 @@ import isPlainObject from 'lodash/isPlainObject.js';
 import { Encoder } from './encoder.js';
 import { PrivateKeySigner } from './private-key-signer.js';
 import { signatureAlgorithms } from '../jose/algorithms/signing/signature-algorithms.js';
-import { DwnError, DwnErrorCode } from '../index.js';
+import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 
 
 /**

--- a/tests/jose/jws/general.spec.ts
+++ b/tests/jose/jws/general.spec.ts
@@ -193,7 +193,7 @@ describe('General JWS Sign/Verify', () => {
     const verifySignatureSpy = sinon.spy(Jws, 'verifySignature');
     const cacheSetSpy = sinon.spy((GeneralJwsVerifier as any).singleton.cache, 'set');
 
-    // intentionally calling verifySignature twice on the same JWS
+    // intentionally calling verifySignatures() multiple times on the same JWS
     await GeneralJwsVerifier.verifySignatures(jws, resolverStub);
     await GeneralJwsVerifier.verifySignatures(jws, resolverStub);
     await GeneralJwsVerifier.verifySignatures(jws, resolverStub);

--- a/tests/jose/jws/verifier.spec.ts
+++ b/tests/jose/jws/verifier.spec.ts
@@ -1,8 +1,0 @@
-describe('GeneralJwsVerifier', () => {
-  describe('getPublicKey', () => {
-    xit('throws an exception if publicKeyJwk isn\'t present in verificationMethod', () => {});
-    xit('throws an exception if DID could not be resolved', () => {});
-    xit('throws an exception if appropriate key isnt present in DID Doc', () => {});
-    xit('throws an exception if verificationMethod type isn\'t JsonWebKey2020', () => {});
-  });
-});


### PR DESCRIPTION
1. Fixed bug where a new cache is created every time the DWN performs a signature check
1. Removed the need to instantiate a new instance of `GeneralJwsVerifier` every time DWN performs a signature check
1. Improved perf by not doing DID resolution when the signature check result is already cached
1. Minor error code naming improvements