### PR TITLE
tweak rn to depend on esm bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,10 +59,7 @@
       "types": "./dist/types/tests/test-suite.d.ts"
     }
   },
-  "@comment react-native": [
-    "directive for metro (react native build tool)."
-  ],
-  "react-native": "./dist/cjs/index.js",
+  "react-native": "./dist/esm/src/index.js",
   "dependencies": {
     "@ipld/dag-cbor": "9.0.3",
     "@js-temporal/polyfill": "0.4.4",


### PR DESCRIPTION
The RN bundle specified was CJS but RN is compatible with ESM (via babel)