### PR TITLE
Renamed protocol actions `update` -> `co-update` and `delete` -> `co-delete`

### DIFF
--- a/Q_AND_A.md
+++ b/Q_AND_A.md
@@ -94,12 +94,12 @@
 
   This design choice is primarily driven by performance considerations. If we were to make `protocolPath` optional, and it is not specified, we would need to search records across protocol paths. Since protocol rules (protocol rule set) are defined at the per protocol path level, this means we would need to parse the protocol rules for every protocol path in the protocol definition to determine which protocol path the invoked role has access to. Then, we would need to make a database query for each qualified protocol path, which could be quite costly. This is not to say that we should never consider it, but this is the current design choice.
 
-- What is the difference between `write` and `update` actions?
+- What is the difference between `write` and `co-update` actions?
 
-  (Last update: 2023/11/09)
+  (Last update: 2024/03/04)
 
   - `write` - allows a DID to create and update the record they have created
-  - `update` - allows a DID to update a record, regardless of the initial author
+  - `co-update` - allows a DID to update a record, regardless of the initial author
 
 - What is the difference between the terms "global role" and "context role"?
 

--- a/json-schemas/interface-methods/protocol-rule-set.json
+++ b/json-schemas/interface-methods/protocol-rule-set.json
@@ -43,9 +43,9 @@
               "can": {
                 "type": "string",
                 "enum": [
-                  "delete",
-                  "read",
+                  "co-delete",
                   "co-update",
+                  "read",
                   "write"
                 ]
               }
@@ -64,11 +64,11 @@
               "can": {
                 "type": "string",
                 "enum": [
-                  "delete",
+                  "co-delete",
+                  "co-update",
                   "query",
                   "subscribe",
                   "read",
-                  "co-update",
                   "write"
                 ]
               }

--- a/json-schemas/interface-methods/protocol-rule-set.json
+++ b/json-schemas/interface-methods/protocol-rule-set.json
@@ -45,7 +45,7 @@
                 "enum": [
                   "delete",
                   "read",
-                  "update",
+                  "co-update",
                   "write"
                 ]
               }
@@ -68,7 +68,7 @@
                   "query",
                   "subscribe",
                   "read",
