### PR TITLE
Changed protocol 'can' property to an array

### DIFF
--- a/json-schemas/interface-methods/protocol-rule-set.json
+++ b/json-schemas/interface-methods/protocol-rule-set.json
@@ -41,15 +41,19 @@
                 "type": "string"
               },
               "can": {
-                "type": "string",
-                "enum": [
-                  "co-delete",
-                  "co-update",
-                  "create",
-                  "read",
-                  "update",
-                  "write"
-                ]
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "co-delete",
+                    "co-update",
+                    "create",
+                    "read",
+                    "update",
+                    "write"
+                  ]
+                }
               }
             }
           },
@@ -64,17 +68,21 @@
                 "type": "string"
               },
               "can": {
-                "type": "string",
-                "enum": [
-                  "co-delete",
-                  "co-update",
-                  "create",
-                  "query",
-                  "subscribe",
-                  "read",
-                  "update",
-                  "write"
-                ]
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "co-delete",
+                    "co-update",
+                    "create",
+                    "query",
+                    "subscribe",
+                    "read",
+                    "update",
+                    "write"
+                  ]
+                }
               }
             }
           }

--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -79,6 +79,7 @@ export enum DwnErrorCode {
   ProtocolsConfigureInvalidSize = 'ProtocolsConfigureInvalidSize',
   ProtocolsConfigureInvalidActionMissingOf = 'ProtocolsConfigureInvalidActionMissingOf',
   ProtocolsConfigureInvalidActionOfNotAllowed = 'ProtocolsConfigureInvalidActionOfNotAllowed',
+  ProtocolsConfigureInvalidActionUpdateWithoutCreate = 'ProtocolsConfigureInvalidActionUpdateWithoutCreate',
   ProtocolsConfigureInvalidRecipientOfAction = 'ProtocolsConfigureInvalidRecipientOfAction',
   ProtocolsConfigureInvalidRuleSetRecordType = 'ProtocolsConfigureInvalidRuleSetRecordType',
   ProtocolsConfigureQueryNotAllowed = 'ProtocolsConfigureQueryNotAllowed',

--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -76,6 +76,8 @@ export enum DwnErrorCode {
   ProtocolAuthorizationProtocolNotFound = 'ProtocolAuthorizationProtocolNotFound',
   ProtocolAuthorizationQueryWithoutRole = 'ProtocolAuthorizationQueryWithoutRole',
   ProtocolAuthorizationRoleMissingRecipient = 'ProtocolAuthorizationRoleMissingRecipient',
+  ProtocolsConfigureDuplicateActorInRuleSet = 'ProtocolsConfigureDuplicateActorInRuleSet',
+  ProtocolsConfigureDuplicateRoleInRuleSet = 'ProtocolsConfigureDuplicateRoleInRuleSet',
   ProtocolsConfigureInvalidSize = 'ProtocolsConfigureInvalidSize',
   ProtocolsConfigureInvalidActionMissingOf = 'ProtocolsConfigureInvalidActionMissingOf',
   ProtocolsConfigureInvalidActionOfNotAllowed = 'ProtocolsConfigureInvalidActionOfNotAllowed',

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -355,6 +355,7 @@ export class ProtocolAuthorization {
           `Declared protocol path '${declaredProtocolPath}' is not valid for records with no parentId'.`
         );
       }
+
       return;
     }
 
