### PR TITLE
Removed `write` protocol action

### DIFF
--- a/json-schemas/interface-methods/protocol-rule-set.json
+++ b/json-schemas/interface-methods/protocol-rule-set.json
@@ -51,8 +51,7 @@
                     "create",
                     "delete",
                     "read",
-                    "update",
-                    "write"
+                    "update"
                   ]
                 }
               }
@@ -81,8 +80,7 @@
                     "query",
                     "subscribe",
                     "read",
-                    "update",
-                    "write"
+                    "update"
                   ]
                 }
               }

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -554,7 +554,7 @@ export class ProtocolAuthorization {
       const incomingRecordsWrite = incomingMessage as RecordsWrite;
 
       if (await incomingRecordsWrite.isInitialWrite()) {
-        return [ProtocolAction.Write, ProtocolAction.Create];
+        return [ProtocolAction.Create];
       } else {
         // else incoming RecordsWrite not an initial write
 
@@ -568,7 +568,7 @@ export class ProtocolAuthorization {
 
         if (incomingMessage.author === initialWrite.author) {
         // 'write', 'update' or 'co-update' action authorizes the incoming message
-          return [ProtocolAction.Write, ProtocolAction.CoUpdate, ProtocolAction.Update];
+          return [ProtocolAction.CoUpdate, ProtocolAction.Update];
         } else {
           // An update by someone who is not the record author can only be authorized by a 'co-update' rule.
           return [ProtocolAction.CoUpdate];

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -567,7 +567,7 @@ export class ProtocolAuthorization {
         }
 
         if (incomingMessage.author === initialWrite.author) {
-        // 'write', 'update' or 'co-update' action authorizes the incoming message
+        // 'update' or 'co-update' action authorizes the incoming message
           return [ProtocolAction.CoUpdate, ProtocolAction.Update];
         } else {
           // An update by someone who is not the record author can only be authorized by a 'co-update' rule.

--- a/src/types/protocols-types.ts
+++ b/src/types/protocols-types.ts
@@ -49,25 +49,25 @@ export enum ProtocolAction {
 
 /**
  * Rules defining which actors may access a record at the given protocol path.
- * Rules take three forms:
- * 1. Anyone can write.
+ * Rules take three forms, e.g.:
+ * 1. Anyone can create.
  *   {
  *     who: 'anyone',
- *     can: ['write']
+ *     can: ['create']
  *   }
  *
- * 2. Author of protocolPath can write; OR
+ * 2. Author of protocolPath can create; OR
  *    Recipient of protocolPath can write.
  *   {
  *     who: 'recipient'
  *     of: 'requestForQuote',
- *     can: ['write']
+ *     can: ['create']
  *   }
  *
- * 3. Role can write.
+ * 3. Role can create.
  *   {
  *     role: 'friend',
- *     can: ['write']
+ *     can: ['create']
  *   }
  */
 export type ProtocolActionRule = {

--- a/src/types/protocols-types.ts
+++ b/src/types/protocols-types.ts
@@ -44,8 +44,7 @@ export enum ProtocolAction {
   Query = 'query',
   Read = 'read',
   Subscribe = 'subscribe',
-  Update = 'update',
-  Write = 'write'
+  Update = 'update'
 }
 
 /**

--- a/tests/interfaces/protocols-configure.spec.ts
+++ b/tests/interfaces/protocols-configure.spec.ts
@@ -5,6 +5,7 @@ import type { ProtocolsConfigureDescriptor, ProtocolsConfigureMessage } from '..
 
 import dexProtocolDefinition from '../vectors/protocol-definitions/dex.json' assert { type: 'json' };
 import { Jws } from '../../src/utils/jws.js';
+import { ProtocolAction } from '../../src/types/protocols-types.js';
 import { ProtocolsConfigure } from '../../src/interfaces/protocols-configure.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { Time } from '../../src/utils/time.js';
@@ -143,14 +144,14 @@ describe('ProtocolsConfigure', () => {
               secondLevel : {
                 $actions: [{
                   role : 'rootRole', // valid because 'rootRole` has $role: true
-                  can  : ['write']
+                  can  : [ProtocolAction.Create]
                 }]
               }
             },
             firstLevel: {
               $actions: [{
                 role : 'rootRole', // valid because 'rootRole` has $role: true
-                can  : ['write']
+                can  : [ProtocolAction.Create]
               }]
             }
           }
@@ -183,7 +184,7 @@ describe('ProtocolsConfigure', () => {
               chat: {
                 $actions: [{
                   role : 'thread/participant', // valid because 'thread/participant` has $role: true
-                  can  : ['write']
+                  can  : [ProtocolAction.Create]
                 }]
               }
             }

--- a/tests/scenarios/delegated-grant.spec.ts
+++ b/tests/scenarios/delegated-grant.spec.ts
@@ -4,6 +4,7 @@ import type { RecordEvent, RecordsWriteMessage } from '../../src/types/records-t
 
 import chaiAsPromised from 'chai-as-promised';
 import emailProtocolDefinition from '../vectors/protocol-definitions/email.json' assert { type: 'json' };
+import messageProtocolDefinition from '../vectors/protocol-definitions/message.json' assert { type: 'json' };
 import sinon from 'sinon';
 import threadRoleProtocolDefinition from '../vectors/protocol-definitions/thread-role.json' assert { type: 'json' };
 
@@ -73,8 +74,8 @@ export function testDelegatedGrantScenarios(): void {
       const bob = await TestDataGenerator.generateDidKeyPersona();
       const carol = await TestDataGenerator.generateDidKeyPersona();
 
-      // Bob has the email protocol installed
-      const protocolDefinition = emailProtocolDefinition;
+      // Bob has the message protocol installed
+      const protocolDefinition = messageProtocolDefinition;
       const protocol = protocolDefinition.protocol;
       const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
         author: bob,
@@ -117,9 +118,9 @@ export function testDelegatedGrantScenarios(): void {
         signer         : Jws.createSigner(deviceX),
         delegatedGrant : deviceXGrant.asDelegatedGrant(),
         protocol,
-        protocolPath   : 'email', // this comes from `types` in protocol definition
-        schema         : protocolDefinition.types.email.schema,
-        dataFormat     : protocolDefinition.types.email.dataFormats[0],
+        protocolPath   : 'message', // this comes from `types` in protocol definition
+        schema         : protocolDefinition.types.message.schema,
+        dataFormat     : protocolDefinition.types.message.dataFormats[0],
         data           : deviceXData
       });
 
@@ -171,9 +172,9 @@ export function testDelegatedGrantScenarios(): void {
         signer         : Jws.createSigner(carol),
         delegatedGrant : deviceXGrant.asDelegatedGrant(),
         protocol,
-        protocolPath   : 'email', // this comes from `types` in protocol definition
-        schema         : protocolDefinition.types.email.schema,
-        dataFormat     : protocolDefinition.types.email.dataFormats[0],
+        protocolPath   : 'message', // this comes from `types` in protocol definition
+        schema         : protocolDefinition.types.message.schema,
+        dataFormat     : protocolDefinition.types.message.dataFormats[0],
         data           : messageByCarolAsAlice
       });
 

--- a/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
+++ b/tests/validation/json-schemas/protocols/protocols-configure.spec.ts
@@ -1,4 +1,4 @@
-import type { ProtocolDefinition, ProtocolsConfigureMessage } from '../../../../src/types/protocols-types.js';
+import { ProtocolAction, type ProtocolDefinition, type ProtocolsConfigureMessage } from '../../../../src/types/protocols-types.js';
 
 import { expect } from 'chai';
 import { Message } from '../../../../src/core/message.js';
@@ -22,7 +22,7 @@ describe('ProtocolsConfigure schema definition', () => {
           $actions: [
             {
               who : 'unknown',
-              can : ['write']
+              can : [ProtocolAction.Create]
             }
           ]
         }

--- a/tests/vectors/protocol-definitions/author-can.json
+++ b/tests/vectors/protocol-definitions/author-can.json
@@ -11,7 +11,8 @@
         {
           "who": "anyone",
           "can": [
-            "write"
+            "create",
+            "update"
           ]
         }
       ],

--- a/tests/vectors/protocol-definitions/chat.json
+++ b/tests/vectors/protocol-definitions/chat.json
@@ -21,7 +21,8 @@
         {
           "who": "anyone",
           "can": [
-            "write"
+            "create",
+            "update"
           ]
         },
         {
@@ -44,7 +45,8 @@
           {
             "who": "anyone",
             "can": [
-              "write"
+              "create",
+              "update"
             ]
           },
           {

--- a/tests/vectors/protocol-definitions/contribution-reward.json
+++ b/tests/vectors/protocol-definitions/contribution-reward.json
@@ -21,7 +21,8 @@
         {
           "who": "anyone",
           "can": [
-            "write"
+            "create",
+            "update"
           ]
         }
       ]

--- a/tests/vectors/protocol-definitions/credential-issuance.json
+++ b/tests/vectors/protocol-definitions/credential-issuance.json
@@ -21,7 +21,7 @@
         {
           "who": "anyone",
           "can": [
-            "write"
+            "create"
           ]
         }
       ],
@@ -31,7 +31,7 @@
             "who": "recipient",
             "of": "credentialApplication",
             "can": [
-              "write"
+              "create"
             ]
           }
         ]

--- a/tests/vectors/protocol-definitions/dex.json
+++ b/tests/vectors/protocol-definitions/dex.json
@@ -27,7 +27,7 @@
         {
           "who": "anyone",
           "can": [
-            "write"
+            "create"
           ]
         }
       ],
@@ -37,7 +37,7 @@
             "who": "recipient",
             "of": "ask",
             "can": [
-              "write"
+              "create"
             ]
           }
         ],
@@ -47,7 +47,7 @@
               "who": "recipient",
               "of": "ask/offer",
               "can": [
-                "write"
+                "create"
               ]
             }
           ]

--- a/tests/vectors/protocol-definitions/email.json
+++ b/tests/vectors/protocol-definitions/email.json
@@ -15,7 +15,7 @@
         {
           "who": "anyone",
           "can": [
-            "write"
+            "create"
           ]
         },
         {
@@ -38,7 +38,7 @@
           {
             "who": "anyone",
             "can": [
-              "write"
+              "create"
             ]
           },
           {

--- a/tests/vectors/protocol-definitions/free-for-all.json
+++ b/tests/vectors/protocol-definitions/free-for-all.json
@@ -15,7 +15,8 @@
         {
           "who": "anyone",
           "can": [
-            "write",
+            "create",
+            "update",
             "read",
             "co-delete"
           ]

--- a/tests/vectors/protocol-definitions/friend-role.json
+++ b/tests/vectors/protocol-definitions/friend-role.json
@@ -28,7 +28,8 @@
         {
           "role": "friend",
           "can": [
-            "write",
+            "create",
+            "update",
             "read",
             "query",
             "subscribe"

--- a/tests/vectors/protocol-definitions/message.json
+++ b/tests/vectors/protocol-definitions/message.json
@@ -15,7 +15,8 @@
         {
           "who": "anyone",
           "can": [
-            "write"
+            "create",
+            "update"
           ]
         }
       ]

--- a/tests/vectors/protocol-definitions/post-comment.json
+++ b/tests/vectors/protocol-definitions/post-comment.json
@@ -31,7 +31,8 @@
             "who": "anyone",
             "can": [
               "read",
-              "write"
+              "create",
+              "update"
             ]
           },
           {

--- a/tests/vectors/protocol-definitions/slack.json
+++ b/tests/vectors/protocol-definitions/slack.json
@@ -68,14 +68,14 @@
             "who": "author",
             "of": "community",
             "can": [
-              "write",
+              "create",
               "co-delete"
             ]
           },
           {
             "role": "community/admin",
             "can": [
-              "write",
+              "create",
               "co-delete"
             ]
           }
@@ -87,7 +87,7 @@
           {
             "role": "community/admin",
             "can": [
-              "write",
+              "create",
               "co-delete"
             ]
           }
@@ -98,7 +98,8 @@
           {
             "role": "community/admin",
             "can": [
-              "write",
+              "create",
+              "update",
               "co-delete"
             ]
           }
@@ -109,13 +110,15 @@
               "who": "recipient",
               "of": "community/openChannel/message",
               "can": [
-                "write"
+                "create",
+                "update"
               ]
             },
             {
               "role": "community/member",
               "can": [
-                "write",
+                "create",
+                "update",
                 "co-delete"
               ]
             }
@@ -126,7 +129,8 @@
                 "who": "author",
                 "of": "community/openChannel/message",
                 "can": [
-                  "write"
+                  "create",
+                  "update"
                 ]
               }
             ]
@@ -136,7 +140,8 @@
               {
                 "role": "community/member",
                 "can": [
-                  "write",
+                  "create",
+                  "update",
                   "co-delete"
                 ]
               }
@@ -149,7 +154,8 @@
           {
             "role": "community/admin",
             "can": [
-              "write",
+              "create",
+              "update",
               "co-delete"
             ]
           },
@@ -167,14 +173,14 @@
               "who": "author",
               "of": "community/gatedChannel",
               "can": [
-                "write",
+                "create",
                 "co-delete"
               ]
             },
             {
               "role": "community/gatedChannel/participant",
               "can": [
-                "write",
+                "create",
                 "co-delete"
               ]
             }
@@ -186,13 +192,15 @@
               "who": "recipient",
               "of": "community/gatedChannel/message",
               "can": [
-                "write"
+                "create",
+                "update"
               ]
             },
             {
               "role": "community/gatedChannel/participant",
               "can": [
-                "write",
+                "create",
+                "update",
                 "query",
                 "co-delete"
               ]
@@ -204,7 +212,8 @@
                 "who": "author",
                 "of": "community/gatedChannel/message",
                 "can": [
-                  "write"
+                  "create",
+                  "update"
                 ]
               }
             ]
@@ -214,7 +223,8 @@
               {
                 "role": "community/gatedChannel/participant",
                 "can": [
-                  "write",
+                  "create",
+                  "update",
                   "co-delete"
                 ]
               }

--- a/tests/vectors/protocol-definitions/social-media.json
+++ b/tests/vectors/protocol-definitions/social-media.json
@@ -35,7 +35,8 @@
         {
           "who": "anyone",
           "can": [
-            "write"
+            "create",
+            "update"
           ]
         }
       ],
@@ -45,7 +46,8 @@
             "who": "recipient",
             "of": "message",
             "can": [
-              "write"
+              "create",
+              "update"
             ]
           }
         ]
@@ -57,7 +59,8 @@
           "who": "anyone",
           "can": [
             "read",
-            "write"
+            "create",
+            "update"
           ]
         }
       ],
@@ -73,7 +76,8 @@
             "who": "author",
             "of": "image",
             "can": [
-              "write"
+              "create",
+              "update"
             ]
           }
         ]
@@ -91,7 +95,8 @@
             "who": "recipient",
             "of": "image",
             "can": [
-              "write"
+              "create",
+              "update"
             ]
           }
         ]

--- a/tests/vectors/protocol-definitions/thread-role.json
+++ b/tests/vectors/protocol-definitions/thread-role.json
@@ -31,7 +31,7 @@
             "role": "thread/participant",
             "can": [
               "read",
-              "write"
+              "create"
             ]
           }
         ]
@@ -41,8 +41,9 @@
           {
             "role": "thread/participant",
             "can": [
+              "create",
+              "update",
               "read",
-              "write",
               "query",
               "subscribe"
             ]


### PR DESCRIPTION
This is considered an unnecessary and potentially confusing "sugar" now that we have explicit `create` and `update` actions.