### PR TITLE
#564 - Added delegated grant support for RecordsDelete

### DIFF
--- a/json-schemas/interface-methods/records-delete.json
+++ b/json-schemas/interface-methods/records-delete.json
@@ -9,7 +9,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/authorization.json"
+      "$ref": "https://identity.foundation/dwn/json-schemas/authorization-delegated-grant.json"
     },
     "descriptor": {
       "type": "object",

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -468,7 +468,7 @@ export class ProtocolAuthorization {
     if (matchingMessages.length === 0) {
       throw new DwnError(
         DwnErrorCode.ProtocolAuthorizationMissingRole,
-        `No role record found for protocol path ${protocolRole}`
+        `No matching role record found for protocol path ${protocolRole}`
       );
     }
   }

--- a/src/utils/records.ts
+++ b/src/utils/records.ts
@@ -1,7 +1,7 @@
 import type { DerivedPrivateJwk } from './hd-key.js';
 import type { Readable } from 'readable-stream';
 import type { Filter, GenericSignaturePayload, RangeFilter } from '../types/message-types.js';
-import type { RangeCriterion, RecordsFilter, RecordsQueryMessage, RecordsReadMessage, RecordsWriteDescriptor, RecordsWriteMessage } from '../types/records-types.js';
+import type { RangeCriterion, RecordsDeleteMessage, RecordsFilter, RecordsQueryMessage, RecordsReadMessage, RecordsWriteDescriptor, RecordsWriteMessage } from '../types/records-types.js';
 
 import { Encoder } from './encoder.js';
 import { Encryption } from './encryption.js';
@@ -296,7 +296,7 @@ export class Records {
    *                         Usage of this property is purely for performance optimization so we don't have to decode the signature payload again.
    */
   public static validateDelegatedGrantReferentialIntegrity(
-    message: RecordsReadMessage | RecordsQueryMessage | RecordsWriteMessage,
+    message: RecordsReadMessage | RecordsQueryMessage | RecordsWriteMessage | RecordsDeleteMessage,
     signaturePayload: GenericSignaturePayload | undefined
   ): void {
     // `deletedGrantId` in the payload of the message signature and `authorDelegatedGrant` in `authorization` must both exist or be both undefined

--- a/tests/vectors/protocol-definitions/thread-role.json
+++ b/tests/vectors/protocol-definitions/thread-role.json
@@ -5,9 +5,13 @@
     "thread": {},
     "participant": {},
     "admin": {},
+    "globalAdmin": {},
     "chat": {}
   },
   "structure": {
+    "globalAdmin": {
+      "$globalRole": true
+    },
     "thread": {
       "$actions": [
         {
@@ -51,6 +55,10 @@
           },
           {
             "role": "thread/admin",
+            "can": "delete"
+          },
+          {
+            "role": "globalAdmin",
             "can": "delete"
           }
         ]


### PR DESCRIPTION
1. Added delegated grant support for `RecordsDelete`
1. Merged mainline positive and negative cases of delegated grants into one test to reduce context switching.