### PR TITLE
Add `author` to `RecordsFilter`

### DIFF
--- a/json-schemas/interface-methods/records-filter.json
+++ b/json-schemas/interface-methods/records-filter.json
@@ -11,6 +11,9 @@
     "protocolPath": {
       "type": "string"
     },
+    "author": {
+      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/did"
+    },
     "attester": {
       "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/did"
     },

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -103,6 +103,8 @@ export type RecordsQueryDescriptor = {
 };
 
 export type RecordsFilter = {
+  /**the logical author of the record */
+  author?: string;
   attester?: string;
   recipient?: string;
   protocol?: string;


### PR DESCRIPTION
We already index the `author` property for `RecordsWrite` but we currently don't expose it as a filter.