### PR TITLE
Bump `@web5/dids` and add DID Resolver cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ try.js
 MESSAGESTORE
 DATASTORE
 EVENTLOG
+RESOLVERCACHE
 # location for levelDB data storage for non-browser tests
 TEST-DATASTORE
 TEST-MESSAGESTORE

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@js-temporal/polyfill": "0.4.4",
         "@noble/ed25519": "2.0.0",
         "@noble/secp256k1": "2.0.0",
-        "@web5/dids": "0.3.0",
+        "@web5/dids": "0.4.0-alpha-20240209-0ce456e",
         "abstract-level": "1.0.3",
         "ajv": "8.12.0",
         "blockstore-core": "4.2.0",
@@ -991,9 +991,9 @@
       }
     },
     "node_modules/@web5/common": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@web5/common/-/common-0.2.3.tgz",
-      "integrity": "sha512-WTbIS6l5inrQTS5cwOoQP5KEuUHZqOWCKCDAA62qGUn4QyySolog9Gt2HCNUEClIzzk/d5DHcpBgLCadHoJ6rQ==",
+      "version": "0.2.3-alpha-20240209-0ce456e",
+      "resolved": "https://registry.npmjs.org/@web5/common/-/common-0.2.3-alpha-20240209-0ce456e.tgz",
+      "integrity": "sha512-Vrw5WQAGK0YRuLk3jTcdpBgWH3oT/zXpIRz6IG398LNlc0azbXQ3wmNiEwbWPbkfeZys7JMjiXO75/rReA11mw==",
       "dependencies": {
         "level": "8.0.0",
         "multiformats": "11.0.2",
@@ -1019,14 +1019,14 @@
       }
     },
     "node_modules/@web5/crypto": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@web5/crypto/-/crypto-0.4.0.tgz",
-      "integrity": "sha512-GIKn2CizQKeATvHQqmC4ky26b3q2pJOd2GjIYsOSw/3Y3QIEm3holDGqu9FHs6kacmr6u0Pv5ELvccs58+cKEg==",
+      "version": "0.4.0-alpha-20240209-0ce456e",
+      "resolved": "https://registry.npmjs.org/@web5/crypto/-/crypto-0.4.0-alpha-20240209-0ce456e.tgz",
+      "integrity": "sha512-1pJuZIFgQc8S30IZwEL0fkG3J6V6tNX/pmolWYIobGK5vI3mf1Ghx2QdiItKv29VRBgVfsHnPqQ0OzaPtSEC9w==",
       "dependencies": {
         "@noble/ciphers": "0.4.1",
         "@noble/curves": "1.3.0",
         "@noble/hashes": "1.3.3",
-        "@web5/common": "0.2.3"
+        "@web5/common": "0.2.3-alpha-20240209-0ce456e"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1041,14 +1041,14 @@
       }
     },
     "node_modules/@web5/dids": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.3.0.tgz",
