### PR TITLE
Remove circular dependency causing problems in lib consumer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/dwn-sdk-js",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "A reference implementation of https://identity.foundation/decentralized-web-node/spec/",
   "repository": {
     "type": "git",

--- a/src/jose/algorithms/signing/ed25519.ts
+++ b/src/jose/algorithms/signing/ed25519.ts
@@ -2,7 +2,7 @@ import * as Ed25519 from '@noble/ed25519';
 import type { PrivateJwk, PublicJwk, SignatureAlgorithm } from '../../../types/jose-types.js';
 
 import { Encoder } from '../../../utils/encoder.js';
-import { DwnError, DwnErrorCode } from '../../../index.js';
+import { DwnError, DwnErrorCode } from '../../../core/dwn-error.js';
 
 function validateKey(jwk: PrivateJwk | PublicJwk): void {
   if (jwk.kty !== 'OKP' || jwk.crv !== 'Ed25519') {


### PR DESCRIPTION
We have some circular dependencies in `dwn-sdk-js` that we should consider removing/resolving. One circular dependency in particular is causing issues in consumers of `dwn-sdk-js`.

In [this PR](https://github.com/TBD54566975/dwn-sql-store/pull/9) `dwn-sql-store`, we are getting the following error upon running tests:
> ReferenceError: Cannot access 'ed25519' before initialization
    at <anonymous> (/home/runner/work/dwn-sql-store/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/src/jose/algorithms/signing/signature-algorithms.ts:8:17)
    at ModuleJob.run (node:internal/modules/esm/module_job:217:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:316:24)
    at async importModuleDynamicallyWrapper (node:internal/vm/module:431:15)
    at async formattedImport (/home/runner/work/dwn-sql-store/dwn-sql-store/node_modules/mocha/lib/nodejs/esm-utils.js:9:[14](https://github.com/TBD54566975/dwn-sql-store/actions/runs/6738382995/job/18317836074#step:9:15))
    at async exports.requireOrImport (/home/runner/work/dwn-sql-store/dwn-sql-store/node_modules/mocha/lib/nodejs/esm-utils.js:42:28)
    at async exports.loadFilesAsync (/home/runner/work/dwn-sql-store/dwn-sql-store/node_modules/mocha/lib/nodejs/esm-utils.js:100:20)
    at async singleRun (/home/runner/work/dwn-sql-store/dwn-sql-store/node_modules/mocha/lib/cli/run-helpers.js:125:3)
    at async exports.handler (/home/runner/work/dwn-sql-store/dwn-sql-store/node_modules/mocha/lib/cli/run.js:370:5)

This culprit is importing `index.js` in `ed25519.ts` in this PR: https://github.com/TBD54566975/dwn-sdk-js/pull/591/files#diff-1b59382673e9e3dc1c3ec5cc4aebccb275379aa957877a6c0bdf8a6d2cadfcc0R5

Importing directly from `dwn-error.ts` instead of `index.js` fixed the error in `dwn-sql-store`.

