### PR TITLE
use the TBD engineering endpoint for `did:ion`

### DIFF
--- a/src/did/did-ion-resolver.ts
+++ b/src/did/did-ion-resolver.ts
@@ -17,7 +17,7 @@ export class DidIonResolver implements DidMethodResolver {
   /**
    * @param resolutionEndpoint optional custom URL to send DID resolution request to
    */
-  constructor (private resolutionEndpoint: string = 'https://discover.did.msidentity.com/1.0/identifiers/') { }
+  constructor (private resolutionEndpoint: string = 'https://ion.tbd.engineering/identifiers/') { }
 
   method(): string {
     return 'ion';

--- a/tests/did/did-ion-resolver.spec.ts
+++ b/tests/did/did-ion-resolver.spec.ts
@@ -7,7 +7,7 @@ import { DidIonResolver } from '../../src/did/did-ion-resolver.js';
 chai.use(chaiAsPromised);
 
 describe('DidIonResolver', () => {
-  const defaultResolutionEndpoint = 'https://discover.did.msidentity.com/1.0/identifiers/';
+  const defaultResolutionEndpoint = 'https://ion.tbd.engineering/identifiers/';
 
   it('should set a default resolution endpoint when none is given in constructor', async () => {
     const didIonResolver = new DidIonResolver();


### PR DESCRIPTION
This is temporary until we replace our resolvers w/ the `@web5/dids` package.