### PR TITLE
Renamed isTenant() to isActiveTenant() to better support intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,9 +244,9 @@ import { Dwn, TenantGate, DataStoreLevel, EventLogLevel, MessageStoreLevel } fro
 
 // Define a custom implementation of the TenantGate interface.
 class CustomTenantGate implements TenantGate {
-  public async isTenant(did): Promise<void> {
+  public async isActiveTenant(did): Promise<void> {
     // Custom implementation
-    // returns `true` if the given DID is a tenant of the DWN; `false` otherwise
+    // returns `true` if the given DID is an active tenant of the DWN; `false` otherwise
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/dwn-sdk-js",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "A reference implementation of https://identity.foundation/decentralized-web-node/spec/",
   "repository": {
     "type": "git",

--- a/src/core/tenant-gate.ts
+++ b/src/core/tenant-gate.ts
@@ -1,18 +1,18 @@
 /**
- * An interface that determines if a DID is a tenant of the DWN.
+ * An interface that gates tenant access to the DWN.
  */
 export interface TenantGate {
   /**
-   * @returns `true` if the given DID is a tenant of the DWN; `false` otherwise
+   * @returns `true` if the given DID is an active tenant of the DWN; `false` otherwise
    */
-  isTenant(did: string): Promise<boolean>;
+  isActiveTenant(did: string): Promise<boolean>;
 }
 
 /**
- * A tenant gate that treats every DID as a tenant.
+ * A tenant gate that treats every DID as an active tenant.
  */
 export class AllowAllTenantGate implements TenantGate {
-  public async isTenant(_did: string): Promise<boolean> {
+  public async isActiveTenant(_did: string): Promise<boolean> {
     return true;
   }
 }

--- a/src/dwn.ts
+++ b/src/dwn.ts
@@ -130,8 +130,8 @@ export class Dwn {
    * @returns GenericMessageReply if the message has an integrity error, otherwise undefined.
    */
   public async validateTenant(tenant: string): Promise<GenericMessageReply | undefined> {
-    const isTenant = await this.tenantGate.isTenant(tenant);
-    if (!isTenant) {
+    const isActiveTenant = await this.tenantGate.isActiveTenant(tenant);
+    if (!isActiveTenant) {
       return {
         status: { code: 401, detail: `${tenant} is not a tenant` }
       };

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,5 +56,5 @@ export { DataStoreLevel } from './store/data-store-level.js';
 export { EventLogLevel } from './event-log/event-log-level.js';
 export { MessageStoreLevel } from './store/message-store-level.js';
 
-// test generator
-export { TestDataGenerator } from '../tests/utils/test-data-generator.js';
+// test library exports
+export { Persona, TestDataGenerator } from '../tests/utils/test-data-generator.js';

--- a/tests/dwn.spec.ts
+++ b/tests/dwn.spec.ts
@@ -117,7 +117,7 @@ export function testDwnClass(): void {
       it('should throw 401 if message is targeted at a non-tenant', async () => {
       // tenant gate that blocks everyone
         const blockAllTenantGate: TenantGate = {
-          async isTenant(): Promise<boolean> {
+          async isActiveTenant(): Promise<boolean> {
             return false;
           }
         };


### PR DESCRIPTION
Upon adding support tenant registration and tenant gate in `dwn-server`, it occurred to me that `isTenant()` is not a perfect fit, because they can be a tenant, but have agreed to an old/expired terms-of-service, in which case they still should be denied access.

`isActiveTenant()` address the intent better.

All ears if you have an even better word than "active".