### PR TITLE
Allow Union Types in JSON Schema parsing

### DIFF
--- a/build/compile-validators.js
+++ b/build/compile-validators.js
@@ -87,7 +87,7 @@ const schemas = {
   RecordsWriteSignaturePayload
 };
 
-const ajv = new Ajv({ code: { source: true, esm: true } });
+const ajv = new Ajv({ code: { source: true, esm: true }, allowUnionTypes: true });
 
 for (const schemaName in schemas) {
   ajv.addSchema(schemas[schemaName], schemaName);


### PR DESCRIPTION
Currently Ajv throws a warning for union types:
![Screenshot 2024-01-25 at 9 12 07 AM](https://github.com/TBD54566975/dwn-sdk-js/assets/2191517/278034d2-ae6b-4d2b-8a7c-7636c986b77e)


Adding the option `allowUnionTypes: true` removes the warning.