### PR TITLE
Authorize direct recipient of protocol records

### DIFF
--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -72,6 +72,7 @@ export enum DwnErrorCode {
   ProtocolsConfigureInvalidRole = 'ProtocolsConfigureInvalidRole',
   ProtocolsConfigureInvalidActionMissingOf = 'ProtocolsConfigureInvalidActionMissingOf',
   ProtocolsConfigureInvalidActionOfNotAllowed = 'ProtocolsConfigureInvalidActionOfNotAllowed',
+  ProtocolsConfigureInvalidRecipientOfAction = 'ProtocolsConfigureInvalidRecipientOfAction',
   ProtocolsConfigureQueryNotAllowed = 'ProtocolsConfigureQueryNotAllowed',
   ProtocolsConfigureUnauthorized = 'ProtocolsConfigureUnauthorized',
   ProtocolsQueryUnauthorized = 'ProtocolsQueryUnauthorized',

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -555,7 +555,7 @@ export class ProtocolAuthorization {
         if (incomingMessage.message.descriptor.method === DwnMethodName.Write) {
           recordsWriteMessage = incomingMessage.message as RecordsWriteMessage;
         } else {
-          // else the incoming message must be a RecordsDelete because only `update` and `delete` are allowed recipient actions 
+          // else the incoming message must be a RecordsDelete because only `update` and `delete` are allowed recipient actions
           recordsWriteMessage = ancestorMessageChain[ancestorMessageChain.length - 1];
         }
         if (recordsWriteMessage.descriptor.recipient === author) {

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -555,6 +555,7 @@ export class ProtocolAuthorization {
         if (incomingMessage.message.descriptor.method === DwnMethodName.Write) {
           recordsWriteMessage = incomingMessage.message as RecordsWriteMessage;
         } else {
+          // else the incoming message must be a RecordsDelete because only `update` and `delete` are allowed recipient actions 
           recordsWriteMessage = ancestorMessageChain[ancestorMessageChain.length - 1];
         }
         if (recordsWriteMessage.descriptor.recipient === author) {

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -549,6 +549,17 @@ export class ProtocolAuthorization {
         } else {
           continue;
         }
+      } else if (actionRule.who === ProtocolActor.Recipient && actionRule.of === undefined && author !== undefined) {
+        // Author must be recipient of the record being accessed
+        let recordsWriteMessage: RecordsWriteMessage;
+        if (incomingMessage.message.descriptor.method === DwnMethodName.Write) {
+          recordsWriteMessage = incomingMessage.message as RecordsWriteMessage;
+        } else {
+          recordsWriteMessage = ancestorMessageChain[ancestorMessageChain.length - 1];
+        }
+        if (recordsWriteMessage.descriptor.recipient === author) {
+          return;
+        }
       } else if (actionRule.who === ProtocolActor.Anyone) {
         return;
       } else if (author === undefined) {

--- a/src/interfaces/protocols-configure.ts
+++ b/src/interfaces/protocols-configure.ts
@@ -135,6 +135,11 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
       }
 
       // Validate that if `who === recipient` and `of === undefined`, then `can` is either `delete` or `update`
+      // We will not use direct recipient for `read`, `write`, or `query` because:
+      // - Recipients are always allowed to `read`.
+      // - `write` entails ability to create and update, whereas `update` only allows for updates.
+      //    There is no 'recipient' until the record has been created, so it makes no sense to allow recipient to write.
+      // - At this time, `query` is only authorized using roles, so allowing direct recipients to query is outside the scope of this PR.
       if (action.who === ProtocolActor.Recipient &&
           action.of === undefined &&
           !['update', 'delete'].includes(action.can)

--- a/src/interfaces/protocols-configure.ts
+++ b/src/interfaces/protocols-configure.ts
@@ -149,7 +149,7 @@ export class ProtocolsConfigure extends Message<ProtocolsConfigureMessage> {
       if (action.who === ProtocolActor.Author && !action.of) {
         throw new DwnError(
           DwnErrorCode.ProtocolsConfigureInvalidActionMissingOf,
-          `'of' is required at protocol path (${protocolPath})`
+          `'of' is required when 'author' is specified as 'who'`
         );
       }
     }

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -1289,7 +1289,7 @@ export function testRecordsWriteHandler(): void {
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, recordsWrite.dataStream);
             expect(recordsWriteReply.status.code).to.eq(202);
 
-            // Carol is unable to delete the 'post'
+            // Carol is unable to update the 'post'
             const carolRecordsWrite = await TestDataGenerator.generateFromRecordsWrite({
               author        : carol,
               existingWrite : recordsWrite.recordsWrite

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -1298,7 +1298,7 @@ export function testRecordsWriteHandler(): void {
             expect(carolRecordsWriteReply.status.code).to.eq(401);
             expect(carolRecordsWriteReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationActionNotAllowed);
 
-            // Bob is able to delete the post
+            // Bob is able to update the post
             const bobRecordsWrite = await TestDataGenerator.generateFromRecordsWrite({
               author        : bob,
               existingWrite : recordsWrite.recordsWrite,

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -1258,6 +1258,54 @@ export function testRecordsWriteHandler(): void {
             expect(bobTagRecordsReply.status.code).to.equal(401);
             expect(bobTagRecordsReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationActionNotAllowed);
           });
+
+          it('should allowed update with direct recipient rule', async () => {
+            // scenario: Alice creates a 'post' with Bob as recipient. Bob is able to update
+            //           the 'post' because he was recipient of it. Carol is not able to update it.
+
+            const protocolDefinition = recipientCanProtocol as ProtocolDefinition;
+            const alice = await TestDataGenerator.generatePersona();
+            const bob = await TestDataGenerator.generatePersona();
+            const carol = await TestDataGenerator.generatePersona();
+
+            const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
+              author: alice,
+              protocolDefinition
+            });
+
+            // setting up a stub DID resolver
+            TestStubGenerator.stubDidResolver(didResolver, [alice, bob, carol]);
+
+            const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message);
+            expect(protocolsConfigureReply.status.code).to.equal(202);
+
+            // Alice creates a 'post' with Bob as recipient
+            const recordsWrite = await TestDataGenerator.generateRecordsWrite({
+              author       : alice,
+              recipient    : bob.did,
+              protocol     : protocolDefinition.protocol,
+              protocolPath : 'post',
+            });
+            const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, recordsWrite.dataStream);
+            expect(recordsWriteReply.status.code).to.eq(202);
+
+            // Carol is unable to delete the 'post'
+            const carolRecordsWrite = await TestDataGenerator.generateFromRecordsWrite({
+              author        : carol,
+              existingWrite : recordsWrite.recordsWrite
+            });
+            const carolRecordsWriteReply = await dwn.processMessage(alice.did, carolRecordsWrite.message);
+            expect(carolRecordsWriteReply.status.code).to.eq(401);
+            expect(carolRecordsWriteReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationActionNotAllowed);
+
+            // Bob is able to delete the post
+            const bobRecordsWrite = await TestDataGenerator.generateFromRecordsWrite({
+              author        : bob,
+              existingWrite : recordsWrite.recordsWrite,
+            });
+            const bobRecordsWriteReply = await dwn.processMessage(alice.did, bobRecordsWrite.message, bobRecordsWrite.dataStream);
+            expect(bobRecordsWriteReply.status.code).to.eq(202);
+          });
         });
 
         describe('author action rules', () => {

--- a/tests/interfaces/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols-configure.spec.ts
@@ -285,7 +285,7 @@ describe('ProtocolsConfigure', () => {
           .to.be.rejectedWith(DwnErrorCode.ProtocolsConfigureInvalidActionOfNotAllowed);
       });
 
-      it('rejects protocol definitions with actions that have recipient-can rules with actions other than delete or update', async () => {
+      it('rejects protocol definitions with actions that have direct-recipient-can rules with actions other than delete or update', async () => {
         const definition = {
           published : true,
           protocol  : 'http://example.com',

--- a/tests/interfaces/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols-configure.spec.ts
@@ -285,7 +285,35 @@ describe('ProtocolsConfigure', () => {
           .to.be.rejectedWith(DwnErrorCode.ProtocolsConfigureInvalidActionOfNotAllowed);
       });
 
-      it('rejects protocol definitions with actions that don\'t contain `of` and  `who` is `author` or `recipient`', async () => {
+      it('rejects protocol definitions with actions that have recipient-can rules with actions other than delete or update', async () => {
+        const definition = {
+          published : true,
+          protocol  : 'http://example.com',
+          types     : {
+            message: {},
+          },
+          structure: {
+            message: {
+              $actions: [{
+                who : 'recipient',
+                can : 'read' // not allowed, should be either delete or update
+              }]
+            }
+          }
+        };
+
+        const alice = await TestDataGenerator.generatePersona();
+
+        const createProtocolsConfigurePromise = ProtocolsConfigure.create({
+          signer: Jws.createSigner(alice),
+          definition
+        });
+
+        await expect(createProtocolsConfigurePromise)
+          .to.be.rejectedWith(DwnErrorCode.ProtocolsConfigureInvalidRecipientOfAction);
+      });
+
+      it('rejects protocol definitions with actions that don\'t contain `of` and  `who` is `author`', async () => {
         const definition = {
           published : true,
           protocol  : 'http://example.com',

--- a/tests/vectors/protocol-definitions/recipient-can.json
+++ b/tests/vectors/protocol-definitions/recipient-can.json
@@ -7,6 +7,16 @@
   },
   "structure": {
     "post": {
+      "$actions": [
+        {
+          "who": "recipient",
+          "can": "update"
+        },
+        {
+          "who": "recipient",
+          "can": "delete"
+        }
+      ],
       "tag": {
         "$actions": [
           {


### PR DESCRIPTION
Allow actions rules of the format `who: 'recipient', can: ...` for `update` and `delete`.

We will not use direct recipient for `read`, `write`, or `query` because:
* Recipients are always allowed to `read`.
* `write` entails ability to create and update, whereas `update` only allows for updates. There is no 'recipient' until the record has been created, so it makes no sense to allow `recipient` to `write`.
* At this time, `query` is only authorized using `roles`, so allowing direct recipients to query is outside the scope of this PR.