### PR TITLE
Update JWK Verification Method Schema to support `JsonWebKey`

### DIFF
--- a/json-schemas/jwk-verification-method.json
+++ b/json-schemas/jwk-verification-method.json
@@ -14,7 +14,10 @@
       "type": "string"
     },
     "type": {
-      "const": "JsonWebKey2020"
+      "enum": [
+        "JsonWebKey",
+        "JsonWebKey2020"
+      ]
     },
     "controller": {
       "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/did"

--- a/tests/validation/json-schemas/jwk-verification-method.spec.ts
+++ b/tests/validation/json-schemas/jwk-verification-method.spec.ts
@@ -26,6 +26,17 @@ describe('JwkVerificationMethod', async () => {
     ).to.not.throw();
   });
 
+  it('should not throw an exception if verificationMethod uses \'JsonWebKey\' type', () => {
+    expect(
+      () => validateJsonSchema('JwkVerificationMethod', {
+        id           : 'did:jank:alice#key1',
+        type         : 'JsonWebKey',
+        controller   : 'did:jank:alice',
+        publicKeyJwk : publicJwk
+      })
+    ).to.not.throw();
+  });
+
   it('should not throw if `id` does not have the DID as prefix', () => {
     expect(
       () => validateJsonSchema('JwkVerificationMethod', {


### PR DESCRIPTION
This PR will:
- Update the JWK verification method schema to support `JsonWebKey` in addition to `JsonWebKey2020`.

### Context

- All Web5 SDKs use `JsonWebKey` when creating DHT DIDs
- `JsonWebKey` used by the [DID DHT method specification](https://did-dht.com/#representing-keys)
- Eventually all Web5 SDKs will use `JsonWebKey` for DIDs per [this open issue](https://github.com/TBD54566975/web5-spec/issues/73).

> JsonWebKey2020 is deprecated, as it was published as a part of a now-defunct [CCG draft here](https://www.w3.org/community/reports/credentials/CG-FINAL-lds-jws2020-20220721/). It has been replaced with the recommendation-track JsonWebKey defined in [vc-jose-cose](https://w3c.github.io/vc-jose-cose/).