### PR TITLE
v0.2.10 + Added private key signer as part of Persona creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/dwn-sdk-js",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "A reference implementation of https://identity.foundation/decentralized-web-node/spec/",
   "repository": {
     "type": "git",

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -10,6 +10,7 @@ import type { ProtocolsQueryOptions } from '../../src/interfaces/protocols-query
 import type { Readable } from 'readable-stream';
 import type { RecordsQueryOptions } from '../../src/interfaces/records-query.js';
 import type { RecordsWriteMessage } from '../../src/types/records-types.js';
+import type { Signer } from '../../src/types/signer.js';
 import type { AuthorizationModel, Pagination } from '../../src/types/message-types.js';
 import type { CreateFromOptions, EncryptionInput, KeyEncryptionInput, RecordsWriteOptions } from '../../src/interfaces/records-write.js';
 import type { DateSort, RecordsDeleteMessage, RecordsFilter, RecordsQueryMessage } from '../../src/types/records-types.js';
@@ -32,6 +33,7 @@ import { MessagesGet } from '../../src/interfaces/messages-get.js';
 import { PermissionsGrant } from '../../src/interfaces/permissions-grant.js';
 import { PermissionsRequest } from '../../src/interfaces/permissions-request.js';
 import { PermissionsRevoke } from '../../src/interfaces/permissions-revoke.js';
+import { PrivateKeySigner } from '../../src/utils/private-key-signer.js';
 import { ProtocolsConfigure } from '../../src/interfaces/protocols-configure.js';
 import { ProtocolsQuery } from '../../src/interfaces/protocols-query.js';
 import { Records } from '../../src/utils/records.js';
@@ -52,6 +54,7 @@ export type Persona = {
   did: string;
   keyId: string;
   keyPair: { publicJwk: PublicJwk, privateJwk: PrivateJwk };
+  signer: Signer;
 };
 
 export type GenerateProtocolsConfigureInput = {
@@ -279,7 +282,12 @@ export class TestDataGenerator {
     const persona: Persona = {
       did,
       keyId,
-      keyPair
+      keyPair,
+      signer: new PrivateKeySigner({
+        privateJwk : keyPair.privateJwk,
+        algorithm  : keyPair.privateJwk.alg,
+        keyId      : `${did}#${keyId}`,
+      })
     };
 
     return persona;


### PR DESCRIPTION
As part of taking over Finn's PoW work, I see that the `dwn-server` repo has a [`Profile`](https://github.com/TBD54566975/dwn-server/blob/main/tests/utils.ts#L31) wrapper that wraps key signer over `Persona`. The signer can (and arguably should) be included as a first-class/built-in utility for `Persona` to avoid this overhead, so I did.

Hiked the version to v0.2.10 in preparation of a new release to consume this in `dwn-server`.