@@ -583,7 +584,9 @@ export class ProtocolAuthorization {
     const invokedRole = incomingMessage.signaturePayload?.protocolRole;
 
     for (const actionRule of actionRules) {
-      if (!actionsSeekingARuleMatch.includes(actionRule.can as ProtocolAction)) {
+      // If the action rule does not have an allowed action that matches an action that can authorize the message, skip to evaluate next action rule.
+      const ruleHasAMatchingAllowedAction = actionRule.can.some(allowedAction => actionsSeekingARuleMatch.includes(allowedAction as ProtocolAction));
+      if (!ruleHasAMatchingAllowedAction) {
         continue;
       }
 

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -46,7 +46,7 @@ export class ProtocolAuthorization {
     );
 
     // get the rule set for the inbound message
-    const inboundMessageRuleSet = ProtocolAuthorization.getRuleSet(
+    const ruleSet = ProtocolAuthorization.getRuleSet(
       incomingMessage.message.descriptor.protocolPath!,
       protocolDefinition,
     );
@@ -55,12 +55,12 @@ export class ProtocolAuthorization {
     await ProtocolAuthorization.verifyAsRoleRecordIfNeeded(
       tenant,
       incomingMessage,
-      inboundMessageRuleSet,
+      ruleSet,
       messageStore,
     );
 
     // Verify size limit
-    ProtocolAuthorization.verifySizeLimit(incomingMessage, inboundMessageRuleSet);
+    ProtocolAuthorization.verifySizeLimit(incomingMessage, ruleSet);
   }
 
   /**
@@ -84,7 +84,7 @@ export class ProtocolAuthorization {
     );
 
     // get the rule set for the inbound message
-    const inboundMessageRuleSet = ProtocolAuthorization.getRuleSet(
+    const ruleSet = ProtocolAuthorization.getRuleSet(
       incomingMessage.message.descriptor.protocolPath!,
       protocolDefinition,
     );
@@ -99,11 +99,11 @@ export class ProtocolAuthorization {
       messageStore,
     );
 
-    // verify method invoked against the allowed actions
-    await ProtocolAuthorization.verifyAllowedActions(
+    // verify method invoked against the allowed actions in the rule set
+    await ProtocolAuthorization.authorizeAgainstAllowedActions(
       tenant,
       incomingMessage,
-      inboundMessageRuleSet,
+      ruleSet,
       ancestorMessageChain,
       messageStore,
     );
@@ -133,7 +133,7 @@ export class ProtocolAuthorization {
     );
 
     // get the rule set for the inbound message
-    const inboundMessageRuleSet = ProtocolAuthorization.getRuleSet(
+    const ruleSet = ProtocolAuthorization.getRuleSet(
       newestRecordsWrite.message.descriptor.protocolPath!,
       protocolDefinition,
     );
@@ -148,11 +148,11 @@ export class ProtocolAuthorization {
       messageStore,
     );
 
-    // verify method invoked against the allowed actions
-    await ProtocolAuthorization.verifyAllowedActions(
+    // verify method invoked against the allowed actions in the rule set
+    await ProtocolAuthorization.authorizeAgainstAllowedActions(
       tenant,
       incomingMessage,
-      inboundMessageRuleSet,
+      ruleSet,
       ancestorMessageChain,
       messageStore,
     );
@@ -173,7 +173,7 @@ export class ProtocolAuthorization {
     );
 
     // get the rule set for the inbound message
-    const inboundMessageRuleSet = ProtocolAuthorization.getRuleSet(
+    const ruleSet = ProtocolAuthorization.getRuleSet(
       protocolPath!, // presence of `protocolPath` is verified in `parse()`
       protocolDefinition,
     );
@@ -188,11 +188,11 @@ export class ProtocolAuthorization {
       messageStore,
     );
 
-    // verify method invoked against the allowed actions
-    await ProtocolAuthorization.verifyAllowedActions(
+    // verify method invoked against the allowed actions in the rule set
+    await ProtocolAuthorization.authorizeAgainstAllowedActions(
       tenant,
       incomingMessage,
-      inboundMessageRuleSet,
+      ruleSet,
       [], // ancestor chain is not relevant to subscriptions
       messageStore,
     );
@@ -217,7 +217,7 @@ export class ProtocolAuthorization {
     );
 
     // get the rule set for the inbound message
-    const inboundMessageRuleSet = ProtocolAuthorization.getRuleSet(
+    const ruleSet = ProtocolAuthorization.getRuleSet(
       newestRecordsWrite.message.descriptor.protocolPath!,
       protocolDefinition,
     );
@@ -232,11 +232,11 @@ export class ProtocolAuthorization {
       messageStore,
     );
 
-    // verify method invoked against the allowed actions
-    await ProtocolAuthorization.verifyAllowedActions(
+    // verify method invoked against the allowed actions in the rule set
+    await ProtocolAuthorization.authorizeAgainstAllowedActions(
       tenant,
       incomingMessage,
-      inboundMessageRuleSet,
+      ruleSet,
       ancestorMessageChain,
       messageStore,
     );
@@ -558,20 +558,20 @@ export class ProtocolAuthorization {
   }
 
   /**
-   * Verifies the action (e.g. read/write) specified in the given message matches the allowed actions in the rule set.
+   * Verifies the given message is authorized by one of the action rules in the given protocol rule set.
    * @throws {Error} if action not allowed.
    */
-  private static async verifyAllowedActions(
+  private static async authorizeAgainstAllowedActions(
     tenant: string,
     incomingMessage: RecordsDelete | RecordsQuery | RecordsRead | RecordsSubscribe | RecordsWrite,
-    inboundMessageRuleSet: ProtocolRuleSet,
+    ruleSet: ProtocolRuleSet,
     ancestorMessageChain: RecordsWriteMessage[],
     messageStore: MessageStore,
   ): Promise<void> {
     const incomingMessageMethod = incomingMessage.message.descriptor.method;
     const actionsSeekingARuleMatch = await ProtocolAuthorization.getActionsSeekingARuleMatch(tenant, incomingMessage, messageStore);
     const author = incomingMessage.author;
-    const actionRules = inboundMessageRuleSet.$actions;
+    const actionRules = ruleSet.$actions;
 
     // We have already checked that the message is not from tenant, owner, or permissionsGrant
     if (actionRules === undefined) {
@@ -637,9 +637,9 @@ export class ProtocolAuthorization {
    */
   private static verifySizeLimit(
     incomingMessage: RecordsWrite,
-    inboundMessageRuleSet: ProtocolRuleSet
+    ruleSet: ProtocolRuleSet
   ): void {
-    const { min = 0, max } = inboundMessageRuleSet.$size || {};
+    const { min = 0, max } = ruleSet.$size || {};
 
     const dataSize = incomingMessage.message.descriptor.dataSize;
 
@@ -665,10 +665,10 @@ export class ProtocolAuthorization {
   private static async verifyAsRoleRecordIfNeeded(
     tenant: string,
     incomingMessage: RecordsWrite,
-    inboundMessageRuleSet: ProtocolRuleSet,
+    ruleSet: ProtocolRuleSet,
     messageStore: MessageStore,
   ): Promise<void> {
-    if (!inboundMessageRuleSet.$role) {
+    if (!ruleSet.$role) {
       return;
     }
 

--- a/src/interfaces/protocols-configure.ts
+++ b/src/interfaces/protocols-configure.ts
@@ -166,21 +166,22 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
         );
       }
 
-      // Validate that if `who === recipient` and `of === undefined`, then `can` is either `co-delete` or `co-update`
-      // We will allow `read`, `write`, or `query` because:
+      // Validate that if `who === recipient` and `of === undefined`, then `can` can only contain `co-delete` and `co-update`
+      // We do not allow `read`, `write`, or `query` in the `can` array because:
       // - `read` - Recipients are always allowed to `read`.
       // - `write` - Entails ability to create and update.
       //             Since `of` is undefined, it implies the recipient of THIS record,
       //             there is no 'recipient' until this record has been created, so it makes no sense to allow recipient to write this record.
       // - `query` - Only authorized using roles, so allowing direct recipients to query is outside the scope.
-      if (action.who === ProtocolActor.Recipient &&
-          action.of === undefined &&
-          ![ProtocolAction.CoUpdate, ProtocolAction.CoDelete].includes(action.can as ProtocolAction)
-      ) {
-        throw new DwnError(
-          DwnErrorCode.ProtocolsConfigureInvalidRecipientOfAction,
-          'Rules for `recipient` without `of` property must have `can` === `co-delete` or `co-update`'
-        );
+      if (action.who === ProtocolActor.Recipient && action.of === undefined) {
+
+        // throw if `can` contains a value that is not co-update` or `co-delete`
+        if (action.can.some((allowedAction) => ![ProtocolAction.CoUpdate, ProtocolAction.CoDelete].includes(allowedAction as ProtocolAction))) {
+          throw new DwnError(
+            DwnErrorCode.ProtocolsConfigureInvalidRecipientOfAction,
+            'Rules for `recipient` without `of` property must have `can` containing only `co-update` or `co-delete`'
+          );
+        }
       }
 
       // Validate that if `who` is set to `author` then `of` is set

--- a/src/types/protocols-types.ts
+++ b/src/types/protocols-types.ts
@@ -53,7 +53,7 @@ export enum ProtocolAction {
  * 1. Anyone can write.
  *   {
  *     who: 'anyone',
- *     can: 'write
+ *     can: ['write']
  *   }
  *
  * 2. Author of protocolPath can write; OR
@@ -61,13 +61,13 @@ export enum ProtocolAction {
  *   {
  *     who: 'recipient'
  *     of: 'requestForQuote',
- *     can: 'write'
+ *     can: ['write']
  *   }
  *
  * 3. Role can write.
  *   {
  *     role: 'friend',
- *     can: 'write'
+ *     can: ['write']
  *   }
  */
 export type ProtocolActionRule = {
@@ -91,11 +91,11 @@ export type ProtocolActionRule = {
   of?: string;
 
   /**
-   * Action that the actor can perform.
+   * Array of actions that the actor/role can perform.
    * See {ProtocolAction} for possible values.
    * 'query' and 'subscribe' are only supported for `role` rules.
    */
-  can: string;
+  can: string[];
 };
 /**
  * Config for protocol-path encryption scheme.

--- a/tests/features/protocol-create-action.spec.ts
+++ b/tests/features/protocol-create-action.spec.ts
@@ -89,7 +89,7 @@ export function testProtocolCreateAction(): void {
             $actions: [
               {
                 role : 'admin',
-                can  : ProtocolAction.Create
+                can  : [ProtocolAction.Create]
               },
             ],
             bar: {
@@ -97,19 +97,19 @@ export function testProtocolCreateAction(): void {
                 {
                   who : 'author',
                   of  : 'foo',
-                  can : ProtocolAction.Create
+                  can : [ProtocolAction.Create]
                 },
                 {
                   who : 'recipient',
                   of  : 'foo',
-                  can : ProtocolAction.Create
+                  can : [ProtocolAction.Create]
                 }
               ],
               baz: {
                 $actions: [
                   {
                     who : 'anyone',
-                    can : ProtocolAction.Create
+                    can : [ProtocolAction.Create]
                   }
                 ],
               }

--- a/tests/features/protocol-update-action.spec.ts
+++ b/tests/features/protocol-update-action.spec.ts
@@ -88,11 +88,7 @@ export function testProtocolUpdateAction(): void {
             $actions: [
               {
                 role : 'user',
-                can  : ProtocolAction.Create
-              },
-              {
-                role : 'user',
-                can  : ProtocolAction.Update
+                can  : [ProtocolAction.Create, ProtocolAction.Update]
               }
             ]
           }
@@ -250,12 +246,7 @@ export function testProtocolUpdateAction(): void {
                 {
                   who : 'recipient',
                   of  : 'foo',
-                  can : ProtocolAction.Create
-                },
-                {
-                  who : 'recipient',
-                  of  : 'foo',
-                  can : ProtocolAction.Update
+                  can : [ProtocolAction.Create, ProtocolAction.Update]
                 }
               ],
               baz: {
@@ -263,12 +254,7 @@ export function testProtocolUpdateAction(): void {
                   {
                     who : 'author',
                     of  : 'foo/bar',
-                    can : ProtocolAction.Create
-                  },
-                  {
-                    who : 'author',
-                    of  : 'foo/bar',
-                    can : ProtocolAction.Update
+                    can : [ProtocolAction.Create, ProtocolAction.Update]
                   }
                 ]
               }
@@ -476,11 +462,7 @@ export function testProtocolUpdateAction(): void {
             $actions: [
               {
                 who : 'anyone',
-                can : ProtocolAction.Create
-              },
-              {
-                who : 'anyone',
-                can : ProtocolAction.Update
+                can : [ProtocolAction.Create, ProtocolAction.Update]
               }
             ]
           }

--- a/tests/features/protocol-update-action.spec.ts
+++ b/tests/features/protocol-update-action.spec.ts
@@ -1,6 +1,6 @@
 import type { EventStream } from '../../src/types/subscriptions.js';
-import type { ProtocolDefinition, ProtocolsConfigureDescriptor } from '../../src/types/protocols-types.js';
 import type { DataStore, EventLog, MessageStore } from '../../src/index.js';
+import type { ProtocolDefinition, ProtocolsConfigureDescriptor } from '../../src/types/protocols-types.js';
 
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
@@ -548,7 +548,7 @@ export function testProtocolUpdateAction(): void {
       expect(bobUnauthorizedFooUpdateReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationActionNotAllowed);
     });
 
-    it('should not allow creation of a protocol definition with action rule containing `update` without `create` ', async () => {
+    it('should not allow creation of a protocol definition with action rule containing `update` without `create`', async () => {
       const protocolDefinition: ProtocolDefinition = {
         protocol  : 'foo',
         published : true,

--- a/tests/handlers/protocols-configure.spec.ts
+++ b/tests/handlers/protocols-configure.spec.ts
@@ -4,7 +4,9 @@ import type { GenerateProtocolsConfigureOutput } from '../utils/test-data-genera
 import type {
   DataStore,
   EventLog,
-  MessageStore
+  MessageStore,
+  ProtocolDefinition,
+  ProtocolsConfigureDescriptor
 } from '../../src/index.js';
 
 import chaiAsPromised from 'chai-as-promised';
@@ -17,6 +19,7 @@ import minimalProtocolDefinition from '../vectors/protocol-definitions/minimal.j
 import { GeneralJwsBuilder } from '../../src/jose/jws/general/builder.js';
 import { lexicographicalCompare } from '../../src/utils/string.js';
 import { Message } from '../../src/core/message.js';
+import { ProtocolAction } from '../../src/types/protocols-types.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestEventStream } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
@@ -24,7 +27,7 @@ import { TestStubGenerator } from '../utils/test-stub-generator.js';
 import { Time } from '../../src/utils/time.js';
 
 import { DidKey, DidResolver } from '@web5/dids';
-import { Dwn, DwnErrorCode, Encoder, Jws } from '../../src/index.js';
+import { Dwn, DwnErrorCode, DwnInterfaceName, DwnMethodName, Encoder, Jws } from '../../src/index.js';
 
 chai.use(chaiAsPromised);
 
@@ -287,6 +290,147 @@ export function testProtocolsConfigureHandler(): void {
         const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message);
         expect(protocolsConfigureReply.status.code).to.equal(401);
         expect(protocolsConfigureReply.status.detail).to.contain(DwnErrorCode.AuthorizationAuthorNotOwner);
+      });
+
+      it('should reject ProtocolsConfigure with action rule containing duplicated actor (`who`) within a rule set', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://foo-bar',
+          published : true,
+          types     : {
+            foo: {},
+          },
+          structure: {
+            foo: {
+              $actions: [
+                {
+                  who : 'anyone',
+                  can : [ProtocolAction.Create]
+                },
+                // duplicated `who` value
+                {
+                  who : 'anyone',
+                  can : [ProtocolAction.Update]
+                }
+              ]
+            }
+          }
+        };
+
+        // manually craft the invalid ProtocolsConfigure message because our library will not let you create an invalid definition
+        const descriptor: ProtocolsConfigureDescriptor = {
+          interface        : DwnInterfaceName.Protocols,
+          method           : DwnMethodName.Configure,
+          messageTimestamp : Time.getCurrentTimestamp(),
+          definition       : protocolDefinition
+        };
+
+        const authorization = await Message.createAuthorization({
+          descriptor,
+          signer: Jws.createSigner(alice)
+        });
+        const protocolsConfigureMessage = { descriptor, authorization };
+
+        const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfigureMessage);
+        expect(protocolsConfigureReply.status.code).to.equal(400);
+        expect(protocolsConfigureReply.status.detail).to.contain(DwnErrorCode.ProtocolsConfigureDuplicateActorInRuleSet);
+
+
+        // similar test as above but with `of` property
+        const protocolDefinition2: ProtocolDefinition = {
+          protocol  : 'http://foo-bar',
+          published : true,
+          types     : {
+            foo : {},
+            bar : {},
+          },
+          structure: {
+            foo: {
+              bar: {
+                $actions: [
+                  {
+                    who : 'recipient',
+                    of  : 'foo',
+                    can : [ProtocolAction.Create]
+                  },
+                  // duplicated `who` value
+                  {
+                    who : 'recipient',
+                    of  : 'foo',
+                    can : [ProtocolAction.Update]
+                  }
+                ]
+              }
+            }
+          }
+        };
+
+        const descriptor2: ProtocolsConfigureDescriptor = {
+          interface        : DwnInterfaceName.Protocols,
+          method           : DwnMethodName.Configure,
+          messageTimestamp : Time.getCurrentTimestamp(),
+          definition       : protocolDefinition2
+        };
+
+        const authorization2 = await Message.createAuthorization({
+          descriptor : descriptor2,
+          signer     : Jws.createSigner(alice)
+        });
+        const protocolsConfigureMessage2 = { descriptor: descriptor2, authorization: authorization2 };
+
+        const protocolsConfigure2Reply = await dwn.processMessage(alice.did, protocolsConfigureMessage2);
+        expect(protocolsConfigure2Reply.status.code).to.equal(400);
+        expect(protocolsConfigure2Reply.status.detail).to.contain(DwnErrorCode.ProtocolsConfigureDuplicateActorInRuleSet);
+      });
+
+      it('should reject ProtocolsConfigure with action rule containing duplicated role within a rule set', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://foo',
+          published : true,
+          types     : {
+            user : {},
+            foo  : {},
+          },
+          structure: {
+            user: {
+              $role: true
+            },
+            foo: {
+              $actions: [
+                {
+                  role : 'user',
+                  can  : [ProtocolAction.Create]
+                },
+                // duplicated `role` value
+                {
+                  role : 'user',
+                  can  : [ProtocolAction.Update]
+                }
+              ]
+            }
+          }
+        };
+
+        // manually craft the invalid ProtocolsConfigure message because our library will not let you create an invalid definition
+        const descriptor: ProtocolsConfigureDescriptor = {
+          interface        : DwnInterfaceName.Protocols,
+          method           : DwnMethodName.Configure,
+          messageTimestamp : Time.getCurrentTimestamp(),
+          definition       : protocolDefinition
+        };
+
+        const authorization = await Message.createAuthorization({
+          descriptor,
+          signer: Jws.createSigner(alice)
+        });
+        const protocolsConfigureMessage = { descriptor, authorization };
+
+        const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfigureMessage);
+        expect(protocolsConfigureReply.status.code).to.equal(400);
+        expect(protocolsConfigureReply.status.detail).to.contain(DwnErrorCode.ProtocolsConfigureDuplicateRoleInRuleSet);
       });
 
       describe('event log', () => {

--- a/tests/interfaces/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols-configure.spec.ts
@@ -143,14 +143,14 @@ describe('ProtocolsConfigure', () => {
               secondLevel : {
                 $actions: [{
                   role : 'rootRole', // valid because 'rootRole` has $role: true
-                  can  : 'write'
+                  can  : ['write']
                 }]
               }
             },
             firstLevel: {
               $actions: [{
                 role : 'rootRole', // valid because 'rootRole` has $role: true
-                can  : 'write'
+                can  : ['write']
               }]
             }
           }
@@ -183,7 +183,7 @@ describe('ProtocolsConfigure', () => {
               chat: {
                 $actions: [{
                   role : 'thread/participant', // valid because 'thread/participant` has $role: true
-                  can  : 'write'
+                  can  : ['write']
                 }]
               }
             }
@@ -215,7 +215,7 @@ describe('ProtocolsConfigure', () => {
             bar: {
               $actions: [{
                 role : 'foo', // foo is not a role
-                can  : 'read'
+                can  : ['read']
               }]
             }
           }
@@ -244,7 +244,7 @@ describe('ProtocolsConfigure', () => {
               $actions: [{
                 who : 'anyone',
                 of  : 'message', // Not allowed
-                can : 'read'
+                can : ['read']
               }]
             }
           }
@@ -272,7 +272,7 @@ describe('ProtocolsConfigure', () => {
             message: {
               $actions: [{
                 who : 'recipient',
-                can : 'read' // not allowed, should be either delete or update
+                can : ['read'] // not allowed, should be either delete or update
               }]
             }
           }
@@ -301,7 +301,7 @@ describe('ProtocolsConfigure', () => {
               $actions: [{
                 who : 'author',
                 // of : 'message', // Intentionally missing
-                can : 'read'
+                can : ['read']
               }]
             }
           }
@@ -318,7 +318,7 @@ describe('ProtocolsConfigure', () => {
           .to.be.rejectedWith(DwnErrorCode.ProtocolsConfigureInvalidActionMissingOf);
       });
 
-      it('rejects protocol definitions with `can: query` in non-role rules', async () => {
+      it('rejects protocol definitions with `can query` in non-role rules', async () => {
         const definition = {
           published : true,
           protocol  : 'http://example.com',
@@ -330,7 +330,7 @@ describe('ProtocolsConfigure', () => {
               $actions: [{
                 who : 'author',
                 of  : 'message',
-                can : 'query'
+                can : ['query']
               }]
             }
           }

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -22,7 +22,7 @@ describe('ProtocolsConfigure schema definition', () => {
           $actions: [
             {
               who : 'unknown',
-              can : 'write'
+              can : ['write']
             }
           ]
         }
@@ -50,7 +50,7 @@ describe('ProtocolsConfigure schema definition', () => {
         $actions: [{
           who : 'author',
           of  : 'thread',
-          // can: 'read'  // intentionally missing
+          // can: ['read']  // intentionally missing
         }]
       };
 
@@ -58,7 +58,7 @@ describe('ProtocolsConfigure schema definition', () => {
         $actions: [{
           who : 'recipient',
           of  : 'thread',
-          // can: 'read'  // intentionally missing
+          // can: ['read']  // intentionally missing
         }]
       };
 

--- a/tests/vectors/protocol-definitions/anyone-collaborate.json
+++ b/tests/vectors/protocol-definitions/anyone-collaborate.json
@@ -9,15 +9,11 @@
       "$actions": [
         {
           "who": "anyone",
-          "can": "co-update"
-        },
-        {
-          "who": "anyone",
-          "can": "read"
-        },
-        {
-          "who": "anyone",
-          "can": "co-delete"
+          "can": [
+            "read",
+            "co-update",
+            "co-delete"
+          ]
         }
       ]
     }

--- a/tests/vectors/protocol-definitions/author-can.json
+++ b/tests/vectors/protocol-definitions/author-can.json
@@ -10,7 +10,9 @@
       "$actions": [
         {
           "who": "anyone",
-          "can": "write"
+          "can": [
+            "write"
+          ]
         }
       ],
       "comment": {
@@ -18,12 +20,10 @@
           {
             "who": "author",
             "of": "post",
-            "can": "co-update"
-          },
-          {
-            "who": "author",
-            "of": "post",
-            "can": "co-delete"
+            "can": [
+              "co-update",
+              "co-delete"
+            ]
           }
         ]
       }

--- a/tests/vectors/protocol-definitions/chat.json
+++ b/tests/vectors/protocol-definitions/chat.json
@@ -20,34 +20,46 @@
       "$actions": [
         {
           "who": "anyone",
-          "can": "write"
+          "can": [
+            "write"
+          ]
         },
         {
           "who": "author",
           "of": "thread",
-          "can": "read"
+          "can": [
+            "read"
+          ]
         },
         {
           "who": "recipient",
           "of": "thread",
-          "can": "read"
+          "can": [
+            "read"
+          ]
         }
       ],
       "message": {
         "$actions": [
           {
             "who": "anyone",
-            "can": "write"
+            "can": [
+              "write"
+            ]
           },
           {
             "who": "author",
             "of": "thread/message",
-            "can": "read"
+            "can": [
+              "read"
+            ]
           },
           {
             "who": "recipient",
             "of": "thread/message",
-            "can": "read"
+            "can": [
+              "read"
+            ]
           }
         ]
       }

--- a/tests/vectors/protocol-definitions/contribution-reward.json
+++ b/tests/vectors/protocol-definitions/contribution-reward.json
@@ -20,7 +20,9 @@
       "$actions": [
         {
           "who": "anyone",
-          "can": "write"
+          "can": [
+            "write"
+          ]
         }
       ]
     },
@@ -29,7 +31,9 @@
         {
           "who": "author",
           "of": "contribution",
-          "can": "read"
+          "can": [
+            "read"
+          ]
         }
       ]
     }

--- a/tests/vectors/protocol-definitions/credential-issuance.json
+++ b/tests/vectors/protocol-definitions/credential-issuance.json
@@ -20,7 +20,9 @@
       "$actions": [
         {
           "who": "anyone",
-          "can": "write"
+          "can": [
+            "write"
+          ]
         }
       ],
       "credentialResponse": {
@@ -28,7 +30,9 @@
           {
             "who": "recipient",
             "of": "credentialApplication",
-            "can": "write"
+            "can": [
+              "write"
+            ]
           }
         ]
       }

--- a/tests/vectors/protocol-definitions/dex.json
+++ b/tests/vectors/protocol-definitions/dex.json
@@ -26,7 +26,9 @@
       "$actions": [
         {
           "who": "anyone",
-          "can": "write"
+          "can": [
+            "write"
+          ]
         }
       ],
       "offer": {
@@ -34,7 +36,9 @@
           {
             "who": "recipient",
             "of": "ask",
-            "can": "write"
+            "can": [
+              "write"
+            ]
           }
         ],
         "fulfillment": {
@@ -42,7 +46,9 @@
             {
               "who": "recipient",
               "of": "ask/offer",
-              "can": "write"
+              "can": [
+                "write"
+              ]
             }
           ]
         }

--- a/tests/vectors/protocol-definitions/email.json
+++ b/tests/vectors/protocol-definitions/email.json
@@ -14,34 +14,46 @@
       "$actions": [
         {
           "who": "anyone",
-          "can": "write"
+          "can": [
+            "write"
+          ]
         },
         {
           "who": "author",
           "of": "email",
-          "can": "read"
+          "can": [
+            "read"
+          ]
         },
         {
           "who": "recipient",
           "of": "email",
-          "can": "read"
+          "can": [
+            "read"
+          ]
         }
       ],
       "email": {
         "$actions": [
           {
             "who": "anyone",
-            "can": "write"
+            "can": [
+              "write"
+            ]
           },
           {
             "who": "author",
             "of": "email/email",
-            "can": "read"
+            "can": [
+              "read"
+            ]
           },
           {
             "who": "recipient",
             "of": "email/email",
-            "can": "read"
+            "can": [
+              "read"
+            ]
           }
         ]
       }

--- a/tests/vectors/protocol-definitions/free-for-all.json
+++ b/tests/vectors/protocol-definitions/free-for-all.json
@@ -14,15 +14,11 @@
       "$actions": [
         {
           "who": "anyone",
-          "can": "write"
-        },
-        {
-          "who": "anyone",
-          "can": "co-delete"
-        },
-        {
-          "who": "anyone",
-          "can": "read"
+          "can": [
+            "write",
+            "read",
+            "co-delete"
+          ]
         }
       ]
     }

--- a/tests/vectors/protocol-definitions/friend-role.json
+++ b/tests/vectors/protocol-definitions/friend-role.json
@@ -21,31 +21,25 @@
       "$actions": [
         {
           "role": "fan",
-          "can": "read"
+          "can": [
+            "read"
+          ]
         },
         {
           "role": "friend",
-          "can": "write"
-        },
-        {
-          "role": "friend",
-          "can": "read"
-        },
-        {
-          "role": "friend",
-          "can": "query"
-        },
-        {
-          "role": "friend",
-          "can": "subscribe"
+          "can": [
+            "write",
+            "read",
+            "query",
+            "subscribe"
+          ]
         },
         {
           "role": "admin",
-          "can": "co-update"
-        },
-        {
-          "role": "admin",
-          "can": "co-delete"
+          "can": [
+            "co-update",
+            "co-delete"
+          ]
         }
       ]
     }

--- a/tests/vectors/protocol-definitions/message.json
+++ b/tests/vectors/protocol-definitions/message.json
@@ -14,7 +14,9 @@
       "$actions": [
         {
           "who": "anyone",
-          "can": "write"
+          "can": [
+            "write"
+          ]
         }
       ]
     }

--- a/tests/vectors/protocol-definitions/post-comment.json
+++ b/tests/vectors/protocol-definitions/post-comment.json
@@ -20,23 +20,26 @@
       "$actions": [
         {
           "who": "anyone",
-          "can": "read"
+          "can": [
+            "read"
+          ]
         }
       ],
       "comment": {
         "$actions": [
           {
             "who": "anyone",
-            "can": "read"
-          },
-          {
-            "who": "anyone",
-            "can": "write"
+            "can": [
+              "read",
+              "write"
+            ]
           },
           {
             "who": "author",
             "of": "post",
-            "can": "co-delete"
+            "can": [
+              "co-delete"
+            ]
           }
         ]
       }

--- a/tests/vectors/protocol-definitions/recipient-can.json
+++ b/tests/vectors/protocol-definitions/recipient-can.json
@@ -10,11 +10,10 @@
       "$actions": [
         {
           "who": "recipient",
-          "can": "co-update"
-        },
-        {
-          "who": "recipient",
-          "can": "co-delete"
+          "can": [
+            "co-update",
+            "co-delete"
+          ]
         }
       ],
       "tag": {
@@ -22,12 +21,10 @@
           {
             "who": "recipient",
             "of": "post",
-            "can": "co-update"
-          },
-          {
-            "who": "recipient",
-            "of": "post",
-            "can": "co-delete"
+            "can": [
+              "co-update",
+              "co-delete"
+            ]
           }
         ]
       }

--- a/tests/vectors/protocol-definitions/slack.json
+++ b/tests/vectors/protocol-definitions/slack.json
@@ -56,7 +56,9 @@
       "$actions": [
         {
           "role": "community/admin",
-          "can": "read"
+          "can": [
+            "read"
+          ]
         }
       ],
       "admin": {
@@ -65,20 +67,17 @@
           {
             "who": "author",
             "of": "community",
-            "can": "write"
-          },
-          {
-            "who": "author",
-            "of": "community",
-            "can": "co-delete"
-          },
-          {
-            "role": "community/admin",
-            "can": "write"
+            "can": [
+              "write",
+              "co-delete"
+            ]
           },
           {
             "role": "community/admin",
-            "can": "co-delete"
+            "can": [
+              "write",
+              "co-delete"
+            ]
           }
         ]
       },
@@ -87,11 +86,10 @@
         "$actions": [
           {
             "role": "community/admin",
-            "can": "write"
-          },
-          {
-            "role": "community/admin",
-            "can": "co-delete"
+            "can": [
+              "write",
+              "co-delete"
+            ]
           }
         ]
       },
@@ -99,11 +97,10 @@
         "$actions": [
           {
             "role": "community/admin",
-            "can": "write"
-          },
-          {
-            "role": "community/admin",
-            "can": "co-delete"
+            "can": [
+              "write",
+              "co-delete"
+            ]
           }
         ],
         "message": {
@@ -111,15 +108,16 @@
             {
               "who": "recipient",
               "of": "community/openChannel/message",
-              "can": "write"
+              "can": [
+                "write"
+              ]
             },
             {
               "role": "community/member",
-              "can": "write"
-            },
-            {
-              "role": "community/member",
-              "can": "co-delete"
+              "can": [
+                "write",
+                "co-delete"
+              ]
             }
           ],
           "media": {
@@ -127,7 +125,9 @@
               {
                 "who": "author",
                 "of": "community/openChannel/message",
-                "can": "write"
+                "can": [
+                  "write"
+                ]
               }
             ]
           },
@@ -135,11 +135,10 @@
             "$actions": [
               {
                 "role": "community/member",
-                "can": "write"
-              },
-              {
-                "role": "community/member",
-                "can": "co-delete"
+                "can": [
+                  "write",
+                  "co-delete"
+                ]
               }
             ]
           }
@@ -149,15 +148,16 @@
         "$actions": [
           {
             "role": "community/admin",
-            "can": "write"
-          },
-          {
-            "role": "community/admin",
-            "can": "co-delete"
+            "can": [
+              "write",
+              "co-delete"
+            ]
           },
           {
             "role": "community/gatedChannel/participant",
-            "can": "read"
+            "can": [
+              "read"
+            ]
           }
         ],
         "participant": {
@@ -166,20 +166,17 @@
             {
               "who": "author",
               "of": "community/gatedChannel",
-              "can": "write"
-            },
-            {
-              "who": "author",
-              "of": "community/gatedChannel",
-              "can": "co-delete"
-            },
-            {
-              "role": "community/gatedChannel/participant",
-              "can": "write"
+              "can": [
+                "write",
+                "co-delete"
+              ]
             },
             {
               "role": "community/gatedChannel/participant",
-              "can": "co-delete"
+              "can": [
+                "write",
+                "co-delete"
+              ]
             }
           ]
         },
@@ -188,19 +185,17 @@
             {
               "who": "recipient",
               "of": "community/gatedChannel/message",
-              "can": "write"
+              "can": [
+                "write"
+              ]
             },
             {
               "role": "community/gatedChannel/participant",
-              "can": "write"
-            },
-            {
-              "role": "community/gatedChannel/participant",
-              "can": "query"
-            },
-            {
-              "role": "community/gatedChannel/participant",
-              "can": "co-delete"
+              "can": [
+                "write",
+                "query",
+                "co-delete"
+              ]
             }
           ],
           "media": {
@@ -208,7 +203,9 @@
               {
                 "who": "author",
                 "of": "community/gatedChannel/message",
-                "can": "write"
+                "can": [
+                  "write"
+                ]
               }
             ]
           },
@@ -216,11 +213,10 @@
             "$actions": [
               {
                 "role": "community/gatedChannel/participant",
-                "can": "write"
-              },
-              {
-                "role": "community/gatedChannel/participant",
-                "can": "co-delete"
+                "can": [
+                  "write",
+                  "co-delete"
+                ]
               }
             ]
           }

--- a/tests/vectors/protocol-definitions/social-media.json
+++ b/tests/vectors/protocol-definitions/social-media.json
@@ -34,7 +34,9 @@
       "$actions": [
         {
           "who": "anyone",
-          "can": "write"
+          "can": [
+            "write"
+          ]
         }
       ],
       "reply": {
@@ -42,7 +44,9 @@
           {
             "who": "recipient",
             "of": "message",
-            "can": "write"
+            "can": [
+              "write"
+            ]
           }
         ]
       }
@@ -51,23 +55,26 @@
       "$actions": [
         {
           "who": "anyone",
-          "can": "read"
-        },
-        {
-          "who": "anyone",
-          "can": "write"
+          "can": [
+            "read",
+            "write"
+          ]
         }
       ],
       "caption": {
         "$actions": [
           {
             "who": "anyone",
-            "can": "read"
+            "can": [
+              "read"
+            ]
           },
           {
             "who": "author",
             "of": "image",
-            "can": "write"
+            "can": [
+              "write"
+            ]
           }
         ]
       },
@@ -76,12 +83,16 @@
           {
             "who": "author",
             "of": "image",
-            "can": "read"
+            "can": [
+              "read"
+            ]
           },
           {
             "who": "recipient",
             "of": "image",
-            "can": "write"
+            "can": [
+              "write"
+            ]
           }
         ]
       }

--- a/tests/vectors/protocol-definitions/thread-role.json
+++ b/tests/vectors/protocol-definitions/thread-role.json
@@ -16,7 +16,9 @@
       "$actions": [
         {
           "role": "thread/participant",
-          "can": "read"
+          "can": [
+            "read"
+          ]
         }
       ],
       "admin": {
@@ -27,11 +29,10 @@
         "$actions": [
           {
             "role": "thread/participant",
-            "can": "read"
-          },
-          {
-            "role": "thread/participant",
-            "can": "write"
+            "can": [
+              "read",
+              "write"
+            ]
           }
         ]
       },
@@ -39,31 +40,25 @@
         "$actions": [
           {
             "role": "thread/participant",
-            "can": "read"
-          },
-          {
-            "role": "thread/participant",
-            "can": "write"
-          },
-          {
-            "role": "thread/participant",
-            "can": "query"
-          },
-          {
-            "role": "thread/participant",
-            "can": "subscribe"
+            "can": [
+              "read",
+              "write",
+              "query",
+              "subscribe"
+            ]
           },
           {
             "role": "thread/admin",
-            "can": "co-update"
-          },
-          {
-            "role": "thread/admin",
-            "can": "co-delete"
+            "can": [
+              "co-update",
+              "co-delete"
+            ]
           },
           {
             "role": "globalAdmin",
-            "can": "co-delete"
+            "can": [
+              "co-delete"
+            ]
           }
         ]
       }


### PR DESCRIPTION
1. Changed protocol 'can' property to an array
2. Disallowed protocol update action without create
3. Disallowed duplicated actors or roles within a protocol rule set
4. Various renames to improve code readability