### PR TITLE
Included initial write to RecordsRead and RecordsQuery if they are not initial write

### DIFF
--- a/src/handlers/messages-get.ts
+++ b/src/handlers/messages-get.ts
@@ -2,7 +2,7 @@ import type { DataStore } from '../types/data-store.js';
 import type { DidResolver } from '../did/did-resolver.js';
 import type { MessageStore } from '../types/message-store.js';
 import type { MethodHandler } from '../types/method-handler.js';
-import type { RecordsWriteMessageWithOptionalEncodedData } from '../types/records-types.js';
+import type { RecordsQueryReplyEntry } from '../types/records-types.js';
 import type { MessagesGetMessage, MessagesGetReply, MessagesGetReplyEntry } from '../types/messages-types.js';
 
 import { messageReplyFromError } from '../core/message-reply.js';
@@ -65,7 +65,7 @@ export class MessagesGetHandler implements MethodHandler {
 
       // RecordsWrite specific handling, if MessageStore has embedded `encodedData` return it with the entry.
       // we store `encodedData` along with the message if the data is below a certain threshold.
-      const recordsWrite = message as RecordsWriteMessageWithOptionalEncodedData;
+      const recordsWrite = message as RecordsQueryReplyEntry;
       if (recordsWrite.encodedData !== undefined) {
         entry.encodedData = recordsWrite.encodedData;
         delete recordsWrite.encodedData;

--- a/src/handlers/records-read.ts
+++ b/src/handlers/records-read.ts
@@ -3,7 +3,7 @@ import type { DidResolver } from '../did/did-resolver.js';
 import type { Filter } from '../types/query-types.js';
 import type { MessageStore } from '../types//message-store.js';
 import type { MethodHandler } from '../types/method-handler.js';
-import type { RecordsReadMessage, RecordsReadReply, RecordsWriteMessageWithOptionalEncodedData } from '../types/records-types.js';
+import type { RecordsQueryReplyEntry, RecordsReadMessage, RecordsReadReply } from '../types/records-types.js';
 
 import { authenticate } from '../core/auth.js';
 import { DataStream } from '../utils/data-stream.js';
@@ -63,7 +63,7 @@ export class RecordsReadHandler implements MethodHandler {
       ), 400);
     }
 
-    const newestRecordsWrite = existingMessages[0] as RecordsWriteMessageWithOptionalEncodedData;
+    const newestRecordsWrite = existingMessages[0] as RecordsQueryReplyEntry;
     try {
       await RecordsReadHandler.authorizeRecordsRead(tenant, recordsRead, await RecordsWrite.parse(newestRecordsWrite), this.messageStore);
     } catch (error) {
@@ -97,7 +97,7 @@ export class RecordsReadHandler implements MethodHandler {
         tenant,
         [{ recordId: record.recordId, isLatestBaseState: false, method: DwnMethodName.Write }]
       );
-      const initialWrite = initialWriteQueryResult.messages[0] as RecordsWriteMessageWithOptionalEncodedData;
+      const initialWrite = initialWriteQueryResult.messages[0] as RecordsQueryReplyEntry;
       delete initialWrite.encodedData;
       record.initialWrite = initialWrite;
     }

--- a/src/store/storage-controller.ts
+++ b/src/store/storage-controller.ts
@@ -2,7 +2,7 @@ import type { DataStore } from '../types/data-store.js';
 import type { EventLog } from '../types/event-log.js';
 import type { GenericMessage } from '../types/message-types.js';
 import type { MessageStore } from '../types/message-store.js';
-import type { RecordsWriteMessage, RecordsWriteMessageWithOptionalEncodedData } from '../types/records-types.js';
+import type { RecordsQueryReplyEntry, RecordsWriteMessage } from '../types/records-types.js';
 
 import { DwnConstant } from '../core/dwn-constant.js';
 import { DwnMethodName } from '../enums/dwn-interface-method.js';