-      "integrity": "sha512-Y6I/mNkSyjtRxvgTH72DJqcMiCA1ywMVJys09ro//kD0NiFU3NYBulurrFTp/Z4yV4t6KKOq7hj1WopWMagTbQ==",
+      "version": "0.4.0-alpha-20240209-0ce456e",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.4.0-alpha-20240209-0ce456e.tgz",
+      "integrity": "sha512-OqK4n0RimqOmXV2d2mcGdnKweGJhcst5DcVEsE1+yndcQ4jJKc4kaZD3m9Q1IgUWzbbfaRR+G9AV5XoA0lB7jg==",
       "dependencies": {
         "@decentralized-identity/ion-sdk": "1.0.1",
         "@dnsquery/dns-packet": "6.1.1",
-        "@web5/common": "0.2.3",
-        "@web5/crypto": "0.4.0",
+        "@web5/common": "0.2.3-alpha-20240209-0ce456e",
+        "@web5/crypto": "0.4.0-alpha-20240209-0ce456e",
         "bencode": "4.0.0",
         "level": "8.0.0",
         "ms": "2.1.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@js-temporal/polyfill": "0.4.4",
         "@noble/ed25519": "2.0.0",
         "@noble/secp256k1": "2.0.0",
-        "@web5/dids": "0.4.0-alpha-20240209-0ce456e",
+        "@web5/dids": "0.4.0",
         "abstract-level": "1.0.3",
         "ajv": "8.12.0",
         "blockstore-core": "4.2.0",
@@ -991,9 +991,9 @@
       }
     },
     "node_modules/@web5/common": {
-      "version": "0.2.3-alpha-20240209-0ce456e",
-      "resolved": "https://registry.npmjs.org/@web5/common/-/common-0.2.3-alpha-20240209-0ce456e.tgz",
-      "integrity": "sha512-Vrw5WQAGK0YRuLk3jTcdpBgWH3oT/zXpIRz6IG398LNlc0azbXQ3wmNiEwbWPbkfeZys7JMjiXO75/rReA11mw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@web5/common/-/common-0.2.3.tgz",
+      "integrity": "sha512-WTbIS6l5inrQTS5cwOoQP5KEuUHZqOWCKCDAA62qGUn4QyySolog9Gt2HCNUEClIzzk/d5DHcpBgLCadHoJ6rQ==",
       "dependencies": {
         "level": "8.0.0",
         "multiformats": "11.0.2",
@@ -1019,14 +1019,14 @@
       }
     },
     "node_modules/@web5/crypto": {
-      "version": "0.4.0-alpha-20240209-0ce456e",
-      "resolved": "https://registry.npmjs.org/@web5/crypto/-/crypto-0.4.0-alpha-20240209-0ce456e.tgz",
-      "integrity": "sha512-1pJuZIFgQc8S30IZwEL0fkG3J6V6tNX/pmolWYIobGK5vI3mf1Ghx2QdiItKv29VRBgVfsHnPqQ0OzaPtSEC9w==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@web5/crypto/-/crypto-0.4.0.tgz",
+      "integrity": "sha512-GIKn2CizQKeATvHQqmC4ky26b3q2pJOd2GjIYsOSw/3Y3QIEm3holDGqu9FHs6kacmr6u0Pv5ELvccs58+cKEg==",
       "dependencies": {
         "@noble/ciphers": "0.4.1",
         "@noble/curves": "1.3.0",
         "@noble/hashes": "1.3.3",
-        "@web5/common": "0.2.3-alpha-20240209-0ce456e"
+        "@web5/common": "0.2.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1041,14 +1041,14 @@
       }
     },
     "node_modules/@web5/dids": {
-      "version": "0.4.0-alpha-20240209-0ce456e",
-      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.4.0-alpha-20240209-0ce456e.tgz",
-      "integrity": "sha512-OqK4n0RimqOmXV2d2mcGdnKweGJhcst5DcVEsE1+yndcQ4jJKc4kaZD3m9Q1IgUWzbbfaRR+G9AV5XoA0lB7jg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.4.0.tgz",
+      "integrity": "sha512-e+QcrKWlWPJVBbpz4QKrdcgPoj+uC8YUXt4tGKj1mC4kV0rCtIioMLw9Djg+54pp3VXl3eGKxju98UEddyZwqA==",
       "dependencies": {
         "@decentralized-identity/ion-sdk": "1.0.1",
         "@dnsquery/dns-packet": "6.1.1",
-        "@web5/common": "0.2.3-alpha-20240209-0ce456e",
-        "@web5/crypto": "0.4.0-alpha-20240209-0ce456e",
+        "@web5/common": "0.2.3",
+        "@web5/crypto": "0.4.0",
         "bencode": "4.0.0",
         "level": "8.0.0",
         "ms": "2.1.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/dwn-sdk-js",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@js-temporal/polyfill": "0.4.4",
     "@noble/ed25519": "2.0.0",
     "@noble/secp256k1": "2.0.0",
-    "@web5/dids": "0.3.0",
+    "@web5/dids": "0.4.0-alpha-20240209-0ce456e",
     "abstract-level": "1.0.3",
     "ajv": "8.12.0",
     "blockstore-core": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "A reference implementation of https://identity.foundation/decentralized-web-node/spec/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@js-temporal/polyfill": "0.4.4",
     "@noble/ed25519": "2.0.0",
     "@noble/secp256k1": "2.0.0",
-    "@web5/dids": "0.4.0-alpha-20240209-0ce456e",
+    "@web5/dids": "0.4.0",
     "abstract-level": "1.0.3",
     "ajv": "8.12.0",
     "blockstore-core": "4.2.0",

--- a/src/dwn.ts
+++ b/src/dwn.ts
@@ -30,7 +30,7 @@ import { RecordsQueryHandler } from './handlers/records-query.js';
 import { RecordsReadHandler } from './handlers/records-read.js';
 import { RecordsSubscribeHandler } from './handlers/records-subscribe.js';
 import { RecordsWriteHandler } from './handlers/records-write.js';
-import { DidDht, DidIon, DidKey, DidResolver } from '@web5/dids';
+import { DidDht, DidIon, DidKey, DidResolver, DidResolverCacheLevel } from '@web5/dids';
 import { DwnInterfaceName, DwnMethodName } from './enums/dwn-interface-method.js';
 
 export class Dwn {
@@ -134,7 +134,10 @@ export class Dwn {
    * Creates an instance of the DWN.
    */
   public static async create(config: DwnConfig): Promise<Dwn> {
-    config.didResolver ??= new DidResolver({ didResolvers: [DidKey, DidIon, DidDht] });
+    config.didResolver ??= new DidResolver({
+      didResolvers : [DidDht, DidIon, DidKey],
+      cache        : new DidResolverCacheLevel({ location: 'RESOLVERCACHE' }),
+    });
     config.tenantGate ??= new AllowAllTenantGate();
 
     const dwn = new Dwn(config);

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -52,7 +52,6 @@ import { sha256 } from 'multiformats/hashes/sha2';
 import { Time } from '../../src/utils/time.js';
 import { DwnInterfaceName, DwnMethodName } from '../../src/enums/dwn-interface-method.js';
 import { HdKey, KeyDerivationScheme } from '../../src/utils/hd-key.js';
-import { sign } from 'crypto';
 
 /**
  * A logical grouping of user data used to generate test messages.

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -52,6 +52,7 @@ import { sha256 } from 'multiformats/hashes/sha2';
 import { Time } from '../../src/utils/time.js';
 import { DwnInterfaceName, DwnMethodName } from '../../src/enums/dwn-interface-method.js';
 import { HdKey, KeyDerivationScheme } from '../../src/utils/hd-key.js';
+import { sign } from 'crypto';
 
 /**
  * A logical grouping of user data used to generate test messages.
@@ -1000,13 +1001,13 @@ export class TestDataGenerator {
   public static async generateDidKeyPersona(): Promise<Persona> {
 
     const did = await DidKey.create();
-    const signingMethod = await DidKey.getSigningMethod({ didDocument: did.didDocument });
-    const keyId = signingMethod!.id;
-    const portableDid = await DidKey.toKeys({ did });
+    const signingMethod = await DidKey.getSigningMethod({ didDocument: did.document });
+    const keyId = signingMethod.id;
+    const portableDid = await did.export();
     const keyPair = {
       // TODO: #672 - port and use type from @web5/crypto - https://github.com/TBD54566975/dwn-sdk-js/issues/672
-      publicJwk  : portableDid.verificationMethods[0].publicKeyJwk as PublicJwk,
-      privateJwk : portableDid.verificationMethods[0].privateKeyJwk as PrivateJwk,
+      publicJwk  : signingMethod.publicKeyJwk as PublicJwk,
+      privateJwk : portableDid.privateKeys![0] as PrivateJwk,
     };
 
     return {


### PR DESCRIPTION
This PR will:
- Bump the `@web5/dids` package from `0.3.0` to `0.4.0`.
- Adds a DID resolver cache to the default instantiate of a `Dwn`.  The cache is a TTL cache with a 15 minute default timeout.  It uses a persistent LevelDB cache which will keep approximately 8,000 DID documents in an in-memory cache before flushing to disk.  Since the cache entries are persisted to disk, they will survive process restarts.
- Bump `@tbd54566975/dwn-sdk-js` to `0.2.17` so it can be published to NPM Registry.