### PR TITLE
Simplified Data Store interface

### DIFF
--- a/Q_AND_A.md
+++ b/Q_AND_A.md
@@ -87,3 +87,19 @@
   Currently if a subscription is no longer authorized but it is still active, the subscriber will still receive updates until they close the subscription themselves. If they try to re-subscribe after that, it will be rejected with a 401.
 
   This will be addressed in a future upgrade and we've created an issue to track it. https://github.com/TBD54566975/dwn-sdk-js/issues/668 - last updated (2024/01/22)
+
+
+  ## Datastore
+- Is it possible to implement the datastore interface purely using a blob/binary data storage service such as Amazon S3, Azure Blob Storage, or Google Cloud Storage?
+
+  (Last update: 2024/01/30)
+
+  The short answer is: yes.
+
+  The long answer, with context:
+
+  Keys to objects are generally immutable once the object is created by all three vendors. Amazon S3 and Google Cloud Storage do not have built-in mechanisms to search by their metadata/tags on the server side, even though they support the modification of metadata/tags. Only Azure Blob Storage allows both search and modification of metadata for a written object. Amazon S3 and Google Cloud Storage also have limited support for "partitions": a finite limit in S3 or a limited rate of 1 per 2 seconds, while Azure Blob Storage fully supports partitions.
+
+  All of the above means that an implementation using Azure Blob Storage could be the most "clean". However, it should still be straightforward to implement the datastore using Amazon S3 or Google Cloud Storage by using recordId + dataCid as the object key.
+
+  Implementers have the liberty to introduce advanced features such as reference counting to avoid storing the same data twice, but this is not a requirement.

--- a/Q_AND_A.md
+++ b/Q_AND_A.md
@@ -89,8 +89,8 @@
   This will be addressed in a future upgrade and we've created an issue to track it. https://github.com/TBD54566975/dwn-sdk-js/issues/668 - last updated (2024/01/22)
 
 
-  ## Datastore
-- Is it possible to implement the datastore interface purely using a blob/binary data storage service such as Amazon S3, Azure Blob Storage, or Google Cloud Storage?
+  ## Data Store
+- Is it possible to implement the Data Store interface purely using a blob/binary data storage service such as Amazon S3, Azure Blob Storage, or Google Cloud Storage?
 
   (Last update: 2024/01/30)
 
@@ -100,6 +100,6 @@
 
   Keys to objects are generally immutable once the object is created by all three vendors. Amazon S3 and Google Cloud Storage do not have built-in mechanisms to search by their metadata/tags on the server side, even though they support the modification of metadata/tags. Only Azure Blob Storage allows both search and modification of metadata for a written object. Amazon S3 and Google Cloud Storage also have limited support for "partitions": a finite limit in S3 or a limited rate of 1 per 2 seconds, while Azure Blob Storage fully supports partitions.
 
-  All of the above means that an implementation using Azure Blob Storage could be the most "clean". However, it should still be straightforward to implement the datastore using Amazon S3 or Google Cloud Storage by using recordId + dataCid as the object key.
+  All of the above means that an implementation using Azure Blob Storage could be the most "clean". However, it should still be straightforward to implement the Data Store using Amazon S3 or Google Cloud Storage by using recordId + dataCid as the object key.
 
   Implementers have the liberty to introduce advanced features such as reference counting to avoid storing the same data twice, but this is not a requirement.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "ms": "2.1.3",
         "multiformats": "11.0.2",
         "randombytes": "2.1.0",
-        "readable-stream": "4.4.2",
+        "readable-stream": "4.5.2",
         "ulidx": "2.1.0",
         "uuid": "8.3.2",
         "varint": "6.0.0"
@@ -45,7 +45,7 @@
         "@types/ms": "0.7.31",
         "@types/node": "^18.13.0",
         "@types/randombytes": "2.0.0",
-        "@types/readable-stream": "4.0.6",
+        "@types/readable-stream": "4.0.10",
         "@types/secp256k1": "4.0.3",
         "@types/sinon": "10.0.11",
         "@types/uuid": "^9.0.1",
@@ -773,9 +773,9 @@
       }
     },
     "node_modules/@types/readable-stream": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.6.tgz",
-      "integrity": "sha512-awa7+N1SSD9xz8ZvEUSO3/N3itc2PMH6Sca11HiX55TVsWiMaIgmbM76lN+2eZOrCQPiFqj0GmgsfsNtNGWoUw==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.10.tgz",
+      "integrity": "sha512-AbUKBjcC8SHmImNi4yK2bbjogQlkFSg7shZCcicxPQapniOlajG8GCc39lvXzCWX4lLRRs7DM3VAeSlqmEVZUA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -1036,6 +1036,21 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web5/common/node_modules/readable-stream": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@web5/crypto": {
@@ -7249,9 +7264,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "ms": "2.1.3",
     "multiformats": "11.0.2",
     "randombytes": "2.1.0",
-    "readable-stream": "4.4.2",
+    "readable-stream": "4.5.2",
     "ulidx": "2.1.0",
     "uuid": "8.3.2",
     "varint": "6.0.0"