-                  "update",
+                  "co-update",
                   "write"
                 ]
               }

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -521,7 +521,7 @@ export class ProtocolAuthorization {
 
     switch (incomingMessage.message.descriptor.method) {
     case DwnMethodName.Delete:
-      return [ProtocolAction.Delete];
+      return [ProtocolAction.CoDelete];
 
     case DwnMethodName.Query:
       return [ProtocolAction.Query];
@@ -595,7 +595,7 @@ export class ProtocolAuthorization {
         if (incomingMessage.message.descriptor.method === DwnMethodName.Write) {
           recordsWriteMessage = incomingMessage.message as RecordsWriteMessage;
         } else {
-          // else the incoming message must be a RecordsDelete because only `co-update` and `delete` are allowed recipient actions
+          // else the incoming message must be a RecordsDelete because only `co-update` and `co-delete` are allowed recipient actions
           recordsWriteMessage = ancestorMessageChain[ancestorMessageChain.length - 1];
         }
 

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -535,7 +535,7 @@ export class ProtocolAuthorization {
     case DwnMethodName.Write:
       const incomingRecordsWrite = incomingMessage as RecordsWrite;
       if (await incomingRecordsWrite.isInitialWrite()) {
-        // only 'write' allows initial RecordsWrites; 'update' only applies to subsequent RecordsWrites
+        // only 'write' allows initial RecordsWrites
         return [ProtocolAction.Write];
       } else if (await incomingRecordsWrite.isAuthoredByInitialRecordAuthor(tenant, messageStore)) {
         // Both 'co-update' and 'write' authorize the incoming message

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -507,9 +507,11 @@ export class ProtocolAuthorization {
 
   /**
    * Returns a list of ProtocolAction(s) based on the incoming message, one of which must be allowed for the message to be authorized.
-   * NOTE: the reason why there could be multiple actions is because in case of an "update" RecordsWrite by the original record author,
-   * the RecordsWrite can either be authorized by a `write` or `update` allow rule. It is important to recognize that the `write` access that allowed
-   * the original record author to create the record maybe revoked (e.g. by role revocation) by the time an "update" by the same author is attempted.
+   * NOTE: the reason why there could be multiple actions is because in case of a "non-initial" RecordsWrite by the original record author,
+   * the RecordsWrite can either be authorized by a `write` or `co-update` allow rule.
+   *
+   * It is important to recognize that the `write` access that allowed the original record author to create the record maybe revoked
+   * (e.g. by role revocation) by the time a "non-initial" write by the same author is attempted.
    */
   private static async getActionsSeekingARuleMatch(
     tenant: string,
@@ -536,11 +538,11 @@ export class ProtocolAuthorization {
         // only 'write' allows initial RecordsWrites; 'update' only applies to subsequent RecordsWrites
         return [ProtocolAction.Write];
       } else if (await incomingRecordsWrite.isAuthoredByInitialRecordAuthor(tenant, messageStore)) {
-        // Both 'update' and 'write' authorize the incoming message
-        return [ProtocolAction.Write, ProtocolAction.Update];
+        // Both 'co-update' and 'write' authorize the incoming message
+        return [ProtocolAction.Write, ProtocolAction.CoUpdate];
       } else {
-        // Actors other than the initial record author must be authorized to 'update' the message
-        return [ProtocolAction.Update];
+        // Actors other than the initial record author must be authorized to 'co-update' the message
+        return [ProtocolAction.CoUpdate];
       }
 
       // default:
@@ -593,7 +595,7 @@ export class ProtocolAuthorization {
         if (incomingMessage.message.descriptor.method === DwnMethodName.Write) {
           recordsWriteMessage = incomingMessage.message as RecordsWriteMessage;
         } else {
-          // else the incoming message must be a RecordsDelete because only `update` and `delete` are allowed recipient actions
+          // else the incoming message must be a RecordsDelete because only `co-update` and `delete` are allowed recipient actions
           recordsWriteMessage = ancestorMessageChain[ancestorMessageChain.length - 1];
         }
 

--- a/src/interfaces/protocols-configure.ts
+++ b/src/interfaces/protocols-configure.ts
@@ -166,7 +166,7 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
         );
       }
 
-      // Validate that if `who === recipient` and `of === undefined`, then `can` is either `delete` or `co-update`
+      // Validate that if `who === recipient` and `of === undefined`, then `can` is either `co-delete` or `co-update`
       // We will allow `read`, `write`, or `query` because:
       // - `read` - Recipients are always allowed to `read`.
       // - `write` - Entails ability to create and update.
@@ -175,11 +175,11 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
       // - `query` - Only authorized using roles, so allowing direct recipients to query is outside the scope.
       if (action.who === ProtocolActor.Recipient &&
           action.of === undefined &&
-          ![ProtocolAction.CoUpdate, ProtocolAction.Delete].includes(action.can as ProtocolAction)
+          ![ProtocolAction.CoUpdate, ProtocolAction.CoDelete].includes(action.can as ProtocolAction)
       ) {
         throw new DwnError(
           DwnErrorCode.ProtocolsConfigureInvalidRecipientOfAction,
-          'Rules for `recipient` without `of` property must have `can` === `delete` or `update`'
+          'Rules for `recipient` without `of` property must have `can` === `co-delete` or `co-update`'
         );
       }
 

--- a/src/interfaces/protocols-configure.ts
+++ b/src/interfaces/protocols-configure.ts
@@ -3,7 +3,7 @@ import type { ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureDescriptor,
 
 import { AbstractMessage } from '../core/abstract-message.js';
 import { Message } from '../core/message.js';
-import { ProtocolActor } from '../types/protocols-types.js';
+import { ProtocolAction, ProtocolActor } from '../types/protocols-types.js';
 import { Time } from '../utils/time.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
@@ -166,15 +166,16 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
         );
       }
 
-      // Validate that if `who === recipient` and `of === undefined`, then `can` is either `delete` or `update`
-      // We will not use direct recipient for `read`, `write`, or `query` because:
-      // - Recipients are always allowed to `read`.
-      // - `write` entails ability to create and update, whereas `update` only allows for updates.
-      //    There is no 'recipient' until the record has been created, so it makes no sense to allow recipient to write.
-      // - At this time, `query` is only authorized using roles, so allowing direct recipients to query is outside the scope of this PR.
+      // Validate that if `who === recipient` and `of === undefined`, then `can` is either `delete` or `co-update`
+      // We will allow `read`, `write`, or `query` because:
+      // - `read` - Recipients are always allowed to `read`.
+      // - `write` - Entails ability to create and update.
+      //             Since `of` is undefined, it implies the recipient of THIS record,
+      //             there is no 'recipient' until this record has been created, so it makes no sense to allow recipient to write this record.
+      // - `query` - Only authorized using roles, so allowing direct recipients to query is outside the scope.
       if (action.who === ProtocolActor.Recipient &&
           action.of === undefined &&
-          !['update', 'delete'].includes(action.can)
+          ![ProtocolAction.CoUpdate, ProtocolAction.Delete].includes(action.can as ProtocolAction)
       ) {
         throw new DwnError(
           DwnErrorCode.ProtocolsConfigureInvalidRecipientOfAction,

--- a/src/interfaces/protocols-configure.ts
+++ b/src/interfaces/protocols-configure.ts
@@ -3,11 +3,11 @@ import type { ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureDescriptor,
 
 import { AbstractMessage } from '../core/abstract-message.js';
 import { Message } from '../core/message.js';
-import { ProtocolAction, ProtocolActor } from '../types/protocols-types.js';
 import { Time } from '../utils/time.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
 import { normalizeProtocolUrl, normalizeSchemaUrl, validateProtocolUrlNormalized, validateSchemaUrlNormalized } from '../utils/url.js';
+import { ProtocolAction, ProtocolActor } from '../types/protocols-types.js';
 
 export type ProtocolsConfigureOptions = {
   messageTimestamp?: string;

--- a/src/types/protocols-types.ts
+++ b/src/types/protocols-types.ts
@@ -37,11 +37,11 @@ export enum ProtocolActor {
 }
 
 export enum ProtocolAction {
-  Delete = 'delete',
+  CoDelete = 'co-delete',
+  CoUpdate = 'co-update',
   Query = 'query',
   Read = 'read',
   Subscribe = 'subscribe',
-  CoUpdate = 'co-update',
   Write = 'write'
 }
 

--- a/src/types/protocols-types.ts
+++ b/src/types/protocols-types.ts
@@ -41,7 +41,7 @@ export enum ProtocolAction {
   Query = 'query',
   Read = 'read',
   Subscribe = 'subscribe',
-  Update = 'update',
+  CoUpdate = 'co-update',
   Write = 'write'
 }
 

--- a/src/types/protocols-types.ts
+++ b/src/types/protocols-types.ts
@@ -90,7 +90,7 @@ export type ProtocolActionRule = {
 
   /**
    * Action that the actor can perform.
-   * May be 'query' | 'read' | 'write' | 'update' | 'delete' | 'subscribe'.
+   * See {ProtocolAction} for possible values.
    * 'query' and 'subscribe' are only supported for `role` rules.
    */
   can: string;

--- a/tests/handlers/records-delete.spec.ts
+++ b/tests/handlers/records-delete.spec.ts
@@ -502,7 +502,7 @@ export function testRecordsDeleteHandler(): void {
         });
 
         describe('role based deletes', () => {
-          it('should allow deletes by invoking a context role', async () => {
+          it('should allow co-delete by invoking a context role', async () => {
             // scenario: Alice adds Bob as a 'thread/admin' role. She writes a 'thread/chat'.
             //           Bob invokes his admin role to delete the 'thread/chat'. Carol is unable to delete
             //           the 'thread/chat'.
@@ -553,6 +553,7 @@ export function testRecordsDeleteHandler(): void {
             const chatRecordReply = await dwn.processMessage(alice.did, chatRecord.message, { dataStream: chatRecord.dataStream });
             expect(chatRecordReply.status.code).to.equal(202);
 
+            // Verifies that Carol cannot delete without appropriate role
             const chatDeleteCarol = await TestDataGenerator.generateRecordsDelete({
               author   : carol,
               recordId : chatRecord.message.recordId,
@@ -571,7 +572,7 @@ export function testRecordsDeleteHandler(): void {
             expect(chatDeleteReply.status.code).to.equal(202);
           });
 
-          it('should allow delete invoking a root-level role', async () => {
+          it('should allow co-delete invoking a root-level role', async () => {
             // scenario: Alice adds Bob as a root-level 'admin' role. She writes a 'chat'.
             //           Bob invokes his admin role to delete the 'chat'.
 

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -1405,9 +1405,11 @@ export function testRecordsWriteHandler(): void {
             expect(bobTagRecordsReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationActionNotAllowed);
           });
 
-          it('should allowed update with direct recipient rule', async () => {
-            // scenario: Alice creates a 'post' with Bob as recipient. Bob is able to update
-            //           the 'post' because he was recipient of it. Carol is not able to update it.
+          it('should allowed co-update with direct recipient rule', async () => {
+            // scenario:
+            // Alice creates a 'post' with Bob as recipient.
+            // Bob is able to update the 'post' because he was recipient of it.
+            // Carol is not able to update it.
 
             const protocolDefinition = recipientCanProtocol as ProtocolDefinition;
             const alice = await TestDataGenerator.generatePersona();
@@ -1962,7 +1964,7 @@ export function testRecordsWriteHandler(): void {
               expect(chatReply.status.code).to.equal(202);
             });
 
-            it('uses a root-level role to authorize an update', async () => {
+            it('uses a root-level role to authorize a co-update', async () => {
               // scenario: Alice gives Bob a admin role. Bob invokes his
               //           admin role in order to update a chat message that Alice wrote
 
@@ -2128,7 +2130,7 @@ export function testRecordsWriteHandler(): void {
               expect(chatRecordReply.status.code).to.equal(202);
             });
 
-            it('uses a context role to authorize an update', async () => {
+            it('uses a context role to authorize a co-update', async () => {
               // scenario: Alice creates a thread and adds Bob to the 'thread/admin' role.
               //           Bob invokes the record to write in the thread
 
@@ -2176,14 +2178,14 @@ export function testRecordsWriteHandler(): void {
               const chatRecordReply = await dwn.processMessage(alice.did, chatRecord.message, { dataStream: chatRecord.dataStream });
               expect(chatRecordReply.status.code).to.equal(202);
 
-              // Bob invokes his admin role to update the chat message
-              const chatUpdateRecord = await TestDataGenerator.generateFromRecordsWrite({
+              // Bob invokes his admin role to co-update the chat message
+              const chatCoUpdateRecord = await TestDataGenerator.generateFromRecordsWrite({
                 author        : bob,
                 existingWrite : chatRecord.recordsWrite,
                 protocolRole  : 'thread/admin',
               });
               const chatUpdateRecordReply =
-                await dwn.processMessage(alice.did, chatUpdateRecord.message, { dataStream: chatUpdateRecord.dataStream });
+                await dwn.processMessage(alice.did, chatCoUpdateRecord.message, { dataStream: chatCoUpdateRecord.dataStream });
               expect(chatUpdateRecordReply.status.code).to.equal(202);
             });
 

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -1223,7 +1223,7 @@ export function testRecordsWriteHandler(): void {
           expect(bobRecordsQueryReply.entries![0].encodedData).to.equal(Encoder.bytesToBase64Url(bobData));
         });
 
-        it('should allow update with allow-anyone rule', async () => {
+        it('should allow co-update with allow-anyone rule', async () => {
           // scenario: Alice creates a record on her DWN, and Bob (anyone) is able to update it. Bob is not able to
           //           create a record.
 
@@ -1345,7 +1345,7 @@ export function testRecordsWriteHandler(): void {
               .to.equal(base64url.baseEncode(encodedCredentialResponse));
           });
 
-          it('should allow update with ancestor recipient rule', async () => {
+          it('should allow co-update with ancestor recipient rule', async () => {
             // scenario: Alice creates a post with Bob as recipient. Alice adds a tag to the post. Bob is able to update
             //           the tag because he is recipient of the post. Bob is not able to create a new tag.
 
@@ -1405,7 +1405,7 @@ export function testRecordsWriteHandler(): void {
             expect(bobTagRecordsReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationActionNotAllowed);
           });
 
-          it('should allowed co-update with direct recipient rule', async () => {
+          it('should allow co-update with direct recipient rule', async () => {
             // scenario:
             // Alice creates a 'post' with Bob as recipient.
             // Bob is able to update the 'post' because he was recipient of it.
@@ -1531,7 +1531,7 @@ export function testRecordsWriteHandler(): void {
               .to.equal(base64url.baseEncode(encodedCaption));
           });
 
-          it('should allow update with ancestor author rule', async () => {
+          it('should allow co-update with ancestor author rule', async () => {
             // scenario: Bob authors a post on Alice's DWN. Alice adds a comment to the post. Bob is able to update the comment,
             //           since he authored the post.
 

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -2345,7 +2345,7 @@ export function testRecordsWriteHandler(): void {
           expect(newRecordQueryReply.entries![0].encodedData).to.equal(Encoder.bytesToBase64Url(updatedMessageBytes));
         });
 
-        it('should disallow overwriting existing records by a different author if author is not authorized to `update`', async () => {
+        it('should disallow overwriting existing records by a different author if author is not authorized to `co-update`', async () => {
           // scenario: Bob writes into Alice's DWN given Alice's "message" protocol, Carol then attempts to modify the existing message
 
           // write a protocol definition with an allow-anyone rule

--- a/tests/vectors/protocol-definitions/anyone-collaborate.json
+++ b/tests/vectors/protocol-definitions/anyone-collaborate.json
@@ -9,7 +9,7 @@
       "$actions": [
         {
           "who": "anyone",
-          "can": "update"
+          "can": "co-update"
         },
         {
           "who": "anyone",

--- a/tests/vectors/protocol-definitions/anyone-collaborate.json
+++ b/tests/vectors/protocol-definitions/anyone-collaborate.json
@@ -17,7 +17,7 @@
         },
         {
           "who": "anyone",
-          "can": "delete"
+          "can": "co-delete"
         }
       ]
     }

--- a/tests/vectors/protocol-definitions/author-can.json
+++ b/tests/vectors/protocol-definitions/author-can.json
@@ -23,7 +23,7 @@
           {
             "who": "author",
             "of": "post",
-            "can": "delete"
+            "can": "co-delete"
           }
         ]
       }

--- a/tests/vectors/protocol-definitions/author-can.json
+++ b/tests/vectors/protocol-definitions/author-can.json
@@ -18,7 +18,7 @@
           {
             "who": "author",
             "of": "post",
-            "can": "update"
+            "can": "co-update"
           },
           {
             "who": "author",

--- a/tests/vectors/protocol-definitions/free-for-all.json
+++ b/tests/vectors/protocol-definitions/free-for-all.json
@@ -18,7 +18,7 @@
         },
         {
           "who": "anyone",
-          "can": "delete"
+          "can": "co-delete"
         },
         {
           "who": "anyone",

--- a/tests/vectors/protocol-definitions/friend-role.json
+++ b/tests/vectors/protocol-definitions/friend-role.json
@@ -45,7 +45,7 @@
         },
         {
           "role": "admin",
-          "can": "delete"
+          "can": "co-delete"
         }
       ]
     }

--- a/tests/vectors/protocol-definitions/friend-role.json
+++ b/tests/vectors/protocol-definitions/friend-role.json
@@ -41,7 +41,7 @@
         },
         {
           "role": "admin",
-          "can": "update"
+          "can": "co-update"
         },
         {
           "role": "admin",

--- a/tests/vectors/protocol-definitions/post-comment.json
+++ b/tests/vectors/protocol-definitions/post-comment.json
@@ -36,7 +36,7 @@
           {
             "who": "author",
             "of": "post",
-            "can": "delete"
+            "can": "co-delete"
           }
         ]
       }

--- a/tests/vectors/protocol-definitions/recipient-can.json
+++ b/tests/vectors/protocol-definitions/recipient-can.json
@@ -14,7 +14,7 @@
         },
         {
           "who": "recipient",
-          "can": "delete"
+          "can": "co-delete"
         }
       ],
       "tag": {
@@ -27,7 +27,7 @@
           {
             "who": "recipient",
             "of": "post",
-            "can": "delete"
+            "can": "co-delete"
           }
         ]
       }

--- a/tests/vectors/protocol-definitions/recipient-can.json
+++ b/tests/vectors/protocol-definitions/recipient-can.json
@@ -10,7 +10,7 @@
       "$actions": [
         {
           "who": "recipient",
-          "can": "update"
+          "can": "co-update"
         },
         {
           "who": "recipient",
@@ -22,7 +22,7 @@
           {
             "who": "recipient",
             "of": "post",
-            "can": "update"
+            "can": "co-update"
           },
           {
             "who": "recipient",

--- a/tests/vectors/protocol-definitions/slack.json
+++ b/tests/vectors/protocol-definitions/slack.json
@@ -70,7 +70,7 @@
           {
             "who": "author",
             "of": "community",
-            "can": "delete"
+            "can": "co-delete"
           },
           {
             "role": "community/admin",
@@ -78,7 +78,7 @@
           },
           {
             "role": "community/admin",
-            "can": "delete"
+            "can": "co-delete"
           }
         ]
       },
@@ -91,7 +91,7 @@
           },
           {
             "role": "community/admin",
-            "can": "delete"
+            "can": "co-delete"
           }
         ]
       },
@@ -103,7 +103,7 @@
           },
           {
             "role": "community/admin",
-            "can": "delete"
+            "can": "co-delete"
           }
         ],
         "message": {
@@ -119,7 +119,7 @@
             },
             {
               "role": "community/member",
-              "can": "delete"
+              "can": "co-delete"
             }
           ],
           "media": {
@@ -139,7 +139,7 @@
               },
               {
                 "role": "community/member",
-                "can": "delete"
+                "can": "co-delete"
               }
             ]
           }
@@ -153,7 +153,7 @@
           },
           {
             "role": "community/admin",
-            "can": "delete"
+            "can": "co-delete"
           },
           {
             "role": "community/gatedChannel/participant",
@@ -171,7 +171,7 @@
             {
               "who": "author",
               "of": "community/gatedChannel",
-              "can": "delete"
+              "can": "co-delete"
             },
             {
               "role": "community/gatedChannel/participant",
@@ -179,7 +179,7 @@
             },
             {
               "role": "community/gatedChannel/participant",
-              "can": "delete"
+              "can": "co-delete"
             }
           ]
         },
@@ -200,7 +200,7 @@
             },
             {
               "role": "community/gatedChannel/participant",
-              "can": "delete"
+              "can": "co-delete"
             }
           ],
           "media": {
@@ -220,7 +220,7 @@
               },
               {
                 "role": "community/gatedChannel/participant",
-                "can": "delete"
+                "can": "co-delete"
               }
             ]
           }

--- a/tests/vectors/protocol-definitions/thread-role.json
+++ b/tests/vectors/protocol-definitions/thread-role.json
@@ -59,11 +59,11 @@
           },
           {
             "role": "thread/admin",
-            "can": "delete"
+            "can": "co-delete"
           },
           {
             "role": "globalAdmin",
-            "can": "delete"
+            "can": "co-delete"
           }
         ]
       }

--- a/tests/vectors/protocol-definitions/thread-role.json
+++ b/tests/vectors/protocol-definitions/thread-role.json
@@ -55,7 +55,7 @@
           },
           {
             "role": "thread/admin",
-            "can": "update"
+            "can": "co-update"
           },
           {
             "role": "thread/admin",


### PR DESCRIPTION
Next up: reintroduce `delete` action and disambiguate it from `co-delete`.