### PR TITLE
`messageCid` cursor & reverse index kept around during delete

### DIFF
--- a/src/event-log/event-log-level.ts
+++ b/src/event-log/event-log-level.ts
@@ -64,13 +64,4 @@ export class EventLogLevel implements EventLog {
 
     await Promise.all(indexDeletePromises);
   }
-
-  async purgeEventsByCid(tenant: string, messageCids: Array<string>): Promise<void> {
-    const indexDeletePromises: Promise<void>[] = [];
-    for (const messageCid of messageCids) {
-      indexDeletePromises.push(this.index.purge(tenant, messageCid));
-    }
-
-    await Promise.all(indexDeletePromises);
-  }
 }

--- a/src/event-log/event-log-level.ts
+++ b/src/event-log/event-log-level.ts
@@ -64,4 +64,13 @@ export class EventLogLevel implements EventLog {
 
     await Promise.all(indexDeletePromises);
   }
+
+  async purgeEventsByCid(tenant: string, messageCids: Array<string>): Promise<void> {
+    const indexDeletePromises: Promise<void>[] = [];
+    for (const messageCid of messageCids) {
+      indexDeletePromises.push(this.index.purge(tenant, messageCid));
+    }
+
+    await Promise.all(indexDeletePromises);
+  }
 }

--- a/src/store/index-level.ts
+++ b/src/store/index-level.ts
@@ -144,7 +144,7 @@ export class IndexLevel {
   }
 
   /**
-   *  Deletes the property indexes so that the item is not returned within a query.
+   *  Deletes the property indexes so that the item is no longer returned for query.
    *  The reverse lookup is kept in case it is used as a pagination cursor.
    *
    *  Note: Use the `purge` method to truly purge all index data.
@@ -158,10 +158,6 @@ export class IndexLevel {
       return;
     }
 
-    // note: during a delete we keep the indexes reverse lookup
-    // this is done so that we can look up a pagination cursor in the future
-    // however, we still delete the keys for each sortIndex
-    // we can use `purge` to truly purge the item.
     for (const indexName in indexes) {
       const sortValue = indexes[indexName];
       const partitionOperation = await this.createOperationForIndexPartition(

--- a/src/store/index-level.ts
+++ b/src/store/index-level.ts
@@ -13,7 +13,7 @@ type IndexLevelConfig = {
   createLevelDatabase?: typeof createLevelDatabase
 };
 
-type IndexedItem = { itemId: string, indexes: KeyValues };
+type IndexedItem = { itemId: string, indexes: KeyValues, active: boolean };
 
 const INDEX_SUBLEVEL_NAME = 'index';
 
@@ -86,7 +86,7 @@ export class IndexLevel {
       // for example if the property is messageTimestamp the key would look like:
       // '"2023-05-25T18:23:29.425008Z"\u0000bafyreigs3em7lrclhntzhgvkrf75j2muk6e7ypq3lrw3ffgcpyazyw6pry'
       const key = IndexLevel.keySegmentJoin(IndexLevel.encodeValue(indexValue), itemId);
-      const item: IndexedItem = { itemId, indexes };
+      const item: IndexedItem = { itemId, indexes, active: true };
 
       const partitionOperation = await this.createOperationForIndexPartition(
         tenant,
@@ -107,10 +107,7 @@ export class IndexLevel {
     await tenantPartition.batch(indexOps, options);
   }
 
-  /**
-   *  Deletes all of the index data associated with the item.
-   */
-  async delete(tenant: string, itemId: string, options?: IndexLevelOptions): Promise<void> {
+  async purge(tenant: string, itemId: string, options?: IndexLevelOptions): Promise<void> {
     const indexOps: LevelWrapperBatchOperation<string>[] = [];
 
     const indexes = await this.getIndexes(tenant, itemId);
@@ -131,7 +128,43 @@ export class IndexLevel {
         indexName,
         {
           type : 'del',
-          key  : IndexLevel.keySegmentJoin(IndexLevel.encodeValue(sortValue), itemId)
+          key  : IndexLevel.keySegmentJoin(IndexLevel.encodeValue(sortValue), itemId),
+        }
+      );
+      indexOps.push(partitionOperation);
+    }
+
+    const tenantPartition = await this.db.partition(tenant);
+    await tenantPartition.batch(indexOps, options);
+  }
+
+  /**
+   *  Deletes all of the index data associated with the item.
+   */
+  async delete(tenant: string, itemId: string, options?: IndexLevelOptions): Promise<void> {
+    const indexOps: LevelWrapperBatchOperation<string>[] = [];
+
+    const indexes = await this.getIndexes(tenant, itemId);
+    if (indexes === undefined) {
+      // invalid itemId
+      return;
+    }
+
+    // delete the reverse lookup
+    const inactiveItem:IndexedItem = { itemId, indexes, active: false };
+    const partitionOperation = await this.createOperationForIndexesLookupPartition(tenant, { type: 'put', key: itemId, value: JSON.stringify(inactiveItem) });
+    indexOps.push(partitionOperation);
+
+    // delete the keys for each sortIndex
+    for (const indexName in indexes) {
+      const sortValue = indexes[indexName];
+      const partitionOperation = await this.createOperationForIndexPartition(
+        tenant,
+        indexName,
+        {
+          type  : 'put',
+          key   : IndexLevel.keySegmentJoin(IndexLevel.encodeValue(sortValue), itemId),
+          value : JSON.stringify(inactiveItem)
         }
       );
       indexOps.push(partitionOperation);
@@ -256,8 +289,8 @@ export class IndexLevel {
 
     const sortPartition = await this.getIndexPartition(tenant, sortProperty);
     for await (const [ _, val ] of sortPartition.iterator(iteratorOptions, options)) {
-      const { indexes, itemId } = JSON.parse(val);
-      yield { indexes, itemId };
+      const { indexes, itemId, active } = JSON.parse(val);
+      yield { indexes, itemId, active };
     }
   }
 
@@ -312,7 +345,7 @@ export class IndexLevel {
 
     try {
       await Promise.all(filters.map(filter => {
-        return this.executeSingleFilterQuery(tenant, filter, sortProperty, matches, options );
+        return this.executeSingleFilterQuery(tenant, filter, sortProperty, matches, cursor, options );
       }));
     } catch (error) {
       if ((error as DwnError).code === DwnErrorCode.IndexInvalidSortProperty) {
@@ -345,6 +378,7 @@ export class IndexLevel {
     filter: Filter,
     sortProperty: string,
     matches: Map<string, IndexedItem>,
+    cursor?: string,
     levelOptions?: IndexLevelOptions
   ): Promise<void> {
 
@@ -388,7 +422,8 @@ export class IndexLevel {
         // short circuit: if a data is already included to the final matched key set (by a different `Filter`),
         // no need to evaluate if the data satisfies this current filter being evaluated
         // otherwise check that the item is a match.
-        if (matches.has(indexedItem.itemId) || !FilterUtility.matchFilter(indexedItem.indexes, filter)) {
+        const { itemId, indexes, active } = indexedItem;
+        if (matches.has(itemId) || !FilterUtility.matchFilter(indexes, filter) || (!active && itemId !== cursor)) {
           continue;
         }
 

--- a/tests/event-log/event-log-level.spec.ts
+++ b/tests/event-log/event-log-level.spec.ts
@@ -46,12 +46,12 @@ describe('EventLogLevel Tests', () => {
       expect(result.length).to.equal(0);
 
       const keysAfterDelete = await ArrayUtility.fromAsyncGenerator(eventLog.index.db.keys());
-      expect(keysAfterDelete.length).to.equal(15);
+      expect(keysAfterDelete.length).to.equal(1);
     });
   });
 
   describe('purgeEventsByCid', () => {
-    it('deletes all index related data', async () => {
+    it('purges all index related data', async () => {
       const { author, message, recordsWrite } = await TestDataGenerator.generateRecordsWrite();
       const messageCid = await Message.getCid(message);
       const index = await recordsWrite.constructRecordsWriteIndexes(true);

--- a/tests/event-log/event-log-level.spec.ts
+++ b/tests/event-log/event-log-level.spec.ts
@@ -32,12 +32,40 @@ describe('EventLogLevel Tests', () => {
       const index = await recordsWrite.constructRecordsWriteIndexes(true);
       await eventLog.append(author.did, messageCid, index);
 
-      const indexLevelDeleteSpy = sinon.spy(eventLog.index, 'delete');
+      // control
+      let result = await eventLog.getEvents(author.did);
+      expect(result.length).to.equal(1);
+      expect(result[0]).to.equal(await Message.getCid(message));
 
+      const indexLevelDeleteSpy = sinon.spy(eventLog.index, 'delete');
       await eventLog.deleteEventsByCid(author.did, [ messageCid ]);
+      indexLevelDeleteSpy.restore();
       expect(indexLevelDeleteSpy.callCount).to.equal(1);
 
+      result = await eventLog.getEvents(author.did);
+      expect(result.length).to.equal(0);
+
       const keysAfterDelete = await ArrayUtility.fromAsyncGenerator(eventLog.index.db.keys());
+      expect(keysAfterDelete.length).to.equal(15);
+    });
+  });
+
+  describe('purgeEventsByCid', () => {
+    it('deletes all index related data', async () => {
+      const { author, message, recordsWrite } = await TestDataGenerator.generateRecordsWrite();
+      const messageCid = await Message.getCid(message);
+      const index = await recordsWrite.constructRecordsWriteIndexes(true);
+      await eventLog.append(author.did, messageCid, index);
+
+      let keysAfterDelete = await ArrayUtility.fromAsyncGenerator(eventLog.index.db.keys());
+      expect(keysAfterDelete.length).to.equal(15);
+
+      const indexLevelPurgeSpy = sinon.spy(eventLog.index, 'purge');
+      await eventLog.purgeEventsByCid(author.did, [ messageCid ]);
+      indexLevelPurgeSpy.restore();
+      expect(indexLevelPurgeSpy.callCount).to.equal(1);
+
+      keysAfterDelete = await ArrayUtility.fromAsyncGenerator(eventLog.index.db.keys());
       expect(keysAfterDelete.length).to.equal(0);
     });
   });

--- a/tests/event-log/event-log-level.spec.ts
+++ b/tests/event-log/event-log-level.spec.ts
@@ -49,24 +49,4 @@ describe('EventLogLevel Tests', () => {
       expect(keysAfterDelete.length).to.equal(1);
     });
   });
-
-  describe('purgeEventsByCid', () => {
-    it('purges all index related data', async () => {
-      const { author, message, recordsWrite } = await TestDataGenerator.generateRecordsWrite();
-      const messageCid = await Message.getCid(message);
-      const index = await recordsWrite.constructRecordsWriteIndexes(true);
-      await eventLog.append(author.did, messageCid, index);
-
-      let keysAfterDelete = await ArrayUtility.fromAsyncGenerator(eventLog.index.db.keys());
-      expect(keysAfterDelete.length).to.equal(15);
-
-      const indexLevelPurgeSpy = sinon.spy(eventLog.index, 'purge');
-      await eventLog.purgeEventsByCid(author.did, [ messageCid ]);
-      indexLevelPurgeSpy.restore();
-      expect(indexLevelPurgeSpy.callCount).to.equal(1);
-
-      keysAfterDelete = await ArrayUtility.fromAsyncGenerator(eventLog.index.db.keys());
-      expect(keysAfterDelete.length).to.equal(0);
-    });
-  });
 });

--- a/tests/handlers/records-query.spec.ts
+++ b/tests/handlers/records-query.spec.ts
@@ -1347,7 +1347,8 @@ export function testRecordsQueryHandler(): void {
         // scenario:
         //    alice issues a paginated RecordsQuery message which has additional results
         //    alice happens to delete the result that is also the pagination cursor
-        //    a subsequent query with the cursor should still continue from the same place
+        //    this message should be an update message as we always keep an initial write during a delete (tombstone)
+        //    a subsequent query with the cursor should still continue from the same place even after delete
 
         const alice = await DidKeyResolver.generate();
 

--- a/tests/scenarios/events-query.spec.ts
+++ b/tests/scenarios/events-query.spec.ts
@@ -798,7 +798,8 @@ export function testEventsQueryScenarios(): void {
       expect(schema2QueryReply.events?.length).to.equal(0);
     });
 
-    xit('filters by recordId', async () => {
+    it('filters by recordId', async () => {
+
       const alice = await DidKeyResolver.generate();
 
       // a write as a control, will not show up in query

--- a/tests/store/index-level.spec.ts
+++ b/tests/store/index-level.spec.ts
@@ -1030,7 +1030,7 @@ describe('IndexLevel', () => {
       await testIndex.close();
     });
 
-    it('delete keeps indexes but does not return results', async () => {
+    it('delete keeps reverse indexes lookup but does not return results', async () => {
       const id1 = uuid();
       const doc1 = {
         id  : id1,

--- a/tests/store/index-level.spec.ts
+++ b/tests/store/index-level.spec.ts
@@ -1065,7 +1065,7 @@ describe('IndexLevel', () => {
       expect(result.length).to.equal(0);
 
       const allKeys = await ArrayUtility.fromAsyncGenerator(testIndex.db.keys());
-      expect(allKeys.length).to.equal(8); // all keys still exist
+      expect(allKeys.length).to.equal(2); // only keeps 1 index per deleted item
     });
 
     it('purges indexes', async () => {
@@ -1126,7 +1126,7 @@ describe('IndexLevel', () => {
       expect(result).to.contain(id);
     });
 
-    it('does nothing when attempting to purge key that does not exist', async () => {
+    it('does nothing when attempting to delete a key that does not exist', async () => {
       const controller = new AbortController();
       controller.abort('reason');
 
@@ -1140,6 +1140,26 @@ describe('IndexLevel', () => {
 
       // attempt purge an invalid id
       await testIndex.delete(tenant, 'invalid-id');
+
+      const result = await testIndex.query(tenant, [{ foo: 'bar' }], { sortProperty: 'id' });
+      expect(result.length).to.equal(1);
+      expect(result).to.contain(id);
+    });
+
+    it('does nothing when attempting to purge a key that does not exist', async () => {
+      const controller = new AbortController();
+      controller.abort('reason');
+
+      const id = uuid();
+      const doc = {
+        id  : id,
+        foo : 'bar'
+      };
+
+      await testIndex.put(tenant, id, doc);
+
+      // attempt purge an invalid id
+      await testIndex.purge(tenant, 'invalid-id');
 
       const result = await testIndex.query(tenant, [{ foo: 'bar' }], { sortProperty: 'id' });
       expect(result.length).to.equal(1);


### PR DESCRIPTION
There can be a scenario where a user attempts to use a `messageCid` as a cursor for a message after it's been deleted.

In order to remedy this, we keep the reverse index lookup for the items when issuing a `delete`. Then when we have a query with a cursor, we can look up the indexes, and use the item as a cursor point for the in-memory pagination.

I added a `purge` method that truly purges all indexes + reverse, although we never use it in practice (yet).  I think I should probably remove it and we can always add it back later as it's simple.