### PR TITLE
Replace `paginationMessageCid` with `cursor` for pagination query options and response.

### DIFF
--- a/json-schemas/interface-methods/records-query.json
+++ b/json-schemas/interface-methods/records-query.json
@@ -46,7 +46,7 @@
               "type": "number",
               "minimum": 1
             },
-            "messageCid": {
+            "cursor": {
               "type": "string"
             }
           }

--- a/src/types/message-store.ts
+++ b/src/types/message-store.ts
@@ -42,7 +42,7 @@ export interface MessageStore {
     messageSort?: MessageSort,
     pagination?: Pagination,
     options?: MessageStoreOptions
-  ): Promise<{ messages: GenericMessage[], paginationMessageCid?: string }>;
+  ): Promise<{ messages: GenericMessage[], cursor?: string }>;
 
   /**
    * Deletes the message associated with the id provided.

--- a/src/types/message-types.ts
+++ b/src/types/message-types.ts
@@ -93,9 +93,14 @@ export type Filter = {
   [property: string]: EqualFilter | OneOfFilter | RangeFilter
 };
 
+/**
+ * Pagination Options for querying messages.
+ *
+ * The cursor is the messageCid of the message you would like to pagination from.
+ */
 export type Pagination = {
-  messageCid?: string
-  limit?: number
+  cursor?: string;
+  limit?: number;
 };
 
 export enum SortOrder {

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -149,7 +149,7 @@ export type RecordsQueryMessage = GenericMessage & {
 
 export type RecordsQueryReply = GenericMessageReply & {
   entries?: RecordsQueryReplyEntry[];
-  paginationMessageCid?: string;
+  cursor?: string;
 };
 
 export type RecordsReadMessage = {

--- a/tests/store/message-store.spec.ts
+++ b/tests/store/message-store.spec.ts
@@ -389,11 +389,11 @@ export function testMessageStore(): void {
 
           // get all of the records
           const allRecords = await messageStore.query(alice.did, [{}], {}, { limit: 10 });
-          expect(allRecords.paginationMessageCid).to.not.exist;
+          expect(allRecords.cursor).to.not.exist;
 
           // get only partial records
           const partialRecords = await messageStore.query(alice.did, [{}], {}, { limit: 5 });
-          expect(partialRecords.paginationMessageCid).to.exist.and.to.not.be.undefined;
+          expect(partialRecords.cursor).to.exist.and.to.not.be.undefined;
         });
 
         it('should return all records from the cursor onwards when no limit is provided', async () => {
@@ -411,7 +411,7 @@ export function testMessageStore(): void {
           const offset = 5;
           const cursor = await Message.getCid(sortedRecords[offset - 1].message);
 
-          const { messages: limitQuery } = await messageStore.query(alice.did, [{}], {}, { messageCid: cursor });
+          const { messages: limitQuery } = await messageStore.query(alice.did, [{}], {}, { cursor });
           expect(limitQuery.length).to.equal(sortedRecords.slice(offset).length);
           for (let i = 0; i < limitQuery.length; i++) {
             const offsetIndex = i + offset;
@@ -435,7 +435,7 @@ export function testMessageStore(): void {
           const cursor = await Message.getCid(sortedRecords[offset - 1].message);
           const limit = 3;
 
-          const { messages: limitQuery } = await messageStore.query(alice.did, [{}], {}, { messageCid: cursor, limit });
+          const { messages: limitQuery } = await messageStore.query(alice.did, [{}], {}, { cursor, limit });
           expect(limitQuery.length).to.equal(limit);
           for (let i = 0; i < limitQuery.length; i++) {
             const offsetIndex = i + offset;
@@ -456,10 +456,10 @@ export function testMessageStore(): void {
           const results = [];
           let cursor: string | undefined;
           while (true) {
-            const { messages: limitQuery, paginationMessageCid } = await messageStore.query(alice.did, [{}], {}, { messageCid: cursor, limit });
+            const { messages: limitQuery, cursor: queryCursor } = await messageStore.query(alice.did, [{}], {}, { cursor, limit });
             expect(limitQuery.length).to.be.lessThanOrEqual(limit);
             results.push(...limitQuery);
-            cursor = paginationMessageCid;
+            cursor = queryCursor;
             if (cursor === undefined) {
               break;
             }
@@ -482,7 +482,7 @@ export function testMessageStore(): void {
           }
 
           const limit = 4;
-          const { messages: limitQuery } = await messageStore.query(alice.did, [{}], {}, { messageCid: 'some-cursor', limit });
+          const { messages: limitQuery } = await messageStore.query(alice.did, [{}], {}, { cursor: 'some-cursor', limit });
           expect(limitQuery.length).to.be.equal(0);
         });
       });


### PR DESCRIPTION
When bubbling up this change into `web5-js` @frankhinek had a comment about a more intuitive developer experience.
https://github.com/TBD54566975/web5-js/pull/268#discussion_r1388020519

I know we originally wanted to be explicit with what the `cursor` value should be, but I think that it's more appropriate for the spec rather than the naming of the variable.

@thehenrytsai what are your thoughts here?