@@ -65,7 +65,7 @@ export class StorageController {
           const existingRecordsWrite = await RecordsWrite.parse(message as RecordsWriteMessage);
           const isLatestBaseState = false;
           const indexes = await existingRecordsWrite.constructRecordsWriteIndexes(isLatestBaseState);
-          const writeMessage = message as RecordsWriteMessageWithOptionalEncodedData;
+          const writeMessage = message as RecordsQueryReplyEntry;
           delete writeMessage.encodedData;
           await messageStore.put(tenant, writeMessage, indexes);
         } else {

--- a/src/types/message-types.ts
+++ b/src/types/message-types.ts
@@ -62,7 +62,6 @@ export type Descriptor = {
  * Message returned in a query result.
  * NOTE: the message structure is a modified version of the message received, the most notable differences are:
  * 1. May include encoded data
- * 2. May include an initial RecordsWrite message
  */
 export type QueryResultEntry = GenericMessage & {
   encodedData?: string;

--- a/src/types/message-types.ts
+++ b/src/types/message-types.ts
@@ -61,11 +61,10 @@ export type Descriptor = {
 /**
  * Message returned in a query result.
  * NOTE: the message structure is a modified version of the message received, the most notable differences are:
- * 1. does not contain `authorization`
- * 2. may include encoded data
+ * 1. May include encoded data
+ * 2. May include an initial RecordsWrite message
  */
-export type QueryResultEntry = {
-  descriptor: Descriptor;
+export type QueryResultEntry = GenericMessage & {
   encodedData?: string;
 };
 

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -57,7 +57,10 @@ export type RecordsWriteMessage = GenericMessage & {
 /**
  * records with a data size below a threshold are stored within MessageStore with their data embedded
  */
-export type RecordsWriteMessageWithOptionalEncodedData = RecordsWriteMessage & { encodedData?: string };
+export type RecordsWriteMessageWithOptionalEncodedData = RecordsWriteMessage & {
+  encodedData?: string;
+  initialWrite?: RecordsWriteMessage;
+};
 
 export type EncryptionProperty = {
   algorithm: EncryptionAlgorithm;
@@ -90,6 +93,10 @@ export type EncryptedKey = {
  * 2. may include encoded data
  */
 export type RecordsQueryReplyEntry = RecordsWriteMessage & {
+  /**
+   * The initial write of the record if the returned RecordsWrite message itself is not the initial write.
+   */
+  initialWrite?: RecordsWriteMessage;
   encodedData?: string;
 };
 
@@ -149,6 +156,10 @@ export type RecordsReadMessage = {
 
 export type RecordsReadReply = GenericMessageReply & {
   record?: RecordsWriteMessage & {
+    /**
+     * The initial write of the record if the returned RecordsWrite message itself is not the initial write.
+     */
+    initialWrite?: RecordsWriteMessage;
     data: Readable;
   }
 };

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -54,14 +54,6 @@ export type RecordsWriteMessage = GenericMessage & {
   encryption?: EncryptionProperty;
 };
 
-/**
- * records with a data size below a threshold are stored within MessageStore with their data embedded
- */
-export type RecordsWriteMessageWithOptionalEncodedData = RecordsWriteMessage & {
-  encodedData?: string;
-  initialWrite?: RecordsWriteMessage;
-};
-
 export type EncryptionProperty = {
   algorithm: EncryptionAlgorithm;
   initializationVector: string;
@@ -89,14 +81,18 @@ export type EncryptedKey = {
 /**
  * Data structure returned in a `RecordsQuery` reply entry.
  * NOTE: the message structure is a modified version of the message received, the most notable differences are:
- * 1. does not contain `authorization`
- * 2. may include encoded data
+ * 1. May include an initial RecordsWrite message
+ * 2. May include encoded data
  */
 export type RecordsQueryReplyEntry = RecordsWriteMessage & {
   /**
    * The initial write of the record if the returned RecordsWrite message itself is not the initial write.
    */
   initialWrite?: RecordsWriteMessage;
+
+  /**
+   * The encoded data of the record if the data associated with the record is equal or smaller than `DwnConstant.maxDataSizeAllowedToBeEncoded`.
+   */
   encodedData?: string;
 };
 

--- a/tests/core/message.spec.ts
+++ b/tests/core/message.spec.ts
@@ -1,4 +1,4 @@
-import type { RecordsWriteMessageWithOptionalEncodedData } from '../../src/types/records-types.js';
+import type { RecordsQueryReplyEntry } from '../../src/types/records-types.js';
 
 import { expect } from 'chai';
 import { Message } from '../../src/core/message.js';
@@ -77,7 +77,7 @@ describe('Message', () => {
       const { message } = await TestDataGenerator.generateRecordsWrite();
       const cid1 = await Message.getCid(message);
 
-      const messageWithData: RecordsWriteMessageWithOptionalEncodedData = message;
+      const messageWithData: RecordsQueryReplyEntry = message;
       messageWithData.encodedData = TestDataGenerator.randomString(25);
 
       const cid2 = await Message.getCid(messageWithData);

--- a/tests/handlers/records-read.spec.ts
+++ b/tests/handlers/records-read.spec.ts
@@ -196,6 +196,28 @@ export function testRecordsReadHandler(): void {
         expect(ArrayUtility.byteArraysEqual(dataFetched, dataBytes!)).to.be.true;
       });
 
+      it('should include `initialWrite` property if RecordsWrite is not initial write', async () => {
+        const alice = await DidKeyResolver.generate();
+        const write = await TestDataGenerator.generateRecordsWrite({ author: alice, published: false });
+
+        const writeReply = await dwn.processMessage(alice.did, write.message, write.dataStream);
+        expect(writeReply.status.code).to.equal(202);
+
+        // write an update to the record
+        const write2 = await RecordsWrite.createFrom({ recordsWriteMessage: write.message, published: true, signer: Jws.createSigner(alice) });
+        const write2Reply = await dwn.processMessage(alice.did, write2.message);
+        expect(write2Reply.status.code).to.equal(202);
+
+        // make sure result returned now has `initialWrite` property
+        const messageData = await RecordsRead.create({ filter: { recordId: write.message.recordId }, signer: Jws.createSigner(alice) });
+        const reply = await dwn.processMessage(alice.did, messageData.message);
+
+        expect(reply.status.code).to.equal(200);
+        expect(reply.record?.initialWrite).to.exist;
+        expect(reply.record?.initialWrite?.recordId).to.equal(write.message.recordId);
+
+      });
+
       describe('protocol based reads', () => {
         it('should allow read with allow-anyone rule', async () => {
         // scenario: Alice writes an image to her DWN, then Bob reads the image because he is "anyone".

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -1,7 +1,7 @@
 import type { EncryptionInput } from '../../src/interfaces/records-write.js';
 import type { GenerateFromRecordsWriteOut } from '../utils/test-data-generator.js';
 import type { ProtocolDefinition } from '../../src/types/protocols-types.js';
-import type { RecordsWriteMessageWithOptionalEncodedData } from '../../src/types/records-types.js';
+import type { RecordsQueryReplyEntry } from '../../src/types/records-types.js';
 import type { DataStore, EventLog, GetResult, MessageStore } from '../../src/index.js';
 
 import anyoneCollaborateProtocolDefinition from '../vectors/protocol-definitions/anyone-collaborate.json' assert { type: 'json' };
@@ -4109,7 +4109,7 @@ export function testRecordsWriteHandler(): void {
           const messageCid = await Message.getCid(message);
 
           const storedMessage = await messageStore.get(alice.did, messageCid);
-          expect((storedMessage as RecordsWriteMessageWithOptionalEncodedData).encodedData).to.exist.and.not.be.undefined;
+          expect((storedMessage as RecordsQueryReplyEntry).encodedData).to.exist.and.not.be.undefined;
         });
 
         it('should not have encodedData field if dataSize greater than threshold', async () => {
@@ -4122,7 +4122,7 @@ export function testRecordsWriteHandler(): void {
           const messageCid = await Message.getCid(message);
 
           const storedMessage = await messageStore.get(alice.did, messageCid);
-          expect((storedMessage as RecordsWriteMessageWithOptionalEncodedData).encodedData).to.not.exist;
+          expect((storedMessage as RecordsQueryReplyEntry).encodedData).to.not.exist;
         });
 
         it('should retain original RecordsWrite message but without the encodedData if data is under threshold', async () => {
@@ -4135,7 +4135,7 @@ export function testRecordsWriteHandler(): void {
           const messageCid = await Message.getCid(message);
 
           const storedMessage = await messageStore.get(alice.did, messageCid);
-          expect((storedMessage as RecordsWriteMessageWithOptionalEncodedData).encodedData).to.exist.and.not.be.undefined;
+          expect((storedMessage as RecordsQueryReplyEntry).encodedData).to.exist.and.not.be.undefined;
 
           const updatedDataBytes = TestDataGenerator.randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded);
           const newWrite = await RecordsWrite.createFrom({
@@ -4151,10 +4151,10 @@ export function testRecordsWriteHandler(): void {
           expect(writeMessage2.status.code).to.equal(202);
 
           const originalWrite = await messageStore.get(alice.did, messageCid);
-          expect((originalWrite as RecordsWriteMessageWithOptionalEncodedData).encodedData).to.not.exist;
+          expect((originalWrite as RecordsQueryReplyEntry).encodedData).to.not.exist;
 
           const newestWrite = await messageStore.get(alice.did, await Message.getCid(newWrite.message));
-          expect((newestWrite as RecordsWriteMessageWithOptionalEncodedData).encodedData).to.exist.and.not.be.undefined;
+          expect((newestWrite as RecordsQueryReplyEntry).encodedData).to.exist.and.not.be.undefined;
         });
       });
     });

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -2333,7 +2333,7 @@ export function testRecordsWriteHandler(): void {
           });
         });
 
-        it('should allow overwriting records by the same author', async () => {
+        it('should allow updating records by the initial author', async () => {
         // scenario: Bob writes into Alice's DWN given Alice's "message" protocol allow-anyone rule, then modifies the message
 
           // write a protocol definition with an allow-anyone rule


### PR DESCRIPTION
All ears on better/more performant implementation but this is the simplest approach with fastest turnaround to unblock usage.