### PR TITLE
Allow initial RecordsWrite without data to be written to the DWN.

### DIFF
--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -117,6 +117,7 @@ export enum DwnErrorCode {
   RecordsWriteMissingAuthorizationSigner = 'RecordsWriteMissingAuthorizationSigner',
   RecordsWriteMissingSigner = 'RecordsWriteMissingSigner',
   RecordsWriteMissingDataInPrevious = 'RecordsWriteMissingDataInPrevious',
+  RecordsWriteMissingEncodedDataInPrevious = 'RecordsWriteMissingEncodedDataInPrevious',
   RecordsWriteMissingDataAssociation = 'RecordsWriteMissingDataAssociation',
   RecordsWriteMissingDataStream = 'RecordsWriteMissingDataStream',
   RecordsWriteMissingProtocol = 'RecordsWriteMissingProtocol',

--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -114,7 +114,6 @@ export enum DwnErrorCode {
   RecordsWriteGetEntryIdUndefinedAuthor = 'RecordsWriteGetEntryIdUndefinedAuthor',
   RecordsWriteGetInitialWriteNotFound = 'RecordsWriteGetInitialWriteNotFound',
   RecordsWriteImmutablePropertyChanged = 'RecordsWriteImmutablePropertyChanged',
-  RecordsWriteMissingAuthorizationSigner = 'RecordsWriteMissingAuthorizationSigner',
   RecordsWriteMissingSigner = 'RecordsWriteMissingSigner',
   RecordsWriteMissingDataInPrevious = 'RecordsWriteMissingDataInPrevious',
   RecordsWriteMissingEncodedDataInPrevious = 'RecordsWriteMissingEncodedDataInPrevious',

--- a/src/dwn.ts
+++ b/src/dwn.ts
@@ -148,8 +148,6 @@ export class Dwn {
    */
   public async validateMessageIntegrity(
     rawMessage: any,
-    expectedInterface?: DwnInterfaceName,
-    expectedMethod?: DwnMethodName,
   ): Promise<GenericMessageReply | undefined> {
     // Verify interface and method
     const dwnInterface = rawMessage?.descriptor?.interface;
@@ -157,17 +155,6 @@ export class Dwn {
     if (dwnInterface === undefined || dwnMethod === undefined) {
       return {
         status: { code: 400, detail: `Both interface and method must be present, interface: ${dwnInterface}, method: ${dwnMethod}` }
-      };
-    }
-
-    if (expectedInterface !== undefined && expectedInterface !== dwnInterface) {
-      return {
-        status: { code: 400, detail: `Expected interface ${expectedInterface}, received ${dwnInterface}` }
-      };
-    }
-    if (expectedMethod !== undefined && expectedMethod !== dwnMethod) {
-      return {
-        status: { code: 400, detail: `Expected method ${expectedInterface}${expectedMethod}, received ${dwnInterface}${dwnMethod}` }
       };
     }
 

--- a/src/dwn.ts
+++ b/src/dwn.ts
@@ -4,7 +4,6 @@ import type { GenericMessage } from './types/message-types.js';
 import type { MessageStore } from './types/message-store.js';
 import type { MethodHandler } from './types/method-handler.js';
 import type { Readable } from 'readable-stream';
-import type { RecordsWriteHandlerOptions } from './handlers/records-write.js';
 import type { TenantGate } from './core/tenant-gate.js';
 import type { EventsGetMessage, EventsGetReply, EventsQueryMessage, EventsQueryReply } from './types/event-types.js';
 import type { GenericMessageReply, UnionMessageReply } from './core/message-reply.js';
@@ -122,26 +121,6 @@ export class Dwn {
       dataStream
     });
 
-    return methodHandlerReply;
-  }
-
-  /**
-   * Privileged method for writing a pruned initial `RecordsWrite` to a DWN without needing to supply associated data.
-   */
-  public async synchronizePrunedInitialRecordsWrite(tenant: string, message: RecordsWriteMessage): Promise<GenericMessageReply> {
-    const errorMessageReply =
-      await this.validateTenant(tenant) ??
-      await this.validateMessageIntegrity(message, DwnInterfaceName.Records, DwnMethodName.Write);
-    if (errorMessageReply !== undefined) {
-      return errorMessageReply;
-    }
-
-    const options: RecordsWriteHandlerOptions = {
-      skipDataStorage: true,
-    };
-
-    const handler = new RecordsWriteHandler(this.didResolver, this.messageStore, this.dataStore, this.eventLog);
-    const methodHandlerReply = await handler.handle({ tenant, message, options });
     return methodHandlerReply;
   }
 

--- a/src/handlers/records-write.ts
+++ b/src/handlers/records-write.ts
@@ -4,7 +4,7 @@ import type { EventLog } from '../types/event-log.js';
 import type { GenericMessageReply } from '../core/message-reply.js';
 import type { MessageStore } from '../types//message-store.js';
 import type { MethodHandler } from '../types/method-handler.js';
-import type { RecordsDeleteMessage, RecordsWriteMessage, RecordsWriteMessageWithOptionalEncodedData } from '../types/records-types.js';
+import type { RecordsWriteMessage, RecordsWriteMessageWithOptionalEncodedData } from '../types/records-types.js';
 
 import { authenticate } from '../core/auth.js';
 import { Cid } from '../utils/cid.js';
@@ -87,57 +87,43 @@ export class RecordsWriteHandler implements MethodHandler {
       };
     }
 
-    const isLatestBaseState = true;
-    const indexes = await recordsWrite.constructRecordsWriteIndexes(isLatestBaseState);
+    try {
+      // we set latestBaseState initially to false, as we allow `RecordsWrite` without a data stream in some cases
+      // depending on validation rules within `processMessageWithDataStream` and `processMessageWithoutDataStream`
+      // if it has been associated data and should show up in reads/queries
+      let isLatestBaseState = false;
+      let messageWithOptionalEncodedData = message as RecordsWriteMessageWithOptionalEncodedData;
 
-    // if data is below a certain threshold, we embed the data directly into the message for storage in MessageStore.
-    let messageWithOptionalEncodedData: RecordsWriteMessageWithOptionalEncodedData = message;
-    if (dataStream === undefined && newestExistingMessage?.descriptor.method === DwnMethodName.Delete) {
-      return messageReplyFromError(new DwnError(DwnErrorCode.RecordsWriteMissingDataStream, 'No data stream was provided with the previous message being a delete'), 400);
-    } else if (newMessageIsInitialWrite && dataStream === undefined) {
-      // we allow pruned writing of the initial RecordsWrite message in cases where we do not have the original data,
-      // however this is not the latest base state of the record and should not be queryable/readable until a subsequent write with appropriate data.
-      indexes.isLatestBaseState = false;
-    } else {
-
-      try {
-        if (dataStream === undefined) {
-          const newestRecordsWriteMessage = newestExistingMessage as RecordsWriteMessage;
-          // if no data stream exists and this is not the initial message, check data integrity against the newest message.
-          RecordsWriteHandler.validateDataIntegrity(
-            newestRecordsWriteMessage?.descriptor.dataCid,
-            newestRecordsWriteMessage.descriptor.dataSize,
-            message.descriptor.dataCid,
-            message.descriptor.dataSize,
-          );
-        }
-        // if data is below the threshold, we store it within MessageStore
-        if (message.descriptor.dataSize <= DwnConstant.maxDataSizeAllowedToBeEncoded) {
-          // processes and sets `encodedData` with appropriate data.
-          messageWithOptionalEncodedData = await this.processEncodedData(
-            message,
-            dataStream,
-            newestExistingMessage as (RecordsWriteMessage|RecordsDeleteMessage) | undefined
-          );
-        } else {
-          await this.putData(tenant, message, dataStream);
-        }
-      } catch (error) {
-        const e = error as any;
-        if (e.code === DwnErrorCode.RecordsWriteMissingDataInPrevious ||
-            e.code === DwnErrorCode.RecordsWriteMissingDataAssociation ||
-            e.code === DwnErrorCode.RecordsWriteDataCidMismatch ||
-            e.code === DwnErrorCode.RecordsWriteDataSizeMismatch) {
-          return messageReplyFromError(error, 400);
-        }
-
-        // else throw
-        throw error;
+      if (dataStream !== undefined) {
+        ({ isLatestBaseState, messageWithOptionalEncodedData } = await this.processMessageWithDataStream(tenant, message, dataStream));
+      } else if (newestExistingMessage?.descriptor.method === DwnMethodName.Delete) {
+        throw new DwnError(
+          DwnErrorCode.RecordsWriteMissingDataStream,
+          'No data stream was provided with the previous message being a delete'
+        );
+      } else if (!newMessageIsInitialWrite) {
+        // at this point we know that newestExistingMessage exists is not a Delete
+        const newestExistingWrite = newestExistingMessage as RecordsWriteMessageWithOptionalEncodedData;
+        ({ isLatestBaseState, messageWithOptionalEncodedData } = await this.processMessageWithoutDataStream(tenant, message, newestExistingWrite ));
       }
-    }
 
-    await this.messageStore.put(tenant, messageWithOptionalEncodedData, indexes);
-    await this.eventLog.append(tenant, await Message.getCid(message), indexes);
+      const indexes = await recordsWrite.constructRecordsWriteIndexes(isLatestBaseState);
+      await this.messageStore.put(tenant, messageWithOptionalEncodedData, indexes);
+      await this.eventLog.append(tenant, await Message.getCid(message), indexes);
+    } catch (error) {
+      const e = error as any;
+      if (e.code === DwnErrorCode.RecordsWriteMissingEncodedDataInPrevious ||
+          e.code === DwnErrorCode.RecordsWriteMissingDataInPrevious ||
+          e.code === DwnErrorCode.RecordsWriteMissingDataStream ||
+          e.code === DwnErrorCode.RecordsWriteMissingDataAssociation ||
+          e.code === DwnErrorCode.RecordsWriteDataCidMismatch ||
+          e.code === DwnErrorCode.RecordsWriteDataSizeMismatch) {
+        return messageReplyFromError(error, 400);
+      }
+
+      // else throw
+      throw error;
+    }
 
     const messageReply = {
       status: { code: 202, detail: 'Accepted' }
@@ -151,78 +137,110 @@ export class RecordsWriteHandler implements MethodHandler {
     return messageReply;
   };
 
-  /**
-   * Embeds the record's data into the `encodedData` property.
-   * If dataStream is present, it uses the dataStream. Otherwise, uses the `encodedData` from the most recent RecordsWrite.
-   *
-   * @returns {RecordsWriteMessageWithOptionalEncodedData} `encodedData` embedded.
-   *
-   * @throws {DwnError} with `DwnErrorCode.RecordsWriteMissingDataInPrevious`
-   *                    if `dataStream` is absent AND `encodedData` of previous message is missing
-   * @throws {DwnError} with `DwnErrorCode.RecordsWriteDataCidMismatch`
-   *                    if the data stream resulted in a data CID that mismatches with `dataCid` in the given message
-   * @throws {DwnError} with `DwnErrorCode.RecordsWriteDataSizeMismatch`
-   *                    if `dataSize` in `descriptor` given mismatches the actual data size
-   */
-  public async processEncodedData(
+  private async processMessageWithDataStream(
+    tenant: string,
     message: RecordsWriteMessage,
-    dataStream?: _Readable.Readable,
-    newestExistingMessage?: RecordsWriteMessage | RecordsDeleteMessage
-  ): Promise<RecordsWriteMessageWithOptionalEncodedData> {
-    let dataBytes;
-    if (dataStream === undefined) {
-      const newestWithData = newestExistingMessage as RecordsWriteMessageWithOptionalEncodedData | undefined;
-      if (newestWithData?.encodedData === undefined) {
+    dataStream: _Readable.Readable,
+  ):Promise<{
+    isLatestBaseState: boolean
+    messageWithOptionalEncodedData: RecordsWriteMessageWithOptionalEncodedData
+  }> {
+    let isLatestBaseState = false;
+    let messageWithOptionalEncodedData: RecordsWriteMessageWithOptionalEncodedData = message;
+
+    // if data is below the threshold, we store it within MessageStore
+    if (message.descriptor.dataSize <= DwnConstant.maxDataSizeAllowedToBeEncoded) {
+      const dataBytes = await DataStream.toBytes(dataStream!);
+      const dataCid = await Cid.computeDagPbCidFromBytes(dataBytes);
+      // validate data integrity before setting.
+      RecordsWriteHandler.validateDataIntegrity(message.descriptor.dataCid, message.descriptor.dataSize, dataCid, dataBytes.length);
+      messageWithOptionalEncodedData = await this.encodeAndSetData(message, dataBytes);
+      isLatestBaseState = true;
+    } else {
+      const messageCid = await Message.getCid(message);
+      const result = await this.dataStore.put(tenant, messageCid, message.descriptor.dataCid, dataStream);
+      await this.validateDataStoreIntegrity(tenant, message, result.dataCid, result.dataSize);
+      isLatestBaseState = true;
+    }
+
+    return { isLatestBaseState, messageWithOptionalEncodedData };
+  }
+
+  private async processMessageWithoutDataStream(
+    tenant: string,
+    message: RecordsWriteMessage,
+    newestExistingWrite: RecordsWriteMessageWithOptionalEncodedData,
+  ):Promise<{
+    isLatestBaseState: boolean
+    messageWithOptionalEncodedData: RecordsWriteMessageWithOptionalEncodedData
+  }> {
+    let isLatestBaseState = false;
+    let messageWithOptionalEncodedData: RecordsWriteMessageWithOptionalEncodedData = message;
+    const { dataCid, dataSize } = message.descriptor;
+    // if the incoming message is not an initial write, and no dataStream is provided, first check integrity against newest existing write.
+    RecordsWriteHandler.validateDataIntegrity(dataCid, dataSize, newestExistingWrite.descriptor.dataCid, newestExistingWrite.descriptor.dataSize);
+    if (dataSize <= DwnConstant.maxDataSizeAllowedToBeEncoded) {
+      // we encode the data from the original write if it is smaller than the data-store threshold
+      if (newestExistingWrite.encodedData !== undefined) {
+        const dataBytes = Encoder.base64UrlToBytes(newestExistingWrite.encodedData);
+        messageWithOptionalEncodedData = await this.encodeAndSetData(message, dataBytes);
+        isLatestBaseState = true; // will show up in reads/queries
+      } else {
+        throw new DwnError(
+          DwnErrorCode.RecordsWriteMissingEncodedDataInPrevious,
+          `No dataStream was provided and unable to get data from previous message`
+        );
+      }
+    } else {
+      const previousWriteMessageCid = await Message.getCid(newestExistingWrite);
+      // attempt to retrieve the data from the previous message, if it does not exist we have no previous data to associate.
+      // we preform this check in case a user attempts to gain access to data by knowing the dataCid,
+      // https://github.com/TBD54566975/dwn-sdk-js/issues/359
+      // so we insure that the data is already associated with the existing newest message
+      const dataResults = await this.dataStore.get(tenant, previousWriteMessageCid, message.descriptor.dataCid);
+      if (dataResults === undefined) {
         throw new DwnError(
           DwnErrorCode.RecordsWriteMissingDataInPrevious,
           `No dataStream was provided and unable to get data from previous message`
         );
-      } else {
-        dataBytes = Encoder.base64UrlToBytes(newestWithData.encodedData);
       }
-    } else {
-      dataBytes = await DataStream.toBytes(dataStream);
+      const result = await this.dataStore.associate(tenant, await Message.getCid(message), message.descriptor.dataCid);
+      if (result === undefined) {
+        throw new DwnError(
+          DwnErrorCode.RecordsWriteMissingDataAssociation,
+          'No dataStream was provided and unable to associate with previous data'
+        );
+      }
+      await this.validateDataStoreIntegrity(tenant, message, result.dataCid, result.dataSize);
+      isLatestBaseState = true; // will show up in reads/queries
     }
 
-    const dataCid = await Cid.computeDagPbCidFromBytes(dataBytes);
-    RecordsWriteHandler.validateDataIntegrity(message.descriptor.dataCid, message.descriptor.dataSize, dataCid, dataBytes.length);
+    return { isLatestBaseState, messageWithOptionalEncodedData };
+  }
 
+  /**
+   * Returns a `RecordsWriteMessageWithOptionalEncodedData` with a copy of the incoming message and the incoming data encoded to `Base64URL`.
+   */
+  public async encodeAndSetData(message: RecordsWriteMessage, dataBytes: Uint8Array):Promise<RecordsWriteMessageWithOptionalEncodedData> {
     const recordsWrite: RecordsWriteMessageWithOptionalEncodedData = { ...message };
     recordsWrite.encodedData = Encoder.bytesToBase64Url(dataBytes);
     return recordsWrite;
   }
 
   /**
-   * Puts the given data in storage unless tenant already has that data for the given recordId
-   *
-   * @throws {DwnError} with `DwnErrorCode.RecordsWriteMissingDataAssociation`
-   *                    if `dataStream` is absent AND unable to associate data given `dataCid`
-   * @throws {DwnError} with `DwnErrorCode.RecordsWriteDataCidMismatch`
-   *                    if the data stream resulted in a data CID that mismatches with `dataCid` in the given message
-   * @throws {DwnError} with `DwnErrorCode.RecordsWriteDataSizeMismatch`
-   *                    if `dataSize` in `descriptor` given mismatches the actual data size
+   * Validates the data integrity after either putting the data or associating it with a new message.
+   * Upon failure deletes the association, and subsequently the data if there are no other associations.
    */
-  public async putData(
+  private async validateDataStoreIntegrity(
     tenant: string,
     message: RecordsWriteMessage,
-    dataStream?: _Readable.Readable,
+    dataCid: string,
+    dataSize: number
   ): Promise<void> {
-    let result: { dataCid: string, dataSize: number };
     const messageCid = await Message.getCid(message);
 
-    if (dataStream === undefined) {
-      const associateResult = await this.dataStore.associate(tenant, messageCid, message.descriptor.dataCid);
-      if (associateResult === undefined) {
-        throw new DwnError(DwnErrorCode.RecordsWriteMissingDataAssociation, `Unable to associate dataCid ${message.descriptor.dataCid} ` +
-          `to messageCid ${messageCid} because dataStream was not provided and data was not found in dataStore`);
-      }
-      result = associateResult;
-    } else {
-      result = await this.dataStore.put(tenant, messageCid, message.descriptor.dataCid, dataStream);
-    }
-
     try {
-      RecordsWriteHandler.validateDataIntegrity(message.descriptor.dataCid, message.descriptor.dataSize, result.dataCid, result.dataSize);
+      RecordsWriteHandler.validateDataIntegrity(message.descriptor.dataCid, message.descriptor.dataSize, dataCid, dataSize);
     } catch (error) {
       // delete data and throw error to caller
       await this.dataStore.delete(tenant, messageCid, message.descriptor.dataCid);

--- a/tests/handlers/records-query.spec.ts
+++ b/tests/handlers/records-query.spec.ts
@@ -1451,6 +1451,7 @@ export function testRecordsQueryHandler(): void {
           { author: alice, schema, data: Encoder.stringToBytes('5'), published: true, recipient: carol.did }
         );
 
+        // directly inserting data to datastore so that we don't have to setup to grant Bob permission to write to Alice's DWN
         const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStore, dataStore, eventLog);
 
         const additionalIndexes1 = await record1Data.recordsWrite.constructRecordsWriteIndexes(true);

--- a/tests/handlers/records-query.spec.ts
+++ b/tests/handlers/records-query.spec.ts
@@ -1455,27 +1455,27 @@ export function testRecordsQueryHandler(): void {
         const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStore, dataStore, eventLog);
 
         const additionalIndexes1 = await record1Data.recordsWrite.constructRecordsWriteIndexes(true);
-        record1Data.message = await recordsWriteHandler.encodeAndSetData(record1Data.message, record1Data.dataBytes!);
+        record1Data.message = await recordsWriteHandler.cloneAndAddEncodedData(record1Data.message, record1Data.dataBytes!);
         await messageStore.put(alice.did, record1Data.message, additionalIndexes1);
         await eventLog.append(alice.did, await Message.getCid(record1Data.message), additionalIndexes1);
 
         const additionalIndexes2 = await record2Data.recordsWrite.constructRecordsWriteIndexes(true);
-        record2Data.message = await recordsWriteHandler.encodeAndSetData(record2Data.message,record2Data.dataBytes!);
+        record2Data.message = await recordsWriteHandler.cloneAndAddEncodedData(record2Data.message,record2Data.dataBytes!);
         await messageStore.put(alice.did, record2Data.message, additionalIndexes2);
         await eventLog.append(alice.did, await Message.getCid(record2Data.message), additionalIndexes1);
 
         const additionalIndexes3 = await record3Data.recordsWrite.constructRecordsWriteIndexes(true);
-        record3Data.message = await recordsWriteHandler.encodeAndSetData(record3Data.message, record3Data.dataBytes!);
+        record3Data.message = await recordsWriteHandler.cloneAndAddEncodedData(record3Data.message, record3Data.dataBytes!);
         await messageStore.put(alice.did, record3Data.message, additionalIndexes3);
         await eventLog.append(alice.did, await Message.getCid(record3Data.message), additionalIndexes1);
 
         const additionalIndexes4 = await record4Data.recordsWrite.constructRecordsWriteIndexes(true);
-        record4Data.message = await recordsWriteHandler.encodeAndSetData(record4Data.message, record4Data.dataBytes!);
+        record4Data.message = await recordsWriteHandler.cloneAndAddEncodedData(record4Data.message, record4Data.dataBytes!);
         await messageStore.put(alice.did, record4Data.message, additionalIndexes4);
         await eventLog.append(alice.did, await Message.getCid(record4Data.message), additionalIndexes1);
 
         const additionalIndexes5 = await record5Data.recordsWrite.constructRecordsWriteIndexes(true);
-        record5Data.message = await recordsWriteHandler.encodeAndSetData(record5Data.message, record5Data.dataBytes!);
+        record5Data.message = await recordsWriteHandler.cloneAndAddEncodedData(record5Data.message, record5Data.dataBytes!);
         await messageStore.put(alice.did, record5Data.message, additionalIndexes5);
         await eventLog.append(alice.did, await Message.getCid(record5Data.message), additionalIndexes1);
 
@@ -1582,7 +1582,7 @@ export function testRecordsQueryHandler(): void {
         const messages: GenericMessage[] = [];
         for await (const { recordsWrite, message, dataBytes } of messagePromises) {
           const indexes = await recordsWrite.constructRecordsWriteIndexes(true);
-          const processedMessage = await recordsWriteHandler.encodeAndSetData(message, dataBytes!);
+          const processedMessage = await recordsWriteHandler.cloneAndAddEncodedData(message, dataBytes!);
           await messageStore.put(alice.did, processedMessage, indexes);
           await eventLog.append(alice.did, await Message.getCid(processedMessage), indexes);
           messages.push(processedMessage);

--- a/tests/handlers/records-query.spec.ts
+++ b/tests/handlers/records-query.spec.ts
@@ -1451,33 +1451,32 @@ export function testRecordsQueryHandler(): void {
           { author: alice, schema, data: Encoder.stringToBytes('5'), published: true, recipient: carol.did }
         );
 
-        // directly inserting data to datastore so that we don't have to setup to grant Bob permission to write to Alice's DWN
         const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStore, dataStore, eventLog);
 
-        const recordIndexes1 = await record1Data.recordsWrite.constructRecordsWriteIndexes(true);
-        record1Data.message = await recordsWriteHandler.processEncodedData(record1Data.message, record1Data.dataStream);
-        await messageStore.put(alice.did, record1Data.message, recordIndexes1);
-        await eventLog.append(alice.did, await Message.getCid(record1Data.message), recordIndexes1);
+        const additionalIndexes1 = await record1Data.recordsWrite.constructRecordsWriteIndexes(true);
+        record1Data.message = await recordsWriteHandler.encodeAndSetData(record1Data.message, record1Data.dataBytes!);
+        await messageStore.put(alice.did, record1Data.message, additionalIndexes1);
+        await eventLog.append(alice.did, await Message.getCid(record1Data.message), additionalIndexes1);
 
-        const recordIndexes2 = await record2Data.recordsWrite.constructRecordsWriteIndexes(true);
-        record2Data.message = await recordsWriteHandler.processEncodedData(record2Data.message, record2Data.dataStream);
-        await messageStore.put(alice.did, record2Data.message, recordIndexes2);
-        await eventLog.append(alice.did, await Message.getCid(record2Data.message), recordIndexes2);
+        const additionalIndexes2 = await record2Data.recordsWrite.constructRecordsWriteIndexes(true);
+        record2Data.message = await recordsWriteHandler.encodeAndSetData(record2Data.message,record2Data.dataBytes!);
+        await messageStore.put(alice.did, record2Data.message, additionalIndexes2);
+        await eventLog.append(alice.did, await Message.getCid(record2Data.message), additionalIndexes1);
 
-        const recordIndexes3 = await record3Data.recordsWrite.constructRecordsWriteIndexes(true);
-        record3Data.message = await recordsWriteHandler.processEncodedData(record3Data.message, record3Data.dataStream);
-        await messageStore.put(alice.did, record3Data.message, recordIndexes3);
-        await eventLog.append(alice.did, await Message.getCid(record3Data.message), recordIndexes3);
+        const additionalIndexes3 = await record3Data.recordsWrite.constructRecordsWriteIndexes(true);
+        record3Data.message = await recordsWriteHandler.encodeAndSetData(record3Data.message, record3Data.dataBytes!);
+        await messageStore.put(alice.did, record3Data.message, additionalIndexes3);
+        await eventLog.append(alice.did, await Message.getCid(record3Data.message), additionalIndexes1);
 
-        const recordIndexes4 = await record4Data.recordsWrite.constructRecordsWriteIndexes(true);
-        record4Data.message = await recordsWriteHandler.processEncodedData(record4Data.message, record4Data.dataStream);
-        await messageStore.put(alice.did, record4Data.message, recordIndexes4);
-        await eventLog.append(alice.did, await Message.getCid(record4Data.message), recordIndexes4);
+        const additionalIndexes4 = await record4Data.recordsWrite.constructRecordsWriteIndexes(true);
+        record4Data.message = await recordsWriteHandler.encodeAndSetData(record4Data.message, record4Data.dataBytes!);
+        await messageStore.put(alice.did, record4Data.message, additionalIndexes4);
+        await eventLog.append(alice.did, await Message.getCid(record4Data.message), additionalIndexes1);
 
-        const recordIndexes5 = await record5Data.recordsWrite.constructRecordsWriteIndexes(true);
-        record5Data.message = await recordsWriteHandler.processEncodedData(record5Data.message, record5Data.dataStream);
-        await messageStore.put(alice.did, record5Data.message, recordIndexes5);
-        await eventLog.append(alice.did, await Message.getCid(record5Data.message), recordIndexes5);
+        const additionalIndexes5 = await record5Data.recordsWrite.constructRecordsWriteIndexes(true);
+        record5Data.message = await recordsWriteHandler.encodeAndSetData(record5Data.message, record5Data.dataBytes!);
+        await messageStore.put(alice.did, record5Data.message, additionalIndexes5);
+        await eventLog.append(alice.did, await Message.getCid(record5Data.message), additionalIndexes1);
 
         // test correctness for Bob's query
         const bobQueryMessageData = await TestDataGenerator.generateRecordsQuery({
@@ -1580,9 +1579,9 @@ export function testRecordsQueryHandler(): void {
         const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStore, dataStore, eventLog);
 
         const messages: GenericMessage[] = [];
-        for await (const { recordsWrite, message, dataStream } of messagePromises) {
+        for await (const { recordsWrite, message, dataBytes } of messagePromises) {
           const indexes = await recordsWrite.constructRecordsWriteIndexes(true);
-          const processedMessage = await recordsWriteHandler.processEncodedData(message, dataStream);
+          const processedMessage = await recordsWriteHandler.encodeAndSetData(message, dataBytes!);
           await messageStore.put(alice.did, processedMessage, indexes);
           await eventLog.append(alice.did, await Message.getCid(processedMessage), indexes);
           messages.push(processedMessage);

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -4073,11 +4073,11 @@ export function testRecordsWriteHandler(): void {
       });
 
       describe('encodedData threshold', async () => {
-        it('should call encodeAndSetData and not validateDataStoreIntegrity if dataSize is less than or equal to the threshold', async () => {
+        it('should call cloneAndAddEncodedData and not validateDataStoreIntegrity if dataSize is less than or equal to the threshold', async () => {
           const alice = await DidKeyResolver.generate();
           const dataBytes = TestDataGenerator.randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded);
           const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice, data: dataBytes });
-          const processEncoded = sinon.spy(RecordsWriteHandler.prototype as any, 'encodeAndSetData');
+          const processEncoded = sinon.spy(RecordsWriteHandler.prototype as any, 'cloneAndAddEncodedData');
           const validateStore = sinon.spy(RecordsWriteHandler.prototype as any, 'validateDataStoreIntegrity');
 
           const writeMessage = await dwn.processMessage(alice.did, message, dataStream);
@@ -4086,11 +4086,11 @@ export function testRecordsWriteHandler(): void {
           sinon.assert.notCalled(validateStore);
         });
 
-        it('should call validateDataStoreIntegrity and not encodeAndSetData if dataSize is greater than the threshold', async () => {
+        it('should call validateDataStoreIntegrity and not cloneAndAddEncodedData if dataSize is greater than the threshold', async () => {
           const alice = await DidKeyResolver.generate();
           const dataBytes = TestDataGenerator.randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded + 1);
           const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice, data: dataBytes });
-          const processEncoded = sinon.spy(RecordsWriteHandler.prototype as any, 'encodeAndSetData');
+          const processEncoded = sinon.spy(RecordsWriteHandler.prototype as any, 'cloneAndAddEncodedData');
           const validateStore = sinon.spy(RecordsWriteHandler.prototype as any, 'validateDataStoreIntegrity');
 
           const writeMessage = await dwn.processMessage(alice.did, message, dataStream);

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -3993,8 +3993,9 @@ export function testRecordsWriteHandler(): void {
       it('should 400 if dataStream is not provided and previous message does not contain encodedData', async () => {
         // scenario: A sync writes a pruned initial RecordsWrite, without a `dataStream`. Alice does another regular
         // RecordsWrite for the same record, referencing the same `dataCid` but omitting the `dataStream`.
+
         // Pruned RecordsWrite
-        // Data large enough to use the DataStore
+        // Data that would be encoded within the message
         const alice = await DidKeyResolver.generate();
         const data = TestDataGenerator.randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded);
         const prunedRecordsWrite = await TestDataGenerator.generateRecordsWrite({

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -383,7 +383,7 @@ export function testRecordsWriteHandler(): void {
           data          : newDataBytes
         });
 
-        // do not send the new data over
+        // records write should be rejected.
         const newRecordsWriteReply = await dwn.processMessage(alice.did, newRecordsWrite.message);
         expect(newRecordsWriteReply.status.code).to.equal(400);
         expect(newRecordsWriteReply.status.detail).to.contain(DwnErrorCode.RecordsWriteDataCidMismatch);
@@ -3092,7 +3092,7 @@ export function testRecordsWriteHandler(): void {
           expect(bobRecordsQueryRecordIdReply.status.code).to.equal(200);
           expect(bobRecordsQueryRecordIdReply.entries?.length).to.equal(0);
 
-          // attempt update recordsWrite without data
+          // attempt update recordsWrite without data, this will reject
           const updateRecord = await RecordsWrite.createFrom({
             recordsWriteMessage : imageRecordsWrite.message,
             signer              : Jws.createSigner(bob),


### PR DESCRIPTION
There are some cases where a DWN might have an initial `RecordsWrite` message used to create a record, but not have the data associated with it.

Until now this was only possible through a special method on the DWN `synchronizePrunedInitialRecordsWrite` which was only used for sync. However, there are multi-participant scenarios where this same behavior is necessary.

This PR exposes that functionality to the general processing of `RecordsWrite` messages.

If a `RecordsWrite` message is supplied without any data, it is checked that it is the initial `RecordsWrite` and indexes it as not being the latest state, this prevents it from being queryable without any data until a subsequent `RecordsWrite` with data is available.

Addresses: https://github.com/TBD54566975/dwn-sdk-js/issues/628