### PR TITLE
Tags for `RecordsWrite` and for filters within `RecordsQuery`

### DIFF
--- a/json-schemas/interface-methods/records-filter.json
+++ b/json-schemas/interface-methods/records-filter.json
@@ -26,6 +26,36 @@
     "schema": {
       "type": "string"
     },
+    "tags": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": false,
+            "properties": {
+              "from": {
+                "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+              },
+              "to": {
+                "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+              }
+            }
+          }
+        ]
+      }
+    },
     "recordId": {
       "type": "string"
     },

--- a/json-schemas/interface-methods/records-filter.json
+++ b/json-schemas/interface-methods/records-filter.json
@@ -46,10 +46,10 @@
             "additionalProperties": false,
             "properties": {
               "from": {
-                "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+                "type": "string"
               },
               "to": {
-                "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+                "type": "string"
               }
             }
           },{

--- a/json-schemas/interface-methods/records-filter.json
+++ b/json-schemas/interface-methods/records-filter.json
@@ -52,6 +52,8 @@
                 "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
               }
             }
+          },{
+            "$ref": "https://identity.foundation/dwn/json-schemas/number-range-filter.json"
           }
         ]
       }

--- a/json-schemas/interface-methods/records-write-unidentified.json
+++ b/json-schemas/interface-methods/records-write-unidentified.json
@@ -119,6 +119,32 @@
         "schema": {
           "type": "string"
         },
+        "tags": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "boolean"
+                }
+              }
+            ]
+          }
+        },
         "parentId": {
           "type": "string"
         },