@@ -97,7 +97,7 @@
     "@types/ms": "0.7.31",
     "@types/node": "^18.13.0",
     "@types/randombytes": "2.0.0",
-    "@types/readable-stream": "4.0.6",
+    "@types/readable-stream": "4.0.10",
     "@types/secp256k1": "4.0.3",
     "@types/sinon": "10.0.11",
     "@types/uuid": "^9.0.1",

--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -125,7 +125,6 @@ export enum DwnErrorCode {
   RecordsWriteMissingSigner = 'RecordsWriteMissingSigner',
   RecordsWriteMissingDataInPrevious = 'RecordsWriteMissingDataInPrevious',
   RecordsWriteMissingEncodedDataInPrevious = 'RecordsWriteMissingEncodedDataInPrevious',
-  RecordsWriteMissingDataAssociation = 'RecordsWriteMissingDataAssociation',
   RecordsWriteMissingDataStream = 'RecordsWriteMissingDataStream',
   RecordsWriteMissingProtocol = 'RecordsWriteMissingProtocol',
   RecordsWriteMissingSchema = 'RecordsWriteMissingSchema',

--- a/src/handlers/records-read.ts
+++ b/src/handlers/records-read.ts
@@ -76,8 +76,7 @@ export class RecordsReadHandler implements MethodHandler {
       data = DataStream.fromBytes(dataBytes);
       delete matchedRecordsWrite.encodedData;
     } else {
-      const messageCid = await Message.getCid(matchedRecordsWrite);
-      const result = await this.dataStore.get(tenant, messageCid, matchedRecordsWrite.descriptor.dataCid);
+      const result = await this.dataStore.get(tenant, matchedRecordsWrite.recordId, matchedRecordsWrite.descriptor.dataCid);
       if (result?.dataStream === undefined) {
         return {
           status: { code: 404, detail: 'Not Found' }

--- a/src/handlers/records-write.ts
+++ b/src/handlers/records-write.ts
@@ -191,7 +191,6 @@ export class RecordsWriteHandler implements MethodHandler {
       try {
         const [dataCid, putResult] = await Promise.all([
           Cid.computeDagPbCidFromStream(dataStreamCopy1),
-          // TODO: change interface to not return dataCid
           this.dataStore.put(tenant, message.recordId, message.descriptor.dataCid, dataStreamCopy2)
         ]);
 

--- a/src/handlers/records-write.ts
+++ b/src/handlers/records-write.ts
@@ -189,12 +189,12 @@ export class RecordsWriteHandler implements MethodHandler {
       const [dataStreamCopy1, dataStreamCopy2] = DataStream.duplicateDataStream(dataStream, 2);
 
       try {
-        const [dataCid, putResult] = await Promise.all([
+        const [dataCid, DataStorePutResult] = await Promise.all([
           Cid.computeDagPbCidFromStream(dataStreamCopy1),
           this.dataStore.put(tenant, message.recordId, message.descriptor.dataCid, dataStreamCopy2)
         ]);
 
-        RecordsWriteHandler.validateDataIntegrity(message.descriptor.dataCid, message.descriptor.dataSize, dataCid, putResult.dataSize);
+        RecordsWriteHandler.validateDataIntegrity(message.descriptor.dataCid, message.descriptor.dataSize, dataCid, DataStorePutResult.dataSize);
       } catch (error) {
         // unwind/delete data we we have issue with storage or the data failed integrity validation
         await this.dataStore.delete(tenant, message.recordId, message.descriptor.dataCid);
@@ -234,9 +234,9 @@ export class RecordsWriteHandler implements MethodHandler {
       // else just make sure the data is in the data store
 
       // attempt to retrieve the data from the previous message
-      const getResult = await this.dataStore.get(tenant, newestExistingWrite.recordId, message.descriptor.dataCid);
+      const DataStoreGetResult = await this.dataStore.get(tenant, newestExistingWrite.recordId, message.descriptor.dataCid);
 
-      if (getResult === undefined) {
+      if (DataStoreGetResult === undefined) {
         throw new DwnError(
           DwnErrorCode.RecordsWriteMissingDataInPrevious,
           `No dataStream was provided and unable to get data from previous message`

--- a/src/handlers/records-write.ts
+++ b/src/handlers/records-write.ts
@@ -189,6 +189,7 @@ export class RecordsWriteHandler implements MethodHandler {
       const [dataStreamCopy1, dataStreamCopy2] = DataStream.duplicateDataStream(dataStream, 2);
 
       try {
+        // perform storage and CID computation in parallel
         const [dataCid, DataStorePutResult] = await Promise.all([
           Cid.computeDagPbCidFromStream(dataStreamCopy1),
           this.dataStore.put(tenant, message.recordId, message.descriptor.dataCid, dataStreamCopy2)
@@ -196,7 +197,7 @@ export class RecordsWriteHandler implements MethodHandler {
 
         RecordsWriteHandler.validateDataIntegrity(message.descriptor.dataCid, message.descriptor.dataSize, dataCid, DataStorePutResult.dataSize);
       } catch (error) {
-        // unwind/delete data we we have issue with storage or the data failed integrity validation
+        // unwind/delete data if we have issue with storage or the data failed integrity validation
         await this.dataStore.delete(tenant, message.recordId, message.descriptor.dataCid);
 
         throw error;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export { authenticate } from './core/auth.js';
 export { ActiveTenantCheckResult, AllowAllTenantGate, TenantGate } from './core/tenant-gate.js';
 export { Cid } from './utils/cid.js';
 export { RecordsQuery, RecordsQueryOptions } from './interfaces/records-query.js';
-export { DataStore, PutResult, GetResult, AssociateResult } from './types/data-store.js';
+export { DataStore, PutResult, GetResult } from './types/data-store.js';
 export { DataStream } from './utils/data-stream.js';
 export { DateSort } from './types/records-types.js';
 export { DerivedPrivateJwk, HdKey, KeyDerivationScheme } from './utils/hd-key.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export { authenticate } from './core/auth.js';
 export { ActiveTenantCheckResult, AllowAllTenantGate, TenantGate } from './core/tenant-gate.js';
 export { Cid } from './utils/cid.js';
 export { RecordsQuery, RecordsQueryOptions } from './interfaces/records-query.js';
-export { DataStore, PutResult, GetResult } from './types/data-store.js';
+export { DataStore, DataStorePutResult, DataStoreGetResult } from './types/data-store.js';
 export { DataStream } from './utils/data-stream.js';
 export { DateSort } from './types/records-types.js';
 export { DerivedPrivateJwk, HdKey, KeyDerivationScheme } from './utils/hd-key.js';

--- a/src/store/data-store-level.ts
+++ b/src/store/data-store-level.ts
@@ -50,8 +50,7 @@ export class DataStoreLevel implements DataStore {
     for await (dataDagRoot of asyncDataBlocks) { ; }
 
     return {
-      dataCid  : String(dataDagRoot.cid),
-      dataSize : Number(dataDagRoot.unixfs?.fileSize() ?? dataDagRoot.size)
+      dataSize: Number(dataDagRoot.unixfs?.fileSize() ?? dataDagRoot.size)
     };
   }
 
@@ -85,8 +84,7 @@ export class DataStoreLevel implements DataStore {
     }
 
     return {
-      dataCid  : String(dataDagRoot.cid),
-      dataSize : Number(dataSize),
+      dataSize: Number(dataSize),
       dataStream,
     };
   }
@@ -114,7 +112,6 @@ export class DataStoreLevel implements DataStore {
   }
 
   public async delete(tenant: string, recordId: string, dataCid: string): Promise<void> {
-    // TODO: add test to make sure the recordId sublevel is clean up
     const blockstoreForData = await this.getBlockstoreForStoringData(tenant, recordId, dataCid);
     await blockstoreForData.clear();
 

--- a/src/store/data-store-level.ts
+++ b/src/store/data-store-level.ts
@@ -1,5 +1,5 @@
 import type { ImportResult } from 'ipfs-unixfs-importer';
-import type { DataStore, GetResult, PutResult } from '../types/data-store.js';
+import type { DataStore, DataStoreGetResult, DataStorePutResult } from '../types/data-store.js';
 
 import { BlockstoreLevel } from './blockstore-level.js';
 import { createLevelDatabase } from './level-wrapper.js';
@@ -40,7 +40,7 @@ export class DataStoreLevel implements DataStore {
     await this.blockstore.close();
   }
 
-  async put(tenant: string, recordId: string, dataCid: string, dataStream: Readable): Promise<PutResult> {
+  async put(tenant: string, recordId: string, dataCid: string, dataStream: Readable): Promise<DataStorePutResult> {
     const blockstoreForData = await this.getBlockstoreForStoringData(tenant, recordId, dataCid);
 
     const asyncDataBlocks = importer([{ content: dataStream }], blockstoreForData, { cidVersion: 1 });
@@ -54,7 +54,7 @@ export class DataStoreLevel implements DataStore {
     };
   }
 
-  public async get(tenant: string, recordId: string, dataCid: string): Promise<GetResult | undefined> {
+  public async get(tenant: string, recordId: string, dataCid: string): Promise<DataStoreGetResult | undefined> {
     const blockstoreForData = await this.getBlockstoreForStoringData(tenant, recordId, dataCid);
 
     const exists = await blockstoreForData.has(dataCid);

--- a/src/store/data-store-level.ts
+++ b/src/store/data-store-level.ts
@@ -92,13 +92,6 @@ export class DataStoreLevel implements DataStore {
   public async delete(tenant: string, recordId: string, dataCid: string): Promise<void> {
     const blockstoreForData = await this.getBlockstoreForStoringData(tenant, recordId, dataCid);
     await blockstoreForData.clear();
-
-    const partitionForRecordId = await this.getPartitionForRecordId(tenant, recordId);
-
-    const noDataLeft = await partitionForRecordId.isEmpty();
-    if (noDataLeft) {
-      await blockstoreForData.clear();
-    }
   }
 
   /**
@@ -112,20 +105,12 @@ export class DataStoreLevel implements DataStore {
    * Gets the blockstore used for storing data for the given `tenant -> `recordId` -> `dataCid`.
    */
   private async getBlockstoreForStoringData(tenant: string, recordId: string, dataCid: string): Promise<BlockstoreLevel> {
-    const blockstoreOfGivenRecordId = await this.getPartitionForRecordId(tenant, recordId);
-    const blockstoreOfGivenDataCidOfRecordId = await blockstoreOfGivenRecordId.partition(dataCid);
-    return blockstoreOfGivenDataCidOfRecordId;
-  }
-
-  /**
-   * Gets the partition used for a given recordId.
-   */
-  private async getPartitionForRecordId(tenant: string, recordId: string): Promise<BlockstoreLevel> {
     const dataPartitionName = 'data';
     const blockstoreForData = await this.blockstore.partition(dataPartitionName);
     const blockstoreOfGivenTenant = await blockstoreForData.partition(tenant);
     const blockstoreOfGivenRecordId = await blockstoreOfGivenTenant.partition(recordId);
-    return blockstoreOfGivenRecordId;
+    const blockstoreOfGivenDataCidOfRecordId = await blockstoreOfGivenRecordId.partition(dataCid);
+    return blockstoreOfGivenDataCidOfRecordId;
   }
 }
 

--- a/src/store/data-store-level.ts
+++ b/src/store/data-store-level.ts
@@ -11,8 +11,8 @@ import { Readable } from 'readable-stream';
  * A simple implementation of {@link DataStore} that works in both the browser and server-side.
  * Leverages LevelDB under the hood.
  *
- * It has the following structure (`+` represents a sublevel and `->` represents a key->value pair):
- *   'data' + <tenant> + <recordId> -> <data>
+ * It has the following structure (`+` represents an additional sublevel/partition):
+ *   'data' + <tenant> + <recordId> + <dataCid> -> <data>
  */
 export class DataStoreLevel implements DataStore {
   config: DataStoreLevelConfig;

--- a/src/store/data-store-level.ts
+++ b/src/store/data-store-level.ts
@@ -1,5 +1,5 @@
 import type { ImportResult } from 'ipfs-unixfs-importer';
-import type { AssociateResult, DataStore, GetResult, PutResult } from '../types/data-store.js';
+import type { DataStore, GetResult, PutResult } from '../types/data-store.js';
 
 import { BlockstoreLevel } from './blockstore-level.js';
 import { createLevelDatabase } from './level-wrapper.js';
@@ -86,28 +86,6 @@ export class DataStoreLevel implements DataStore {
     return {
       dataSize: Number(dataSize),
       dataStream,
-    };
-  }
-
-  public async associate(tenant: string, recordId: string, dataCid: string): Promise<AssociateResult | undefined> {
-    const blockstoreForData = await this.getBlockstoreForStoringData(tenant, recordId, dataCid);
-
-    const dataExists = await blockstoreForData.has(dataCid);
-    if (!dataExists) {
-      return undefined;
-    }
-
-    const dataDagRoot = await exporter(dataCid, blockstoreForData);
-
-    let dataSize = dataDagRoot.size;
-
-    if (dataDagRoot.type === 'file' || dataDagRoot.type === 'directory') {
-      dataSize = dataDagRoot.unixfs.fileSize();
-    }
-
-    return {
-      dataCid  : String(dataDagRoot.cid),
-      dataSize : Number(dataSize)
     };
   }
 

--- a/src/store/storage-controller.ts
+++ b/src/store/storage-controller.ts
@@ -14,34 +14,44 @@ import { RecordsWrite } from '../interfaces/records-write.js';
  */
 export class StorageController {
   /**
-   * Deletes a message.
+   * Deletes the data referenced by the given message if needed.
+   * @param message The message to check if the data it references should be deleted.
    */
-  private static async delete(
-    messageStore: MessageStore,
+  private static async deleteFromDataStoreIfNeeded(
     dataStore: DataStore,
     tenant: string,
-    message: GenericMessage
+    message: GenericMessage,
+    newestMessage: GenericMessage
   ): Promise<void> {
-    const messageCid = await Message.getCid(message);
-
-    if (message.descriptor.method === DwnMethodName.Write &&
-        (message as RecordsWriteMessage).descriptor.dataSize > DwnConstant.maxDataSizeAllowedToBeEncoded) {
-      const recordsWriteMessage = message as RecordsWriteMessage;
-      await dataStore.delete(tenant, messageCid, recordsWriteMessage.descriptor.dataCid);
+    if (message.descriptor.method !== DwnMethodName.Write) {
+      return;
     }
 
-    await messageStore.delete(tenant, messageCid);
+    const recordsWriteMessage = message as RecordsWriteMessage;
+
+    // Optional short-circuit optimization to avoid unnecessary data store call since the data should be encoded with the message itself in this case,
+    // but data store call is a no-op thus code still works correctly even if this short-circuit is removed.
+    if (recordsWriteMessage.descriptor.dataSize <= DwnConstant.maxDataSizeAllowedToBeEncoded) {
+      return;
+    }
+
+    // We must still keep the data if the newest message still references the same data.
+    if (recordsWriteMessage.descriptor.dataCid === (newestMessage as RecordsWriteMessage).descriptor.dataCid) {
+      return;
+    }
+
+    // Else we delete the data from the data store.
+    await dataStore.delete(tenant, recordsWriteMessage.recordId, recordsWriteMessage.descriptor.dataCid);
   }
 
-
   /**
-   * Deletes all messages in `existingMessages` that are older than the `comparedToMessage` in the given tenant,
+   * Deletes all messages in `existingMessages` that are older than the `newestMessage` in the given tenant,
    * but keep the initial write write for future processing by ensuring its `isLatestBaseState` index is "false".
    */
   public static async deleteAllOlderMessagesButKeepInitialWrite(
     tenant: string,
     existingMessages: GenericMessage[],
-    comparedToMessage: GenericMessage,
+    newestMessage: GenericMessage,
     messageStore: MessageStore,
     dataStore: DataStore,
     eventLog: EventLog
@@ -51,12 +61,17 @@ export class StorageController {
     // NOTE: under normal operation, there should only be at most two existing records per `recordId` (initial + a potential subsequent write/delete),
     // but the DWN may crash before `delete()` is called below, so we use a loop as a tactic to clean up lingering data as needed
     for (const message of existingMessages) {
-      const messageIsOld = await Message.isOlder(message, comparedToMessage);
+      const messageIsOld = await Message.isOlder(message, newestMessage);
       if (messageIsOld) {
-      // the easiest implementation here is delete each old messages
-      // and re-create it with the right index (isLatestBaseState = 'false') if the message is the initial write,
-      // but there is room for better/more efficient implementation here
-        await StorageController.delete(messageStore, dataStore, tenant, message);
+        // the easiest implementation here is delete each old messages
+        // and re-create it with the right index (isLatestBaseState = 'false') if the message is the initial write,
+        // but there is room for better/more efficient implementation here
+
+        await StorageController.deleteFromDataStoreIfNeeded(dataStore, tenant, message, newestMessage);
+
+        // delete message from message store
+        const messageCid = await Message.getCid(message);
+        await messageStore.delete(tenant, messageCid);
 
         // if the existing message is the initial write
         // we actually need to keep it BUT, need to ensure the message is no longer marked as the latest state

--- a/src/types/data-store.ts
+++ b/src/types/data-store.ts
@@ -15,7 +15,7 @@ export interface DataStore {
   close(): Promise<void>;
 
   /**
-   * Puts the given data in store.
+   * Stores the given data.
    * @param recordId The logical ID of the record that references the data.
    * @param dataCid The IPFS CID of the data.
    */
@@ -25,18 +25,19 @@ export interface DataStore {
    * Fetches the specified data.
    * @param recordId The logical ID of the record that references the data.
    * @param dataCid The IPFS CID of the data.
+   * @returns the data size and data stream if found, otherwise `undefined`.
    */
   get(tenant: string, recordId: string, dataCid: string): Promise<GetResult | undefined>;
 
   /**
-   * Deletes the specified data.
+   * Deletes the specified data. No-op if the data does not exist.
    * @param recordId The logical ID of the record that references the data.
    * @param dataCid The IPFS CID of the data.
    */
   delete(tenant: string, recordId: string, dataCid: string): Promise<void>;
 
   /**
-   * Clears the entire store. Mainly used for cleaning up in test environment.
+   * Clears the entire store. Mainly used for testing to cleaning up in test environment.
    */
   clear(): Promise<void>;
 }
@@ -52,7 +53,7 @@ export type PutResult = {
 };
 
 /**
- * Result of a data store `get()` method call.
+ * Result of a data store `get()` method call if the data exists.
  */
 export type GetResult = {
   /**

--- a/src/types/data-store.ts
+++ b/src/types/data-store.ts
@@ -1,7 +1,7 @@
 import type { Readable } from 'readable-stream';
 
 /**
- * The interface that defines how to store and fetch data associated with a message
+ * The interface that defines how to store and fetch data associated with a message.
  */
 export interface DataStore {
   /**
@@ -31,16 +31,6 @@ export interface DataStore {
   get(tenant: string, messageCid: string, dataCid: string): Promise<GetResult | undefined>;
 
   /**
-   * Associates dataCid of existing data with the given messageCid.
-   * The returned dataCid and returned dataSize will be verified against the given dataCid (and inferred dataSize).
-   * @param tenant The tenant in which the data must exist under for the association to occur.
-   * @param messageCid CID of the message that references the data.
-   * @param dataCid The CID of the data stored.
-   * @returns {AssociateResult} if association succeeds. `undefined` if data to be associated is not found.
-   */
-  associate(tenant: string, messageCid: string, dataCid: string): Promise<AssociateResult | undefined>;
-
-  /**
    * Deletes the specified data.
    * @param messageCid CID of the message that references the data.
    */
@@ -65,12 +55,4 @@ export type PutResult = {
 export type GetResult = {
   dataSize: number;
   dataStream: Readable;
-};
-
-/**
- * Result of a data store `associate()` method call.
- */
-export type AssociateResult = {
-  dataCid: string;
-  dataSize: number;
 };

--- a/src/types/data-store.ts
+++ b/src/types/data-store.ts
@@ -56,7 +56,6 @@ export interface DataStore {
  * Result of a data store `put()` method call.
  */
 export type PutResult = {
-  dataCid: string;
   dataSize: number;
 };
 
@@ -64,7 +63,6 @@ export type PutResult = {
  * Result of a data store `get()` method call.
  */
 export type GetResult = {
-  dataCid: string;
   dataSize: number;
   dataStream: Readable;
 };

--- a/src/types/data-store.ts
+++ b/src/types/data-store.ts
@@ -19,7 +19,7 @@ export interface DataStore {
    * @param recordId The logical ID of the record that references the data.
    * @param dataCid The IPFS CID of the data.
    */
-  put(tenant: string, recordId: string, dataCid: string, dataStream: Readable): Promise<PutResult>;
+  put(tenant: string, recordId: string, dataCid: string, dataStream: Readable): Promise<DataStorePutResult>;
 
   /**
    * Fetches the specified data.
@@ -27,7 +27,7 @@ export interface DataStore {
    * @param dataCid The IPFS CID of the data.
    * @returns the data size and data stream if found, otherwise `undefined`.
    */
-  get(tenant: string, recordId: string, dataCid: string): Promise<GetResult | undefined>;
+  get(tenant: string, recordId: string, dataCid: string): Promise<DataStoreGetResult | undefined>;
 
   /**
    * Deletes the specified data. No-op if the data does not exist.
@@ -37,7 +37,7 @@ export interface DataStore {
   delete(tenant: string, recordId: string, dataCid: string): Promise<void>;
 
   /**
-   * Clears the entire store. Mainly used for testing to cleaning up in test environment.
+   * Clears the entire store. Mainly used for testing to cleaning up in test environments.
    */
   clear(): Promise<void>;
 }
@@ -45,7 +45,7 @@ export interface DataStore {
 /**
  * Result of a data store `put()` method call.
  */
-export type PutResult = {
+export type DataStorePutResult = {
   /**
    * The number of bytes of the data stored.
    */
@@ -55,7 +55,7 @@ export type PutResult = {
 /**
  * Result of a data store `get()` method call if the data exists.
  */
-export type GetResult = {
+export type DataStoreGetResult = {
   /**
    * The number of bytes of the data stored.
    */

--- a/src/types/data-store.ts
+++ b/src/types/data-store.ts
@@ -16,25 +16,24 @@ export interface DataStore {
 
   /**
    * Puts the given data in store.
-   * It is expected that the CID of the dataStream matches the given dataCid.
-   * The returned dataCid and returned dataSize will be verified against the given dataCid (and inferred dataSize).
-   * @param messageCid CID of the message that references the data.
-   * @returns The CID and size in number of bytes of the data stored.
+   * @param recordId The logical ID of the record that references the data.
+   * @param dataCid The IPFS CID of the data.
    */
-  put(tenant: string, messageCid: string, dataCid: string, dataStream: Readable): Promise<PutResult>;
+  put(tenant: string, recordId: string, dataCid: string, dataStream: Readable): Promise<PutResult>;
 
   /**
    * Fetches the specified data.
-   * The returned dataCid and returned dataSize will be verified against the given dataCid (and inferred dataSize).
-   * @param messageCid CID of the message that references the data.
+   * @param recordId The logical ID of the record that references the data.
+   * @param dataCid The IPFS CID of the data.
    */
-  get(tenant: string, messageCid: string, dataCid: string): Promise<GetResult | undefined>;
+  get(tenant: string, recordId: string, dataCid: string): Promise<GetResult | undefined>;
 
   /**
    * Deletes the specified data.
-   * @param messageCid CID of the message that references the data.
+   * @param recordId The logical ID of the record that references the data.
+   * @param dataCid The IPFS CID of the data.
    */
-  delete(tenant: string, messageCid: string, dataCid: string): Promise<void>;
+  delete(tenant: string, recordId: string, dataCid: string): Promise<void>;
 
   /**
    * Clears the entire store. Mainly used for cleaning up in test environment.
@@ -46,6 +45,9 @@ export interface DataStore {
  * Result of a data store `put()` method call.
  */
 export type PutResult = {
+  /**
+   * The number of bytes of the data stored.
+   */
   dataSize: number;
 };
 
@@ -53,6 +55,9 @@ export type PutResult = {
  * Result of a data store `get()` method call.
  */
 export type GetResult = {
+  /**
+   * The number of bytes of the data stored.
+   */
   dataSize: number;
   dataStream: Readable;
 };

--- a/src/utils/data-stream.ts
+++ b/src/utils/data-stream.ts
@@ -1,5 +1,5 @@
 import { Encoder } from './encoder.js';
-import { Readable } from 'readable-stream';
+import { PassThrough, Readable } from 'readable-stream';
 
 /**
  * Utility class for readable data stream, intentionally named to disambiguate from ReadableStream, readable-stream, Readable etc.
@@ -81,5 +81,19 @@ export class DataStream {
   public static fromObject(object: Record<string, any>): Readable {
     const bytes = Encoder.objectToBytes(object);
     return DataStream.fromBytes(bytes);
+  }
+
+  /**
+   * Duplicates the given data stream into the number of streams specified so that multiple handlers can consume the same data stream.
+   */
+  public static duplicateDataStream(dataStream: Readable, count: number): Readable[] {
+    const streams: Readable[] = [];
+    for (let i = 0; i < count; i++) {
+      const passThrough = new PassThrough();
+      dataStream.pipe(passThrough);
+      streams.push(passThrough as unknown as Readable);
+    }
+
+    return streams;
   }
 }

--- a/tests/handlers/records-delete.spec.ts
+++ b/tests/handlers/records-delete.spec.ts
@@ -124,9 +124,9 @@ export function testRecordsDeleteHandler(): void {
         expect(aliceWriteReply.status.code).to.equal(202);
 
         // alice writes another record with the same data
-        const aliceAssociateData = await TestDataGenerator.generateRecordsWrite({ author: alice, data });
-        const aliceAssociateReply = await dwn.processMessage(alice.did, aliceAssociateData.message, { dataStream: aliceAssociateData.dataStream });
-        expect(aliceAssociateReply.status.code).to.equal(202);
+        const aliceWrite2Data = await TestDataGenerator.generateRecordsWrite({ author: alice, data });
+        const aliceWrite2Reply = await dwn.processMessage(alice.did, aliceWrite2Data.message, { dataStream: aliceWrite2Data.dataStream });
+        expect(aliceWrite2Reply.status.code).to.equal(202);
 
         // bob writes a records with same data
         const bobWriteData = await TestDataGenerator.generateRecordsWrite({ author: bob, data });
@@ -134,9 +134,9 @@ export function testRecordsDeleteHandler(): void {
         expect(bobWriteReply.status.code).to.equal(202);
 
         // bob writes another record with the same data
-        const bobAssociateData = await TestDataGenerator.generateRecordsWrite({ author: bob, data });
-        const bobAssociateReply = await dwn.processMessage(bob.did, bobAssociateData.message, { dataStream: bobAssociateData.dataStream });
-        expect(bobAssociateReply.status.code).to.equal(202);
+        const bobWrite2Data = await TestDataGenerator.generateRecordsWrite({ author: bob, data });
+        const bobWrite2Reply = await dwn.processMessage(bob.did, bobWrite2Data.message, { dataStream: bobWrite2Data.dataStream });
+        expect(bobWrite2Reply.status.code).to.equal(202);
 
         // alice deletes one of the two records
         const aliceDeleteWriteData = await TestDataGenerator.generateRecordsDelete({
@@ -149,7 +149,7 @@ export function testRecordsDeleteHandler(): void {
         // verify the other record with the same data is unaffected
         const aliceRead1 = await RecordsRead.create({
           filter: {
-            recordId: aliceAssociateData.message.recordId,
+            recordId: aliceWrite2Data.message.recordId,
           },
           signer: Jws.createSigner(alice)
         });
@@ -161,12 +161,12 @@ export function testRecordsDeleteHandler(): void {
         expect(ArrayUtility.byteArraysEqual(aliceDataFetched, data)).to.be.true;
 
         // alice deletes the other record
-        const aliceDeleteAssociateData = await TestDataGenerator.generateRecordsDelete({
+        const aliceDeleteWrite2Data = await TestDataGenerator.generateRecordsDelete({
           author   : alice,
-          recordId : aliceAssociateData.message.recordId
+          recordId : aliceWrite2Data.message.recordId
         });
-        const aliceDeleteAssociateReply = await dwn.processMessage(alice.did, aliceDeleteAssociateData.message);
-        expect(aliceDeleteAssociateReply.status.code).to.equal(202);
+        const aliceDeleteWrite2Reply = await dwn.processMessage(alice.did, aliceDeleteWrite2Data.message);
+        expect(aliceDeleteWrite2Reply.status.code).to.equal(202);
 
         // verify that alice can no longer fetch the 2nd record
         const aliceRead2Reply = await dwn.processMessage(alice.did, aliceRead1.message);
@@ -175,7 +175,7 @@ export function testRecordsDeleteHandler(): void {
         // verify that bob can still fetch record with the same data
         const bobRead1 = await RecordsRead.create({
           filter: {
-            recordId: bobAssociateData.message.recordId,
+            recordId: bobWriteData.message.recordId,
           },
           signer: Jws.createSigner(bob)
         });

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -3167,13 +3167,13 @@ export function testRecordsWriteHandler(): void {
           expect(bobRecordsQueryReply.entries?.length).to.equal(0);
 
           //further sanity query for specific recordId
-          const bobRecordsQueryReordId = await RecordsQuery.create({
+          const bobRecordsQueryRecordId = await RecordsQuery.create({
             filter: {
               recordId: imageRecordsWrite.message.recordId,
             },
             signer: Jws.createSigner(bob)
           });
-          const bobRecordsQueryRecordIdReply = await dwn.processMessage(alice.did, bobRecordsQueryReordId.message);
+          const bobRecordsQueryRecordIdReply = await dwn.processMessage(alice.did, bobRecordsQueryRecordId.message);
           expect(bobRecordsQueryRecordIdReply.status.code).to.equal(200);
           expect(bobRecordsQueryRecordIdReply.entries?.length).to.equal(0);
 
@@ -3259,13 +3259,13 @@ export function testRecordsWriteHandler(): void {
           expect(bobRecordsQueryReply.entries?.length).to.equal(0);
 
           //further sanity query for specific recordId
-          const bobRecordsQueryReordId = await RecordsQuery.create({
+          const bobRecordsQueryRecordId = await RecordsQuery.create({
             filter: {
               recordId: imageRecordsWrite.message.recordId,
             },
             signer: Jws.createSigner(bob)
           });
-          const bobRecordsQueryRecordIdReply = await dwn.processMessage(alice.did, bobRecordsQueryReordId.message);
+          const bobRecordsQueryRecordIdReply = await dwn.processMessage(alice.did, bobRecordsQueryRecordId.message);
           expect(bobRecordsQueryRecordIdReply.status.code).to.equal(200);
           expect(bobRecordsQueryRecordIdReply.entries?.length).to.equal(0);
 

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -3,7 +3,7 @@ import type { EventStream } from '../../src/types/subscriptions.js';
 import type { GenerateFromRecordsWriteOut } from '../utils/test-data-generator.js';
 import type { ProtocolDefinition } from '../../src/types/protocols-types.js';
 import type { RecordsQueryReplyEntry } from '../../src/types/records-types.js';
-import type { DataStore, EventLog, GetResult, MessageStore } from '../../src/index.js';
+import type { DataStore, EventLog, MessageStore } from '../../src/index.js';
 
 import anyoneCollaborateProtocolDefinition from '../vectors/protocol-definitions/anyone-collaborate.json' assert { type: 'json' };
 import authorCanProtocolDefinition from '../vectors/protocol-definitions/author-can.json' assert { type: 'json' };

--- a/tests/store/data-store-level.spec.ts
+++ b/tests/store/data-store-level.spec.ts
@@ -87,21 +87,18 @@ describe('DataStoreLevel Test Suite', () => {
       expect(result).to.be.undefined;
     });
 
-    it('should return `undefined if the dataCid is different than the dataStream`', async () => {
+    it('should return `undefined` if the dataCid is different than the dataStream`', async () => {
       const tenant = await TestDataGenerator.randomCborSha256Cid();
-      const messageCid = await TestDataGenerator.randomCborSha256Cid();
+      const recordId = await TestDataGenerator.randomCborSha256Cid();
 
       const randomCid = await TestDataGenerator.randomCborSha256Cid();
 
       const dataBytes = TestDataGenerator.randomBytes(10_000_000);
       const dataStream = DataStream.fromBytes(dataBytes);
 
-      const { dataCid } = await store.put(tenant, messageCid, randomCid, dataStream);
+      await store.put(tenant, recordId, randomCid, dataStream);
 
-      expect(dataCid).to.not.equal(randomCid);
-
-      const result = await store.get(tenant, messageCid, randomCid);
-
+      const result = await store.get(tenant, recordId, randomCid);
       expect(result).to.be.undefined;
     });
   });

--- a/tests/store/data-store-level.spec.ts
+++ b/tests/store/data-store-level.spec.ts
@@ -79,10 +79,10 @@ describe('DataStoreLevel Test Suite', () => {
   describe('get', function () {
     it('should return `undefined if unable to find the data specified`', async () => {
       const tenant = await TestDataGenerator.randomCborSha256Cid();
-      const messageCid = await TestDataGenerator.randomCborSha256Cid();
+      const recordId = await TestDataGenerator.randomCborSha256Cid();
 
       const randomCid = await TestDataGenerator.randomCborSha256Cid();
-      const result = await store.get(tenant, messageCid, randomCid);
+      const result = await store.get(tenant, recordId, randomCid);
 
       expect(result).to.be.undefined;
     });

--- a/tests/store/data-store-level.spec.ts
+++ b/tests/store/data-store-level.spec.ts
@@ -33,7 +33,7 @@ describe('DataStoreLevel Test Suite', () => {
       let dataSizeInBytes = 10;
 
       // iterate through order of magnitude in size until hitting 10MB
-      while (dataSizeInBytes <= 10) {
+      while (dataSizeInBytes <= 10_000_000) {
         const dataBytes = TestDataGenerator.randomBytes(dataSizeInBytes);
         const dataStream = DataStream.fromBytes(dataBytes);
         const dataCid = await Cid.computeDagPbCidFromBytes(dataBytes);


### PR DESCRIPTION
1. Removed the need for SQL-like DB for reference counting.
2. Removed  the need for `associate()` implementation entirely.
3. Removed the need to return `dataCid` from data store and handled the `dataCid` computation within the `dwn-sdk-js` itself.
4. As a result, simplified the Level implementation which now only requires 135 lines of code.
5. Various other complexity that went away because of the simplification.

In summary an implementer now only needs to implement `put()`, `get()` and `delete()`.