### PR TITLE
Update `DateSort` export and `UnionMessageReply`

### DIFF
--- a/src/core/message-reply.ts
+++ b/src/core/message-reply.ts
@@ -30,7 +30,13 @@ export type UnionMessageReply = GenericMessageReply & {
 
   /**
    * Data corresponding to the message received if applicable (e.g. RecordsRead).
-   * Mutually exclusive with `entries`.
+   * Mutually exclusive with `entries` and `cursor`.
    */
   data?: Readable;
+
+  /**
+   * A cursor for pagination if applicable (e.g. RecordsQuery).
+   * Mutually exclusive with `data`.
+   */
+  cursor?: string;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,13 +8,14 @@ export type { MessagesGetMessage, MessagesGetReply } from './types/messages-type
 export type { PermissionConditions, PermissionScope, PermissionsGrantDescriptor } from './types/permissions-grant-descriptor.js';
 export type { PermissionsGrantMessage, PermissionsRequestDescriptor, PermissionsRequestMessage, PermissionsRevokeDescriptor, PermissionsRevokeMessage } from './types/permissions-types.js';
 export type { ProtocolsConfigureDescriptor, ProtocolDefinition, ProtocolTypes, ProtocolRuleSet, ProtocolsQueryFilter, ProtocolsConfigureMessage, ProtocolsQueryMessage, ProtocolsQueryReply } from './types/protocols-types.js';
-export type { DateSort, EncryptionProperty, RecordsDeleteMessage, RecordsQueryMessage, RecordsQueryReply, RecordsQueryReplyEntry, RecordsReadReply, RecordsWriteDescriptor, RecordsWriteMessage } from './types/records-types.js';
+export type { EncryptionProperty, RecordsDeleteMessage, RecordsQueryMessage, RecordsQueryReply, RecordsQueryReplyEntry, RecordsReadReply, RecordsWriteDescriptor, RecordsWriteMessage } from './types/records-types.js';
 export { authenticate } from './core/auth.js';
 export { AllowAllTenantGate, TenantGate } from './core/tenant-gate.js';
 export { Cid } from './utils/cid.js';
 export { RecordsQuery, RecordsQueryOptions } from './interfaces/records-query.js';
 export { DataStore, PutResult, GetResult, AssociateResult } from './types/data-store.js';
 export { DataStream } from './utils/data-stream.js';
+export { DateSort } from './types/records-types.js';
 export { DerivedPrivateJwk, HdKey, KeyDerivationScheme } from './utils/hd-key.js';
 export { DidKeyResolver } from './did/did-key-resolver.js';
 export { DidIonResolver } from './did/did-ion-resolver.js';


### PR DESCRIPTION
- When fixing circular deps `DateSort` was exported as a type, however it is an enum and to use the enum values you must export it without the type flag.
- Adding an optional `cursor` to `UnionMessageReply` so that `processMessage` for a generic message will respond with an appropriate type.