--- a/json-schemas/interface-methods/records-write-unidentified.json
+++ b/json-schemas/interface-methods/records-write-unidentified.json
@@ -122,22 +122,29 @@
         "tags": {
           "type": "object",
           "minProperties": 1,
+          "maxProperties": 10,
           "additionalProperties": {
             "oneOf": [
               {
                 "type": "array",
+                "minItems": 1,
+                "maxItems": 10,
                 "items": {
                   "type": "string"
                 }
               },
               {
                 "type": "array",
+                "minItems": 1,
+                "maxItems": 10,
                 "items": {
                   "type": "number"
                 }
               },
               {
                 "type": "array",
+                "maxItems": 1,
+                "minItems": 1,
                 "items": {
                   "type": "boolean"
                 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export type { MessagesGetMessage, MessagesGetReply, MessagesGetReplyEntry } from
 export type { PermissionConditions, PermissionScope, PermissionsGrantDescriptor } from './types/permissions-grant-descriptor.js';
 export type { PermissionsGrantMessage, PermissionsRequestDescriptor, PermissionsRequestMessage, PermissionsRevokeDescriptor, PermissionsRevokeMessage } from './types/permissions-types.js';
 export type { ProtocolsConfigureDescriptor, ProtocolDefinition, ProtocolTypes, ProtocolRuleSet, ProtocolsQueryFilter, ProtocolsConfigureMessage, ProtocolsQueryMessage, ProtocolsQueryReply } from './types/protocols-types.js';
-export type { EncryptionProperty, RecordsDeleteMessage, RecordsQueryMessage, RecordsQueryReply, RecordsQueryReplyEntry, RecordsReadReply, RecordsWriteDescriptor, RecordsWriteMessage } from './types/records-types.js';
+export type { EncryptionProperty, RecordsDeleteMessage, RecordsTags, RecordsQueryMessage, RecordsQueryReply, RecordsQueryReplyEntry, RecordsReadReply, RecordsWriteDescriptor, RecordsWriteMessage } from './types/records-types.js';
 export { authenticate } from './core/auth.js';
 export { AllowAllTenantGate, TenantGate } from './core/tenant-gate.js';
 export { Cid } from './utils/cid.js';

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -239,7 +239,6 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
     }
 
     await RecordsWrite.validateAttestationIntegrity(message);
-
     const recordsWrite = new RecordsWrite(message);
 
     await recordsWrite.validateIntegrity(); // RecordsWrite specific data integrity check

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -9,6 +9,7 @@ import type {
   EncryptedKey,
   EncryptionProperty,
   InternalRecordsWriteMessage,
+  RecordsTags,
   RecordsWriteAttestationPayload,
   RecordsWriteDescriptor,
   RecordsWriteMessage,
@@ -40,6 +41,7 @@ export type RecordsWriteOptions = {
   protocolRole?: string;
   contextId?: string;
   schema?: string;
+  tags?: RecordsTags;
   recordId?: string;
   parentId?: string;
   data?: Uint8Array;
@@ -120,6 +122,7 @@ export type KeyEncryptionInput = {
 
 export type CreateFromOptions = {
   recordsWriteMessage: RecordsWriteMessage,
+  tags?: RecordsTags;
   data?: Uint8Array;
   published?: boolean;
   messageTimestamp?: string;
@@ -290,6 +293,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
       protocolPath     : options.protocolPath,
       recipient        : options.recipient,
       schema           : options.schema !== undefined ? normalizeSchemaUrl(options.schema) : undefined,
+      tags             : options.tags,
       parentId         : options.parentId,
       dataCid,
       dataSize,
@@ -406,6 +410,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
       dataSize           : options.data ? undefined : sourceMessage.descriptor.dataSize, // if data not given, use base message dataSize
       protocolRole       : options.protocolRole,
       delegatedGrant     : options.delegatedGrant,
+      tags               : options.tags,
       // finally still need signers
       signer             : options.signer,
       attestationSigners : options.attestationSigners

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -693,8 +693,10 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
     isLatestBaseState: boolean
   ): Promise<KeyValues> {
     const message = this.message;
-    const descriptor = { ...message.descriptor };
+    const { ...descriptor } = { ...message.descriptor };
+    // const { tags, ...descriptor } = { ...message.descriptor };
     delete descriptor.published; // handle `published` specifically further down
+    // const flattenedTags = flatten(tags) as { [property: string]: string[] | number[] | boolean[] };
 
     const indexes: KeyValues = {
       ...descriptor,

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -9,7 +9,6 @@ import type {
   EncryptedKey,
   EncryptionProperty,
   InternalRecordsWriteMessage,
-  RecordsTags,
   RecordsWriteAttestationPayload,
   RecordsWriteDescriptor,
   RecordsWriteMessage,
@@ -27,11 +26,11 @@ import { KeyDerivationScheme } from '../utils/hd-key.js';
 import { Message } from '../core/message.js';
 import { Records } from '../utils/records.js';
 import { RecordsGrantAuthorization } from '../core/records-grant-authorization.js';
+import { removeUndefinedProperties } from '../utils/object.js';
 import { Secp256k1 } from '../utils/secp256k1.js';
 import { Time } from '../utils/time.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
-import { flatten, removeUndefinedProperties } from '../utils/object.js';
 import { normalizeProtocolUrl, normalizeSchemaUrl, validateProtocolUrlNormalized, validateSchemaUrlNormalized } from '../utils/url.js';
 
 export type RecordsWriteOptions = {
@@ -708,7 +707,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
 
     // we don't want the tags to occupy the descriptor tag space, so we augment them with tag. for each indexed property
     if (tags !== undefined) {
-      const flattenedTags = this.flattenTags(tags);
+      const flattenedTags = Records.flattenTags(tags);
       indexes = { ...indexes, ...flattenedTags };
     }
 
@@ -718,13 +717,6 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
     if (message.contextId !== undefined) { indexes.contextId = message.contextId; }
 
     return indexes;
-  }
-
-  /**
-   * This will create individual keys for each of the gats that look like `tag.tag_property`
-   */
-  public flattenTags(tags: RecordsTags): KeyValues {
-    return flatten({ tag: tags }) as KeyValues;
   }
 
   /**

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -698,6 +698,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
     isLatestBaseState: boolean
   ): Promise<KeyValues> {
     const message = this.message;
+    // we want to process tags separately from the rest of descriptors as it is an object and not a primitive KeyValue type.
     const { tags, ...descriptor } = { ...message.descriptor };
     delete descriptor.published; // handle `published` specifically further down
 
@@ -710,7 +711,8 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
       entryId   : await RecordsWrite.getEntryId(this.author, this.message.descriptor)
     };
 
-    // we don't want the tags to occupy the descriptor tag space, so we augment them with tag. for each indexed property
+    // we don't want the tags properties to occupy the descriptor index namespace
+    // so we augment them with `tag.property_name` for each tag property and add them to the indexes
     if (tags !== undefined) {
       const flattenedTags = Records.flattenTags(tags);
       indexes = { ...indexes, ...flattenedTags };

--- a/src/types/query-types.ts
+++ b/src/types/query-types.ts
@@ -10,7 +10,7 @@ export enum SortDirection {
   Ascending = 1
 }
 
-export type KeyValues = { [key:string]: string | number | boolean };
+export type KeyValues = { [key:string]: string | number | boolean | string[] | number[] | boolean[] };
 
 export type EqualFilter = string | number | boolean;
 

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -26,7 +26,7 @@ export type RecordsWriteDescriptor = {
   recipient?: string;
   schema?: string;
   parentId?: string;
-  // tags?: RecordsTags;
+  tags?: RecordsTags;
   dataCid: string;
   dataSize: number;
   dateCreated: string;

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -117,6 +117,7 @@ export type RecordsFilter = {
   published?: boolean;
   contextId?: string;
   schema?: string;
+  tags?: { [property: string]: RangeCriterion | string | number | boolean };
   recordId?: string;
   parentId?: string;
   dataFormat?: string;

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -18,6 +18,8 @@ export type RecordsTags = {
   [property: string]: string[] | number[] | boolean[]
 };
 
+export type TagsFilter = RangeFilter | RangeCriterion | string | number | boolean;
+
 export type RecordsWriteDescriptor = {
   interface: DwnInterfaceName.Records;
   method: DwnMethodName.Write;
@@ -117,7 +119,7 @@ export type RecordsFilter = {
   published?: boolean;
   contextId?: string;
   schema?: string;
-  tags?: { [property: string]: RangeFilter | RangeCriterion | string | number | boolean };
+  tags?: { [property: string]: TagsFilter };
   recordId?: string;
   parentId?: string;
   dataFormat?: string;

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -14,6 +14,10 @@ export enum DateSort {
   PublishedDescending = 'publishedDescending'
 }
 
+export type RecordsTags = {
+  [property: string]: string[] | number[] | boolean[]
+};
+
 export type RecordsWriteDescriptor = {
   interface: DwnInterfaceName.Records;
   method: DwnMethodName.Write;
@@ -22,6 +26,7 @@ export type RecordsWriteDescriptor = {
   recipient?: string;
   schema?: string;
   parentId?: string;
+  // tags?: RecordsTags;
   dataCid: string;
   dataSize: number;
   dateCreated: string;

--- a/src/types/records-types.ts
+++ b/src/types/records-types.ts
@@ -117,7 +117,7 @@ export type RecordsFilter = {
   published?: boolean;
   contextId?: string;
   schema?: string;
-  tags?: { [property: string]: RangeCriterion | string | number | boolean };
+  tags?: { [property: string]: RangeFilter | RangeCriterion | string | number | boolean };
   recordId?: string;
   parentId?: string;
   dataFormat?: string;

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -43,34 +43,49 @@ export class FilterUtility {
         return false;
       }
 
-      if (typeof filterValue === 'object') {
-        if (Array.isArray(filterValue)) {
-          // if `filterValue` is an array, it is a OneOfFilter
-          // Support OR matches by querying for each values separately,
-          if (!this.matchOneOf(filterValue, indexValue)) {
+      if (Array.isArray(indexValue)) {
+        for (const indexValueItem in indexValue) {
+          if (this.matchFilterIndex(filterValue, indexValueItem)) {
+            missingPropertyMatches.delete(filterProperty);
+          } else {
             return false;
           }
-          missingPropertyMatches.delete(filterProperty);
-          continue;
-        } else {
-          // `filterValue` is a `RangeFilter`
-          // range filters cannot range over booleans
-          if (!this.matchRange(filterValue, indexValue as RangeValue)) {
-            return false;
-          }
-          missingPropertyMatches.delete(filterProperty);
-          continue;
         }
-      } else {
-        // filterValue is an EqualFilter, meaning it is a non-object primitive type
-        if (indexValue !== filterValue) {
-          return false;
-        }
-        missingPropertyMatches.delete(filterProperty);
         continue;
+      }
+      if (this.matchFilterIndex(filterValue, indexValue)) {
+        missingPropertyMatches.delete(filterProperty);
+      } else {
+        return false;
       }
     }
     return missingPropertyMatches.size === 0;
+  }
+
+  private static matchFilterIndex(filterValue: FilterValue, indexValue: string | number | boolean): boolean {
+    if (typeof filterValue === 'object') {
+      if (Array.isArray(filterValue)) {
+        // if `filterValue` is an array, it is a OneOfFilter
+        // Support OR matches by querying for each values separately,
+        if (!this.matchOneOf(filterValue, indexValue)) {
+          return false;
+        }
+        return true;
+      } else {
+        // `filterValue` is a `RangeFilter`
+        // range filters cannot range over booleans
+        if (!this.matchRange(filterValue, indexValue as RangeValue)) {
+          return false;
+        }
+        return true;
+      }
+    } else {
+      // filterValue is an EqualFilter, meaning it is a non-object primitive type
+      if (indexValue !== filterValue) {
+        return false;
+      }
+      return true;
+    }
   }
 
   /**

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -158,6 +158,10 @@ export class FilterUtility {
     return false;
   }
 
+  public static isRangeCriterion(filter: RangeFilter | RangeCriterion | string | number | boolean ): filter is RangeCriterion {
+    return typeof filter === 'object' && ('from' in filter || 'to' in filter);
+  }
+
   static convertRangeCriterion(inputFilter: RangeCriterion): RangeFilter | undefined {
     let rangeFilter: RangeFilter | undefined;
     if (inputFilter.to !== undefined && inputFilter.from !== undefined) {

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -158,10 +158,6 @@ export class FilterUtility {
     return false;
   }
 
-  public static isRangeCriterion(filter: RangeFilter | RangeCriterion | string | number | boolean ): filter is RangeCriterion {
-    return typeof filter === 'object' && ('from' in filter || 'to' in filter);
-  }
-
   static convertRangeCriterion(inputFilter: RangeCriterion): RangeFilter | undefined {
     let rangeFilter: RangeFilter | undefined;
     if (inputFilter.to !== undefined && inputFilter.from !== undefined) {

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -43,17 +43,13 @@ export class FilterUtility {
         return false;
       }
 
-      if (Array.isArray(indexValue)) {
-        for (const indexValueItem in indexValue) {
-          if (this.matchFilterIndex(filterValue, indexValueItem)) {
-            missingPropertyMatches.delete(filterProperty);
-          } else {
-            return false;
-          }
-        }
-        continue;
-      }
-      if (this.matchFilterIndex(filterValue, indexValue)) {
+      // the indexed value can be a singular value or an array of values.
+      // the array value is matched if any of the items within the array match the filter.
+      const matched = Array.isArray(indexValue) ?
+        this.matchArrayFilterIndex(filterValue, indexValue) :
+        this.matchFilterIndex(filterValue, indexValue);
+
+      if (matched) {
         missingPropertyMatches.delete(filterProperty);
       } else {
         return false;
@@ -62,6 +58,22 @@ export class FilterUtility {
     return missingPropertyMatches.size === 0;
   }
 
+  /**
+   *  Matches a FilterValue for any of the the individual indexValues within the array provided.
+   */
+  private static matchArrayFilterIndex(filterValue: FilterValue, indexValues: string[] | number[] | boolean[]): boolean {
+    for (const indexValue of indexValues) {
+      if (this.matchFilterIndex(filterValue, indexValue)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   *  Matches a FilterValue for an individual indexed value.
+   */
   private static matchFilterIndex(filterValue: FilterValue, indexValue: string | number | boolean): boolean {
     if (typeof filterValue === 'object') {
       if (Array.isArray(filterValue)) {

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,15 +1,3 @@
-import flat from 'flat';
-
-/**
- * Flattens the given object.
- * e.g. `{ a: { b: { c: 42 } } }` becomes `{ 'a.b.c': 42 }`
- */
-export function flatten(obj: unknown): Record<string, unknown> {
-  const flattened = flat.flatten<unknown, Record<string, unknown>>(obj);
-  removeEmptyObjects(flattened);
-  return flattened;
-}
-
 /**
  * Checks whether the given object has any properties.
  */

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,3 +1,15 @@
+import flat from 'flat';
+
+/**
+ * Flattens the given object.
+ * e.g. `{ a: { b: { c: 42 } } }` becomes `{ 'a.b.c': 42 }`
+ */
+export function flatten(obj: unknown): Record<string, unknown> {
+  const flattened = flat.flatten<unknown, Record<string, unknown>>(obj);
+  removeEmptyObjects(flattened);
+  return flattened;
+}
+
 /**
  * Checks whether the given object has any properties.
  */

--- a/src/utils/records.ts
+++ b/src/utils/records.ts
@@ -1,7 +1,7 @@
 import type { DerivedPrivateJwk } from './hd-key.js';
 import type { GenericSignaturePayload } from '../types/message-types.js';
 import type { Readable } from 'readable-stream';
-import type { Filter, KeyValues, RangeCriterion } from '../types/query-types.js';
+import type { Filter, KeyValues, RangeCriterion, RangeFilter } from '../types/query-types.js';
 import type { RecordsDeleteMessage, RecordsFilter, RecordsQueryMessage, RecordsReadMessage, RecordsTags, RecordsWriteDescriptor, RecordsWriteMessage } from '../types/records-types.js';
 
 import { DateSort } from '../types/records-types.js';
@@ -10,9 +10,9 @@ import { Encryption } from './encryption.js';
 import { FilterUtility } from './filter.js';
 import { KeyDerivationScheme } from './hd-key.js';
 import { Message } from '../core/message.js';
+import { removeUndefinedProperties } from './object.js';
 import { Secp256k1 } from './secp256k1.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
-import { flatten, removeUndefinedProperties } from './object.js';
 import { normalizeProtocolUrl, normalizeSchemaUrl } from './url.js';
 
 /**
@@ -252,14 +252,24 @@ export class Records {
    * This will create individual keys for each of the tags that look like `tag.tag_property`
    */
   public static flattenTags(tags: RecordsTags): KeyValues {
-    return flatten({ tag: tags }) as KeyValues;
+    const tagValues:KeyValues = {};
+    for (const property in tags) {
+      const value = tags[property];
+      tagValues[`tag.${property}`] = value;
+    }
+    return tagValues;
   }
 
   /**
    * This will create individual keys for each of the tag filters that look like `tag.tag_filter_property`
    */
-  public static flattenTagFilters( tags: { [property: string]: RangeCriterion | string | number | boolean }): Filter {
-    return flatten({ tag: tags }) as Filter;
+  public static flattenTagFilters( tags: { [property: string]: RangeFilter | RangeCriterion | string | number | boolean }): Filter {
+    const tagValues:Filter = {};
+    for (const property in tags) {
+      const value = tags[property];
+      tagValues[`tag.${property}`] = FilterUtility.isRangeCriterion(value) ? FilterUtility.convertRangeCriterion(value)! : value;
+    }
+    return tagValues;
   }
 
   /**

--- a/tests/handlers/records-query.spec.ts
+++ b/tests/handlers/records-query.spec.ts
@@ -471,6 +471,22 @@ export function testRecordsQueryHandler(): void {
         expect(tagRangeFilterReply.status.code).to.equal(200);
         expect(tagRangeFilterReply.entries?.length).to.equal(2, 'tag2: gt 2 lt 4');
         expect(tagRangeFilterReply.entries?.map(entry => entry.recordId)).to.have.members([ tagsRecord1.message.recordId, tagsRecord2.message.recordId ], 'tag2: 3');
+
+        const tagRangeTextFilter = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : {
+            tags: {
+              tag1: {
+                from : 'tag2',
+                to   : 'tag4'
+              }
+            }
+          }
+        });
+        const tagRangeTextFilterReply = await dwn.processMessage(alice.did, tagRangeTextFilter.message);
+        expect(tagRangeTextFilterReply.status.code).to.equal(200);
+        expect(tagRangeTextFilterReply.entries?.length).to.equal(2, 'tag1: from tag1 to tag3');
+        expect(tagRangeTextFilterReply.entries?.map(entry => entry.recordId)).to.have.members([ tagsRecord1.message.recordId, tagsRecord2.message.recordId ], 'tag2: 3');
       });
 
 

--- a/tests/handlers/records-query.spec.ts
+++ b/tests/handlers/records-query.spec.ts
@@ -309,6 +309,171 @@ export function testRecordsQueryHandler(): void {
         expect(queryReply.entries![0].recordId).to.equal(bobAuthorWrite.message.recordId);
       });
 
+      it('should be able to query by string tags', async () => {
+        const alice = await DidKeyResolver.generate();
+
+        // create a record with some tags
+        const tagsRecord1 = await TestDataGenerator.generateRecordsWrite({
+          author    : alice,
+          published : true,
+          schema    : 'post',
+          tags      : {
+            tag1 : [ 'tag1', 'tag2', 'tag3' ],
+            tag2 : [ 1, 2, 3 ],
+            tag3 : [ true ]
+          }
+        });
+        const tagsRecord1WriteReply = await dwn.processMessage(alice.did, tagsRecord1.message, tagsRecord1.dataStream);
+        expect(tagsRecord1WriteReply.status.code).to.equal(202);
+
+        // create a record with the same tags but different values
+        const tagsRecord2 = await TestDataGenerator.generateRecordsWrite({
+          author    : alice,
+          published : true,
+          schema    : 'post',
+          tags      : {
+            tag1 : [ 'tag3', 'tag4'],
+            tag2 : [ 3, 4 ],
+            tag3 : [ false ]
+          }
+        });
+        const tagsRecord2WriteReply = await dwn.processMessage(alice.did, tagsRecord2.message, tagsRecord2.dataStream);
+        expect(tagsRecord2WriteReply.status.code).to.equal(202);
+
+        // filter for `tag2` value, returns 1 record
+        const tag2Filter = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : {
+            tags: {
+              tag1: 'tag2'
+            }
+          }
+        });
+        const tag2FilterReply = await dwn.processMessage(alice.did, tag2Filter.message);
+        expect(tag2FilterReply.status.code).to.equal(200);
+        expect(tag2FilterReply.entries?.length).to.equal(1, 'tag2');
+        expect(tag2FilterReply.entries![0].recordId).to.equal(tagsRecord1.message.recordId, 'tag2');
+
+        // filter for `tag4` value, returns 1 record
+        const tag4Filter = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : {
+            tags: {
+              tag1: 'tag4'
+            }
+          }
+        });
+        const tag4FilterReply = await dwn.processMessage(alice.did, tag4Filter.message);
+        expect(tag4FilterReply.status.code).to.equal(200);
+        expect(tag4FilterReply.entries?.length).to.equal(1, 'tag4');
+        expect(tag4FilterReply.entries![0].recordId).to.equal(tagsRecord2.message.recordId, 'tag4');
+
+        // filter for `tag3` value, returns 2 records
+        const tag3Filter = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : {
+            tags: {
+              tag1: 'tag3'
+            }
+          }
+        });
+        const tag3FilterReply = await dwn.processMessage(alice.did, tag3Filter.message);
+        expect(tag3FilterReply.status.code).to.equal(200);
+        expect(tag3FilterReply.entries?.length).to.equal(2, 'tag3');
+        expect(tag3FilterReply.entries?.map(entry => entry.recordId)).to.have.members([ tagsRecord1.message.recordId, tagsRecord2.message.recordId ], 'tag3');
+      });
+
+      it('should be able to query by number tags', async () => {
+        const alice = await DidKeyResolver.generate();
+
+        // create a record with some tags
+        const tagsRecord1 = await TestDataGenerator.generateRecordsWrite({
+          author    : alice,
+          published : true,
+          schema    : 'post',
+          tags      : {
+            tag1 : [ 'tag1', 'tag2', 'tag3' ],
+            tag2 : [ 1, 2, 3 ],
+            tag3 : [ true ]
+          }
+        });
+        const tagsRecord1WriteReply = await dwn.processMessage(alice.did, tagsRecord1.message, tagsRecord1.dataStream);
+        expect(tagsRecord1WriteReply.status.code).to.equal(202);
+
+        // create a record with the same tags but different values
+        const tagsRecord2 = await TestDataGenerator.generateRecordsWrite({
+          author    : alice,
+          published : true,
+          schema    : 'post',
+          tags      : {
+            tag1 : [ 'tag3', 'tag4'],
+            tag2 : [ 3, 4 ],
+            tag3 : [ false ]
+          }
+        });
+        const tagsRecord2WriteReply = await dwn.processMessage(alice.did, tagsRecord2.message, tagsRecord2.dataStream);
+        expect(tagsRecord2WriteReply.status.code).to.equal(202);
+
+        // filter for `2` value, returns 1 record
+        const value2Filter = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : {
+            tags: {
+              tag2: 2,
+            }
+          }
+        });
+        const tag2FilterReply = await dwn.processMessage(alice.did, value2Filter.message);
+        expect(tag2FilterReply.status.code).to.equal(200);
+        expect(tag2FilterReply.entries?.length).to.equal(1, 'tag2: 2');
+        expect(tag2FilterReply.entries![0].recordId).to.equal(tagsRecord1.message.recordId, 'tag2: 2');
+
+        // filter for `4` value, returns 1 record
+        const tag4Filter = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : {
+            tags: {
+              tag2: 4
+            }
+          }
+        });
+        const tag4FilterReply = await dwn.processMessage(alice.did, tag4Filter.message);
+        expect(tag4FilterReply.status.code).to.equal(200);
+        expect(tag4FilterReply.entries?.length).to.equal(1, 'tag2: 4');
+        expect(tag4FilterReply.entries![0].recordId).to.equal(tagsRecord2.message.recordId, 'tag2: 4');
+
+        // filter for `tag3` value, returns 2 records
+        const tag3Filter = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : {
+            tags: {
+              tag2: 3
+            }
+          }
+        });
+        const tag3FilterReply = await dwn.processMessage(alice.did, tag3Filter.message);
+        expect(tag3FilterReply.status.code).to.equal(200);
+        expect(tag3FilterReply.entries?.length).to.equal(2, 'tag2: 3');
+        expect(tag3FilterReply.entries?.map(entry => entry.recordId)).to.have.members([ tagsRecord1.message.recordId, tagsRecord2.message.recordId ], 'tag2: 3');
+
+        const tagRangeFilter = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : {
+            tags: {
+              tag2: {
+                gt : 2,
+                lt : 4,
+              }
+            }
+          }
+        });
+        const tagRangeFilterReply = await dwn.processMessage(alice.did, tagRangeFilter.message);
+        expect(tagRangeFilterReply.status.code).to.equal(200);
+        expect(tagRangeFilterReply.entries?.length).to.equal(2, 'tag2: gt 2 lt 4');
+        expect(tagRangeFilterReply.entries?.map(entry => entry.recordId)).to.have.members([ tagsRecord1.message.recordId, tagsRecord2.message.recordId ], 'tag2: 3');
+      });
+
+
       it('should be able to query for published records', async () => {
         const alice = await DidKeyResolver.generate();
         const bob = await DidKeyResolver.generate();

--- a/tests/interfaces/records-write.spec.ts
+++ b/tests/interfaces/records-write.spec.ts
@@ -321,6 +321,35 @@ describe('RecordsWrite', () => {
 
       expect(write.message.descriptor.published).to.be.true;
     });
+
+    it('replace tags with updated tags, if tags do not exist in createFrom remove them', async () => {
+      const { author, message, recordsWrite } = await TestDataGenerator.generateRecordsWrite({
+        tags: {
+          tag1: [ 'value1', 'value2' ]
+        }
+      });
+      expect(message.descriptor.tags).to.exist;
+      expect(message.descriptor.tags!.tag1).to.exist;
+      expect(message.descriptor.tags!.tag1).to.have.members([ 'value1', 'value2' ]);
+
+      const write = await RecordsWrite.createFrom({
+        recordsWriteMessage : recordsWrite.message,
+        signer              : Jws.createSigner(author),
+        tags                : {
+          tag2: [ 'value1', 'value2', 'value3' ]
+        }
+      });
+      expect(write.message.descriptor.tags).to.exist;
+      expect(write.message.descriptor.tags!.tag1).to.not.exist;
+      expect(write.message.descriptor.tags!.tag2).to.exist;
+      expect(write.message.descriptor.tags!.tag2).to.have.members([ 'value1', 'value2', 'value3' ]);
+
+      const write2 = await RecordsWrite.createFrom({
+        recordsWriteMessage : write.message,
+        signer              : Jws.createSigner(author),
+      });
+      expect(write2.message.descriptor.tags).to.not.exist;
+    });
   });
 
   describe('parse()', () => {
@@ -355,6 +384,8 @@ describe('RecordsWrite', () => {
 
       await expect(parsePromise).to.be.rejectedWith(DwnErrorCode.RecordsValidateIntegrityDelegatedGrantAndIdExistenceMismatch);
     });
+
+
   });
 
   describe('isSignedByDelegate()', () => {

--- a/tests/utils/filters.spec.ts
+++ b/tests/utils/filters.spec.ts
@@ -1,6 +1,7 @@
 import type { Filter } from '../../src/types/query-types.js';
 
 import { Time } from '../../src/utils/time.js';
+import { v4 as uuid } from 'uuid';
 import { FilterSelector, FilterUtility } from '../../src/utils/filter.js';
 
 import chaiAsPromised from 'chai-as-promised';
@@ -228,6 +229,38 @@ describe('filters util', () => {
       });
 
       describe('numbers', () => {
+      });
+
+      describe('array value types', () => {
+        it('strings', async () => {
+          const taggedItem = {
+            id   : uuid(),
+            tags : ['tag1', 'tag2', 'tag3']
+          };
+
+          expect(FilterUtility.matchAnyFilter(taggedItem, [{ tags: 'tag2' }])).to.be.true;
+          expect(FilterUtility.matchAnyFilter(taggedItem, [{ tags: 'tag4' }])).to.be.false;
+        });
+
+        it('number', async () => {
+          const taggedItem = {
+            id   : uuid(),
+            tags : [ 1, 2, 3 ]
+          };
+
+          expect(FilterUtility.matchAnyFilter(taggedItem, [{ tags: 2 }])).to.be.true;
+          expect(FilterUtility.matchAnyFilter(taggedItem, [{ tags: 4 }])).to.be.false;
+        });
+
+        it('boolean', async () => {
+          const taggedItem = {
+            id   : uuid(),
+            tags : [ true ]
+          };
+
+          expect(FilterUtility.matchAnyFilter(taggedItem, [{ tags: true }])).to.be.true;
+          expect(FilterUtility.matchAnyFilter(taggedItem, [{ tags: false }])).to.be.false;
+        });
       });
     });
 

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -9,7 +9,6 @@ import type { ProtocolsConfigureOptions } from '../../src/interfaces/protocols-c
 import type { ProtocolsQueryOptions } from '../../src/interfaces/protocols-query.js';
 import type { Readable } from 'readable-stream';
 import type { RecordsQueryOptions } from '../../src/interfaces/records-query.js';
-import type { RecordsWriteMessage } from '../../src/types/records-types.js';
 import type { Signer } from '../../src/types/signer.js';
 import type { AuthorizationModel, Pagination } from '../../src/types/message-types.js';
 import type { CreateFromOptions, EncryptionInput, KeyEncryptionInput, RecordsWriteOptions } from '../../src/interfaces/records-write.js';
@@ -19,6 +18,7 @@ import type { PermissionConditions, PermissionScope } from '../../src/types/perm
 import type { PermissionsGrantMessage, PermissionsRequestMessage, PermissionsRevokeMessage } from '../../src/types/permissions-types.js';
 import type { PrivateJwk, PublicJwk } from '../../src/types/jose-types.js';
 import type { ProtocolDefinition, ProtocolsConfigureMessage, ProtocolsQueryMessage } from '../../src/types/protocols-types.js';
+import type { RecordsTags, RecordsWriteMessage } from '../../src/types/records-types.js';
 
 
 import * as cbor from '@ipld/dag-cbor';
@@ -104,6 +104,7 @@ export type GenerateRecordsWriteInput = {
   protocolRole?: string;
   contextId?: string;
   schema?: string;
+  tags?: RecordsTags;
   recordId?: string;
   parentId?: string;
   published?: boolean;
@@ -396,6 +397,7 @@ export class TestDataGenerator {
       protocolRole       : input?.protocolRole,
       contextId          : input?.contextId,
       schema             : input?.schema ?? `http://${TestDataGenerator.randomString(20)}`,
+      tags               : input?.tags,
       recordId           : input?.recordId,
       parentId           : input?.parentId,
       published          : input?.published,


### PR DESCRIPTION
This is a first pass at adding the functionality for `tags` within records as mentioned here https://github.com/TBD54566975/dwn-sdk-js/issues/642.

Need to implement size limits for tags, additional tests, and pepper with comments.

Additionally tags are not able to be used as a sort property, right now it returns zero results (as other invalid sort properties would).

Tags are written to records as follows:
```typescript
{
    published : true,
    schema    : 'post',
    tags      : {
      tag1 : [ 'tag1', 'tag2', 'tag3' ],
      tag2 : [ 1, 2, 3 ],
      tag3 : [ true ]
    }
}
```

// OneOf match tag
Filters as follows:
```typescript
{
  filter : {
    tags: {
      tag1: 'tag2'
    }
  }
}
```
OneOf match boolean
```typescript
{
  filter : {
    tags: {
      tag3: true
    }
  }
}
```

// OneOf match numeric
```typescript
 {
   filter : {
      tags: {
        tag2: 2
      }
    }
 }
```
// numerical match range
```typescript
 {
   filter : {
      tags: {
        gt : 2,
        lt : 4,
      }
    }
 }
```
// string match range, can be used for date strings.
```typescript
 {
   filter : {
      tags: {
        tag1: {
          from : 'tag2',
          to   : 'tag4'
        }
      }
    }
 }
```


Test case to look at: [should be able to query by string tags](https://github.com/TBD54566975/dwn-sdk-js/blob/8ea2d5f31cf1d0477ed89882151aed0a313eaadc/tests/handlers/records-query.spec.ts#L312)