### PR TITLE
Refactored grant related code for readability

### DIFF
--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -1,5 +1,6 @@
-import type { AuthorizationModel } from '../types/message-types.js';
 import type { DidResolver } from '../did/did-resolver.js';
+import type { MessageInterface } from '../types/message-interface.js';
+import type { AuthorizationModel, GenericMessage } from '../types/message-types.js';
 
 import { GeneralJwsVerifier } from '../jose/jws/general/verifier.js';
 import { PermissionsGrant } from '../interfaces/permissions-grant.js';
@@ -30,14 +31,17 @@ export async function authenticate(authorizationModel: AuthorizationModel | unde
 }
 
 /**
- * Authorizes the incoming message.
- * @throws {Error} if fails authentication
+ * Authorizes owner authored message.
+ * @throws {DwnError} if fails authorization.
  */
-export async function authorize(tenant: string, incomingMessage: { author: string | undefined }): Promise<void> {
+export async function authorizeOwner(tenant: string, incomingMessage: MessageInterface<GenericMessage>): Promise<void> {
   // if author is the same as the target tenant, we can directly grant access
   if (incomingMessage.author === tenant) {
     return;
   } else {
-    throw new DwnError(DwnErrorCode.AuthorizationUnknownAuthor, 'message failed authorization. Only the tenant is authorized');
+    throw new DwnError(
+      DwnErrorCode.AuthorizationAuthorNotOwner,
+      `Message authored by ${incomingMessage.author}, not authored by expected owner ${tenant}.`
+    );
   }
 }

--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -16,7 +16,7 @@ export enum DwnErrorCode {
   AuthenticateJwsMissing = 'AuthenticateJwsMissing',
   AuthenticateDescriptorCidMismatch = 'AuthenticateDescriptorCidMismatch',
   AuthenticationMoreThanOneSignatureNotSupported = 'AuthenticationMoreThanOneSignatureNotSupported',
-  AuthorizationUnknownAuthor = 'AuthorizationUnknownAuthor',
+  AuthorizationAuthorNotOwner = 'AuthorizationAuthorNotOwner',
   AuthorizationNotGrantedToAuthor = 'AuthorizationNotGrantedToAuthor',
   ComputeCidCodecNotSupported = 'ComputeCidCodecNotSupported',
   ComputeCidMultihashNotSupported = 'ComputeCidMultihashNotSupported',

--- a/src/core/message.ts
+++ b/src/core/message.ts
@@ -196,12 +196,15 @@ export class Message {
 
 
   /**
-   * Validates the structural integrity of the message signature given.
-   * NOTE: signature is not verified.
+   * Validates the structural integrity of the message signature given:
+   * 1. The message signature must contain exactly 1 signature
+   * 2. Passes JSON schema validation
+   * 3. The `descriptorCid` property matches the CID of the message descriptor
+   * NOTE: signature is NOT verified.
    * @param payloadJsonSchemaKey The key to look up the JSON schema referenced in `compile-validators.js` and perform payload schema validation on.
    * @returns the parsed JSON payload object if validation succeeds.
    */
-  public static async validateMessageSignatureIntegrity(
+  public static async validateSignatureStructure(
     messageSignature: GeneralJws,
     messageDescriptor: Descriptor,
     payloadJsonSchemaKey: string = 'GenericSignaturePayload',

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -590,7 +590,7 @@ export class ProtocolAuthorization {
     inboundMessageRuleSet: ProtocolRuleSet,
     messageStore: MessageStore,
   ): Promise<void> {
-    const incomingRecordsWrite = incomingMessage as RecordsWrite;
+    const incomingRecordsWrite = incomingMessage;
     if (!inboundMessageRuleSet.$globalRole && !inboundMessageRuleSet.$contextRole) {
       return;
     }

--- a/src/handlers/events-get.ts
+++ b/src/handlers/events-get.ts
@@ -6,7 +6,7 @@ import type { EventsGetMessage, EventsGetReply } from '../types/event-types.js';
 
 import { EventsGet } from '../interfaces/events-get.js';
 import { messageReplyFromError } from '../core/message-reply.js';
-import { authenticate, authorize } from '../core/auth.js';
+import { authenticate, authorizeOwner } from '../core/auth.js';
 
 type HandleArgs = {tenant: string, message: EventsGetMessage};
 
@@ -24,7 +24,7 @@ export class EventsGetHandler implements MethodHandler {
 
     try {
       await authenticate(message.authorization, this.didResolver);
-      await authorize(tenant, eventsGet);
+      await authorizeOwner(tenant, eventsGet);
     } catch (e) {
       return messageReplyFromError(e, 401);
     }

--- a/src/handlers/events-query.ts
+++ b/src/handlers/events-query.ts
@@ -5,7 +5,7 @@ import type { EventsQueryMessage, EventsQueryReply } from '../types/event-types.
 
 import { EventsQuery } from '../interfaces/events-query.js';
 import { messageReplyFromError } from '../core/message-reply.js';
-import { authenticate, authorize } from '../core/auth.js';
+import { authenticate, authorizeOwner } from '../core/auth.js';
 
 
 export class EventsQueryHandler implements MethodHandler {
@@ -26,7 +26,7 @@ export class EventsQueryHandler implements MethodHandler {
 
     try {
       await authenticate(message.authorization, this.didResolver);
-      await authorize(tenant, eventsQuery);
+      await authorizeOwner(tenant, eventsQuery);
     } catch (e) {
       return messageReplyFromError(e, 401);
     }

--- a/src/handlers/messages-get.ts
+++ b/src/handlers/messages-get.ts
@@ -7,7 +7,7 @@ import type { MessagesGetMessage, MessagesGetReply, MessagesGetReplyEntry } from
 
 import { messageReplyFromError } from '../core/message-reply.js';
 import { MessagesGet } from '../interfaces/messages-get.js';
-import { authenticate, authorize } from '../core/auth.js';
+import { authenticate, authorizeOwner } from '../core/auth.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
 
 type HandleArgs = { tenant: string, message: MessagesGetMessage };
@@ -26,7 +26,7 @@ export class MessagesGetHandler implements MethodHandler {
 
     try {
       await authenticate(message.authorization, this.didResolver);
-      await authorize(tenant, messagesGet);
+      await authorizeOwner(tenant, messagesGet);
     } catch (e) {
       return messageReplyFromError(e, 401);
     }

--- a/src/handlers/protocols-configure.ts
+++ b/src/handlers/protocols-configure.ts
@@ -9,7 +9,7 @@ import type { ProtocolsConfigureMessage } from '../types/protocols-types.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { ProtocolsConfigure } from '../interfaces/protocols-configure.js';
-import { authenticate, authorize } from '../core/auth.js';
+import { authenticate, authorizeOwner } from '../core/auth.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
 
 export class ProtocolsConfigureHandler implements MethodHandler {
@@ -32,7 +32,7 @@ export class ProtocolsConfigureHandler implements MethodHandler {
     // authentication & authorization
     try {
       await authenticate(message.authorization, this.didResolver);
-      await authorize(tenant, protocolsConfigure);
+      await authorizeOwner(tenant, protocolsConfigure);
     } catch (e) {
       return messageReplyFromError(e, 401);
     }

--- a/src/handlers/records-read.ts
+++ b/src/handlers/records-read.ts
@@ -135,9 +135,14 @@ export class RecordsReadHandler implements MethodHandler {
       return;
     } else if (recordsRead.author !== undefined && recordsRead.signaturePayload!.permissionsGrantId !== undefined) {
       const permissionsGrantMessage = await GrantAuthorization.fetchGrant(tenant, messageStore, recordsRead.signaturePayload!.permissionsGrantId);
-      await RecordsGrantAuthorization.authorizeRead(
-        tenant, recordsRead.message, matchedRecordsWrite.message, recordsRead.author, permissionsGrantMessage, messageStore
-      );
+      await RecordsGrantAuthorization.authorizeRead({
+        recordsReadMessage          : recordsRead.message,
+        recordsWriteMessageToBeRead : matchedRecordsWrite.message,
+        expectedGrantedToInGrant    : recordsRead.author,
+        expectedGrantedForInGrant   : tenant,
+        permissionsGrantMessage,
+        messageStore
+      });
     } else if (descriptor.protocol !== undefined) {
       await ProtocolAuthorization.authorizeRead(tenant, recordsRead, matchedRecordsWrite, messageStore);
     } else {

--- a/src/handlers/records-write.ts
+++ b/src/handlers/records-write.ts
@@ -303,7 +303,13 @@ export class RecordsWriteHandler implements MethodHandler {
       return;
     } else if (recordsWrite.author !== undefined && recordsWrite.signaturePayload!.permissionsGrantId !== undefined) {
       const permissionsGrantMessage = await GrantAuthorization.fetchGrant(tenant, messageStore, recordsWrite.signaturePayload!.permissionsGrantId);
-      await RecordsGrantAuthorization.authorizeWrite(tenant, recordsWrite.message, recordsWrite.author, permissionsGrantMessage, messageStore);
+      await RecordsGrantAuthorization.authorizeWrite({
+        recordsWriteMessage       : recordsWrite.message,
+        expectedGrantedToInGrant  : recordsWrite.author,
+        expectedGrantedForInGrant : tenant,
+        permissionsGrantMessage,
+        messageStore
+      });
     } else if (recordsWrite.message.descriptor.protocol !== undefined) {
       await ProtocolAuthorization.authorizeWrite(tenant, recordsWrite, messageStore);
     } else {

--- a/src/interfaces/events-get.ts
+++ b/src/interfaces/events-get.ts
@@ -16,7 +16,7 @@ export class EventsGet extends AbstractMessage<EventsGetMessage> {
 
   public static async parse(message: EventsGetMessage): Promise<EventsGet> {
     Message.validateJsonSchema(message);
-    await Message.validateMessageSignatureIntegrity(message.authorization.signature, message.descriptor);
+    await Message.validateSignatureStructure(message.authorization.signature, message.descriptor);
     Time.validateTimestamp(message.descriptor.messageTimestamp);
 
     return new EventsGet(message);

--- a/src/interfaces/events-query.ts
+++ b/src/interfaces/events-query.ts
@@ -23,7 +23,7 @@ export class EventsQuery extends AbstractMessage<EventsQueryMessage>{
 
   public static async parse(message: EventsQueryMessage): Promise<EventsQuery> {
     Message.validateJsonSchema(message);
-    await Message.validateMessageSignatureIntegrity(message.authorization.signature, message.descriptor);
+    await Message.validateSignatureStructure(message.authorization.signature, message.descriptor);
 
     return new EventsQuery(message);
   }

--- a/src/interfaces/messages-get.ts
+++ b/src/interfaces/messages-get.ts
@@ -19,7 +19,7 @@ export class MessagesGet extends AbstractMessage<MessagesGetMessage> {
     Message.validateJsonSchema(message);
     this.validateMessageCids(message.descriptor.messageCids);
 
-    await Message.validateMessageSignatureIntegrity(message.authorization.signature, message.descriptor);
+    await Message.validateSignatureStructure(message.authorization.signature, message.descriptor);
     Time.validateTimestamp(message.descriptor.messageTimestamp);
 
     return new MessagesGet(message);

--- a/src/interfaces/permissions-grant.ts
+++ b/src/interfaces/permissions-grant.ts
@@ -39,7 +39,7 @@ export type CreateFromPermissionsRequestOverrides = {
 export class PermissionsGrant extends AbstractMessage<PermissionsGrantMessage> {
 
   public static async parse(message: PermissionsGrantMessage): Promise<PermissionsGrant> {
-    await Message.validateMessageSignatureIntegrity(message.authorization.signature, message.descriptor);
+    await Message.validateSignatureStructure(message.authorization.signature, message.descriptor);
     PermissionsGrant.validateScope(message);
     Time.validateTimestamp(message.descriptor.messageTimestamp);
     Time.validateTimestamp(message.descriptor.dateExpires);
@@ -147,7 +147,6 @@ export class PermissionsGrant extends AbstractMessage<PermissionsGrantMessage> {
 
   /**
    * Validates scope structure for properties beyond `interface` and `method`.
-   * Currently only grants for RecordsRead and RecordsWrite have such properties and need validation beyond JSON Schema.
    */
   public static validateScope(permissionsGrantMessage: PermissionsGrantMessage): void {
     const recordsScope = permissionsGrantMessage.descriptor.scope as RecordsPermissionScope;

--- a/src/interfaces/permissions-request.ts
+++ b/src/interfaces/permissions-request.ts
@@ -22,7 +22,7 @@ export type PermissionsRequestOptions = {
 export class PermissionsRequest extends AbstractMessage<PermissionsRequestMessage> {
 
   public static async parse(message: PermissionsRequestMessage): Promise<PermissionsRequest> {
-    await Message.validateMessageSignatureIntegrity(message.authorization.signature, message.descriptor);
+    await Message.validateSignatureStructure(message.authorization.signature, message.descriptor);
     Time.validateTimestamp(message.descriptor.messageTimestamp);
 
     return new PermissionsRequest(message);

--- a/src/interfaces/permissions-revoke.ts
+++ b/src/interfaces/permissions-revoke.ts
@@ -15,7 +15,7 @@ export type PermissionsRevokeOptions = {
 
 export class PermissionsRevoke extends AbstractMessage<PermissionsRevokeMessage> {
   public static async parse(message: PermissionsRevokeMessage): Promise<PermissionsRevoke> {
-    await Message.validateMessageSignatureIntegrity(message.authorization.signature, message.descriptor);
+    await Message.validateSignatureStructure(message.authorization.signature, message.descriptor);
     Time.validateTimestamp(message.descriptor.messageTimestamp);
 
     return new PermissionsRevoke(message);

--- a/src/interfaces/protocols-configure.ts
+++ b/src/interfaces/protocols-configure.ts
@@ -20,7 +20,7 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
   public static async parse(message: ProtocolsConfigureMessage): Promise<ProtocolsConfigure> {
     Message.validateJsonSchema(message);
     ProtocolsConfigure.validateProtocolDefinition(message.descriptor.definition);
-    await Message.validateMessageSignatureIntegrity(message.authorization.signature, message.descriptor);
+    await Message.validateSignatureStructure(message.authorization.signature, message.descriptor);
     Time.validateTimestamp(message.descriptor.messageTimestamp);
 
     return new ProtocolsConfigure(message);

--- a/src/interfaces/protocols-query.ts
+++ b/src/interfaces/protocols-query.ts
@@ -24,7 +24,7 @@ export class ProtocolsQuery extends AbstractMessage<ProtocolsQueryMessage> {
 
   public static async parse(message: ProtocolsQueryMessage): Promise<ProtocolsQuery> {
     if (message.authorization !== undefined) {
-      await Message.validateMessageSignatureIntegrity(message.authorization.signature, message.descriptor);
+      await Message.validateSignatureStructure(message.authorization.signature, message.descriptor);
     }
 
     if (message.descriptor.filter !== undefined) {
@@ -82,10 +82,10 @@ export class ProtocolsQuery extends AbstractMessage<ProtocolsQueryMessage> {
       return;
     } else if (this.author !== undefined && this.signaturePayload!.permissionsGrantId) {
       const permissionsGrantMessage = await GrantAuthorization.fetchGrant(tenant, messageStore, this.signaturePayload!.permissionsGrantId);
-      await GrantAuthorization.authorizeGenericMessage({
-        tenant,
-        incomingMessage : this.message,
-        author          : this.author,
+      await GrantAuthorization.performBaseValidation({
+        incomingMessage           : this.message,
+        expectedGrantedToInGrant  : this.author,
+        expectedGrantedForInGrant : tenant,
         permissionsGrantMessage,
         messageStore
       });

--- a/src/types/permissions-types.ts
+++ b/src/types/permissions-types.ts
@@ -1,6 +1,6 @@
 import type { AuthorizationModel, GenericMessage } from './message-types.js';
 import type { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
-import type { PermissionConditions, PermissionScope, PermissionsGrantDescriptor } from './permissions-grant-descriptor.js';
+import type { PermissionConditions, PermissionScope, PermissionsGrantDescriptor, RecordsPermissionScope } from './permissions-grant-descriptor.js';
 
 export type PermissionsRequestDescriptor = {
   interface: DwnInterfaceName.Permissions;
@@ -26,6 +26,12 @@ export type PermissionsRequestMessage = GenericMessage & {
 export type PermissionsGrantMessage = GenericMessage & {
   authorization: AuthorizationModel; // overriding `GenericMessage` with `authorization` being required
   descriptor: PermissionsGrantDescriptor;
+};
+
+export type RecordsPermissionsGrantMessage = PermissionsGrantMessage & {
+  descriptor: {
+    scope: RecordsPermissionScope;
+  };
 };
 
 export type PermissionsRevokeDescriptor = {

--- a/tests/handlers/protocols-configure.spec.ts
+++ b/tests/handlers/protocols-configure.spec.ts
@@ -278,7 +278,7 @@ export function testProtocolsConfigureHandler(): void {
         });
         const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message);
         expect(protocolsConfigureReply.status.code).to.equal(401);
-        expect(protocolsConfigureReply.status.detail).to.contain('message failed authorization');
+        expect(protocolsConfigureReply.status.detail).to.contain(DwnErrorCode.AuthorizationAuthorNotOwner);
       });
 
       describe('event log', () => {


### PR DESCRIPTION
- Turned RecordsGrantAuthorization.authorizeQuery/Read/Write parameters into `input` instead for readability
- Renamed `authorize()` to `authorizeOwner()`
- Renamed `authorizeProtocolRecord()` to `verifyProtocolRecordScope()`
- Renamed `authorizeFlatRecord()` to `verifyFlatRecordScope()`
- Renamed `GrantAuthorization.authorizeGenericMessage()` to `GrantAuthorization.performBaseValidation()`
- Renamed `validateMessageSignatureIntegrity()` to `validateSignatureStructure()`
- Introduced `RecordsPermissionsGrantMessage` for readability