### PR TITLE
Remove unnecessary conversions to hex format

### DIFF
--- a/src/jose/algorithms/signing/ed25519.ts
+++ b/src/jose/algorithms/signing/ed25519.ts
@@ -27,11 +27,9 @@ export const ed25519: SignatureAlgorithm = {
   sign: async (content: Uint8Array, privateJwk: PrivateJwk): Promise<Uint8Array> => {
     validateKey(privateJwk);
 
-    const contentHex = Ed25519.etc.bytesToHex(content);
     const privateKeyBytes = Encoder.base64UrlToBytes(privateJwk.d);
-    const privateKeyHex = Ed25519.etc.bytesToHex(privateKeyBytes);
 
-    return Ed25519.signAsync(contentHex, privateKeyHex);
+    return Ed25519.signAsync(content, privateKeyBytes);
   },
 
   verify: async (content: Uint8Array, signature: Uint8Array, publicJwk: PublicJwk): Promise<boolean> => {
@@ -44,8 +42,7 @@ export const ed25519: SignatureAlgorithm = {
 
   generateKeyPair: async (): Promise<{publicJwk: PublicJwk, privateJwk: PrivateJwk}> => {
     const privateKeyBytes = Ed25519.utils.randomPrivateKey();
-    const privateKeyHex = Ed25519.etc.bytesToHex(privateKeyBytes);
-    const publicKeyBytes = await Ed25519.getPublicKeyAsync(privateKeyHex);
+    const publicKeyBytes = await Ed25519.getPublicKeyAsync(privateKeyBytes);
 
     const d = Encoder.bytesToBase64Url(privateKeyBytes);
 

--- a/src/utils/secp256k1.ts
+++ b/src/utils/secp256k1.ts
@@ -27,9 +27,8 @@ export class Secp256k1 {
   // ensure public key is in uncompressed format so we can convert it into both x and y value
     let uncompressedPublicKeyBytes;
     if (publicKeyBytes.byteLength === 33) {
-    // this means given key is compressed
-      const publicKeyHex = secp256k1.etc.bytesToHex(publicKeyBytes);
-      const curvePoints = secp256k1.ProjectivePoint.fromHex(publicKeyHex);
+      // this means given key is compressed
+      const curvePoints = secp256k1.ProjectivePoint.fromHex(publicKeyBytes);
       uncompressedPublicKeyBytes = curvePoints.toRawBytes(false); // isCompressed = false
     } else {
       uncompressedPublicKeyBytes = publicKeyBytes;
@@ -96,11 +95,9 @@ export class Secp256k1 {
     // the underlying lib expects us to hash the content ourselves:
     // https://github.com/paulmillr/noble-secp256k1/blob/97aa518b9c12563544ea87eba471b32ecf179916/index.ts#L1160
     const hashedContent = await sha256.encode(content);
-    const hashedContentHex = secp256k1.etc.bytesToHex(hashedContent);
     const privateKeyBytes = Secp256k1.privateJwkToBytes(privateJwk);
-    const privateKeyHex = secp256k1.etc.bytesToHex(privateKeyBytes);
 
-    return (await secp256k1.signAsync(hashedContentHex, privateKeyHex, )).toCompactRawBytes();
+    return (await secp256k1.signAsync(hashedContent, privateKeyBytes)).toCompactRawBytes();
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR primarily focuses on performance improvement for the two digital signature algorithms supported by `dwn-sdk-js.

## Context

In [this Discord thread](https://discord.com/channels/937858703112155166/1181470744023146538) @shamilovtim noted significant delays while profiling [web5-wallet](https://github.com/TBD54566975/web5-wallet) performance.

During the troubleshooting process, a tangentially related issue was discovered that unnecessarily reduces the performance of `Ed25519` and `secp256k1` sign operations.  While updating `dwn-sdk-js` to the v2.0 versions of `@noble/ed5519` and `@noble/secp256k1` in PR #396, unnecessary conversions to hex format were added in the `sign()` method (but not `verify()`).

The result of this change is that `sign()` performance degrades rapidly as the data size of the content increases:

<img width="1092" alt="Screenshot 2023-12-05 at 12 29 40 PM" src="https://github.com/TBD54566975/dwn-sdk-js/assets/134693/074ab22d-0089-497a-a047-7e9687b6c962">


With a 100MB data payload, the sign operation in `dwn-sdk-js` is ⚠️ **40 times slower** ⚠️  than it should be.

If we switch the time axis to log scale, you can see that the verify operations both in `dwn-sdk-js` and `@noble/ed25519` track almost identically, since verify does not include the conversion to hex before verification.

<img width="1090" alt="Screenshot 2023-12-05 at 12 30 35 PM" src="https://github.com/TBD54566975/dwn-sdk-js/assets/134693/5ef40f3d-4956-4302-80e0-fdf658386ed5">

## Changes

- Remove all occurrences of hex format conversions from both:
    - `src/jose/algorithms/signing/ed25519.ts`
    - `src/utils/secp256k1.ts`

After implementing these changes, the performance of the sign operation is nearly identical whether called from the `dwn-sdk-js` wrapper or directly to the `@noble` lib and scales linearly as the payload size increases:

<img width="1093" alt="Screenshot 2023-12-05 at 12 49 27 PM" src="https://github.com/TBD54566975/dwn-sdk-js/assets/134693/2cf821eb-35ed-4885-a11e-11a6cac50069">