### PR TITLE
Introduced first-class Permissions protocol

### DIFF
--- a/json-schemas/permission-grant.json
+++ b/json-schemas/permission-grant.json
@@ -1,0 +1,46 @@
+{
+  "$id": "https://identity.foundation/dwn/json-schemas/permission-grant.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "messageTimestamp",
+    "dateExpires"
+  ],
+  "properties": {
+    "messageTimestamp": {
+      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+    },
+    "dateExpires": {
+      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+    },
+    "description": {
+      "type": "string"
+    },
+    "delegated": {
+      "type": "boolean"
+    },
+    "grantedTo": {
+      "description": "DID of the grantee",
+      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/definitions/grantedTo"
+    },
+    "grantedBy": {
+      "description": "DID of the grantor",
+      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/definitions/grantedBy"
+    },
+    "grantedFor": {
+      "description": "DID of the DWN to which the grantee is given access",
+      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/definitions/grantedFor"
+    },
+    "permissionsRequestId": {
+      "description": "CID of an associated PermissionsRequest message",
+      "type": "string"
+    },
+    "scope": {
+      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/definitions/scope"
+    },
+    "conditions": {
+      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/definitions/conditions"
+    }
+  }
+}

--- a/json-schemas/permission-grant.json
+++ b/json-schemas/permission-grant.json
@@ -4,13 +4,10 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "messageTimestamp",
-    "dateExpires"
+    "dateExpires",
+    "scope"
   ],
   "properties": {
-    "messageTimestamp": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
-    },
     "dateExpires": {
       "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
     },
@@ -20,20 +17,8 @@
     "delegated": {
       "type": "boolean"
     },
-    "grantedTo": {
-      "description": "DID of the grantee",
-      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/definitions/grantedTo"
-    },
-    "grantedBy": {
-      "description": "DID of the grantor",
-      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/definitions/grantedBy"
-    },
-    "grantedFor": {
-      "description": "DID of the DWN to which the grantee is given access",
-      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/definitions/grantedFor"
-    },
-    "permissionsRequestId": {
-      "description": "CID of an associated PermissionsRequest message",
+    "requestId": {
+      "description": "CID of an associated permission request DWN message",
       "type": "string"
     },
     "scope": {

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -8,6 +8,7 @@ import type { RecordsWriteMessage } from '../types/records-types.js';
 import type { ProtocolActionRule, ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureMessage, ProtocolType, ProtocolTypes } from '../types/protocols-types.js';
 
 import { FilterUtility } from '../utils/filter.js';
+import { PermissionsProtocol } from '../protocols/permissions.js';
 import { Records } from '../utils/records.js';
 import { RecordsWrite } from '../interfaces/records-write.js';
 import { DwnError, DwnErrorCode } from './dwn-error.js';
@@ -250,6 +251,11 @@ export class ProtocolAuthorization {
     protocolUri: string,
     messageStore: MessageStore
   ): Promise<ProtocolDefinition> {
+    // if first-class protocol, return the definition from const object directly without doing to data store
+    if (protocolUri === PermissionsProtocol.uri) {
+      return PermissionsProtocol.definition;
+    }
+
     // fetch the corresponding protocol definition
     const query: Filter = {
       interface : DwnInterfaceName.Protocols,

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -251,7 +251,7 @@ export class ProtocolAuthorization {
     protocolUri: string,
     messageStore: MessageStore
   ): Promise<ProtocolDefinition> {
-    // if first-class protocol, return the definition from const object directly without doing to data store
+    // if first-class protocol, return the definition from const object directly without going to data store
     if (protocolUri === PermissionsProtocol.uri) {
       return PermissionsProtocol.definition;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ export { UnionMessageReply } from './core/message-reply.js';
 export { MessageStore, MessageStoreOptions } from './types/message-store.js';
 export { PermissionsGrant, PermissionsGrantOptions } from './interfaces/permissions-grant.js';
 export { PermissionsRequest, PermissionsRequestOptions } from './interfaces/permissions-request.js';
+export { PermissionsProtocol } from './protocols/permissions.js';
 export { PermissionsRevoke, PermissionsRevokeOptions } from './interfaces/permissions-revoke.js';
 export { PrivateKeySigner } from './utils/private-key-signer.js';
 export { Protocols } from './utils/protocols.js';

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -57,12 +57,12 @@ export type RecordsWriteOptions = {
   dataFormat: string;
 
   /**
-   * Signer of the message.
+   * The signer of the message, which is commonly the author, but can also be a delegate.
    */
   signer?: Signer;
 
   /**
-   * The delegated grant to sign on behalf of the logical author, which is the grantor (`grantedBy`) of the delegated grant.
+   * The delegated grant invoked to sign on behalf of the logical author, which is the grantor of the delegated grant.
    */
   delegatedGrant?: DelegatedGrantMessage;
 
@@ -136,8 +136,9 @@ export type CreateFromOptions = {
   messageTimestamp?: string;
   datePublished?: string;
 
+
   /**
-   * Signer of the message.
+   * The signer of the message, which is commonly the author, but can also be a delegate.
    */
   signer?: Signer;
 
@@ -487,7 +488,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
   }
 
   /**
-   * Signs the RecordsWrite, commonly as author, but can also be a delegate.
+   * Signs the RecordsWrite, the signer is commonly the author, but can also be a delegate.
    */
   public async sign(options: {
     signer: Signer,

--- a/src/protocols/permissions.ts
+++ b/src/protocols/permissions.ts
@@ -156,10 +156,12 @@ export class PermissionsProtocol {
     permissionRequestModel: PermissionRequestModel,
     permissionRequestBytes: Uint8Array
   }> {
+    const scope = PermissionsProtocol.normalizePermissionScope(options.scope);
+
     const permissionRequestModel: PermissionRequestModel = {
       description : options.description,
       delegated   : options.delegated,
-      scope       : options.scope,
+      scope,
       conditions  : options.conditions,
     };
 
@@ -188,22 +190,14 @@ export class PermissionsProtocol {
     permissionGrantModel: PermissionGrantModel,
     permissionGrantBytes: Uint8Array
   }> {
-    const scope = { ...options.scope } as RecordsPermissionScope;
-
-    // normalize protocol and schema URLs if they are present
-    if (scope.protocol !== undefined) {
-      scope.protocol = normalizeProtocolUrl(scope.protocol);
-    }
-    if (scope.schema !== undefined) {
-      scope.schema = normalizeSchemaUrl(scope.schema);
-    }
+    const scope = PermissionsProtocol.normalizePermissionScope(options.scope);
 
     const permissionGrantModel: PermissionGrantModel = {
       dateExpires : options.dateExpires,
       requestId   : options.requestId,
       description : options.description,
       delegated   : options.delegated,
-      scope       : scope,
+      scope,
       conditions  : options.conditions,
     };
 
@@ -252,5 +246,32 @@ export class PermissionsProtocol {
       permissionRevocationModel,
       permissionRevocationBytes
     };
+  }
+
+  /**
+   * Normalizes the given permission scope if needed.
+   * @returns The normalized permission scope.
+   */
+  private static normalizePermissionScope(permissionScope: PermissionScope): PermissionScope {
+    const scope = { ...permissionScope };
+
+    if (PermissionsProtocol.isRecordPermissionScope(scope)) {
+      // normalize protocol and schema URLs if they are present
+      if (scope.protocol !== undefined) {
+        scope.protocol = normalizeProtocolUrl(scope.protocol);
+      }
+      if (scope.schema !== undefined) {
+        scope.schema = normalizeSchemaUrl(scope.schema);
+      }
+    }
+
+    return scope;
+  }
+
+  /**
+   * Type guard to determine if the scope is a record permission scope.
+   */
+  private static isRecordPermissionScope(scope: PermissionScope): scope is RecordsPermissionScope {
+    return scope.interface === 'Records';
   }
 };

--- a/src/protocols/permissions.ts
+++ b/src/protocols/permissions.ts
@@ -149,7 +149,7 @@ export class PermissionsProtocol {
   }
 
   /**
-   * Convenience method to creates a permission request.
+   * Convenience method to create a permission request.
    */
   public static async createRequest(options: PermissionRequestCreateOptions): Promise<{
     recordsWrite: RecordsWrite,

--- a/src/protocols/permissions.ts
+++ b/src/protocols/permissions.ts
@@ -1,0 +1,182 @@
+import type { ProtocolDefinition } from '../types/protocols-types.js';
+import type { PermissionConditions, PermissionGrantModel, PermissionRequestModel, PermissionRevocationModel, PermissionScope, RecordsPermissionScope } from '../types/permissions-grant-descriptor.js';
+
+import { Encoder } from '../utils/encoder.js';
+import { Time } from '../utils/time.js';
+import { normalizeProtocolUrl, normalizeSchemaUrl } from '../utils/url.js';
+
+/**
+ * Options for creating a permission request.
+ */
+export type PermissionRequestCreateOptions = {
+  dateRequested?: string;
+  description?: string;
+  grantedBy: string;
+  grantedTo: string;
+  delegated?: boolean;
+  scope: PermissionScope;
+  conditions?: PermissionConditions;
+};
+
+/**
+ * Options for creating a permission grant.
+ */
+export type PermissionGrantCreateOptions = {
+  description?: string;
+  dateGranted?: string;
+
+  /**
+   * Expire time in UTC ISO-8601 format with microsecond precision.
+   */
+  dateExpires: string;
+
+  grantedBy: string;
+  grantedTo: string;
+  delegated?: boolean;
+  permissionRequestId?: string;
+  scope: PermissionScope;
+  conditions?: PermissionConditions;
+};
+
+/**
+ * Options for creating a permission revocation.
+ */
+export type PermissionRevocationCreateOptions = {
+  dateRevoked?: string;
+  permissionGrantId: string;
+};
+
+/**
+ * This is a first-class DWN protocol for managing permission grants of a given DWN.
+ */
+export class PermissionsProtocol {
+  /**
+   * The URI of the DWN Permissions protocol.
+   */
+  public static readonly uri = 'https://tbd.website/dwn/permissions';
+
+  /**
+   * The protocol path of the `request` record.
+   */
+  public static readonly requestPath = 'request';
+
+  /**
+   * The protocol path of the `grant` record.
+   */
+  public static readonly grantPath = 'grant';
+
+  /**
+   * The protocol path of the `revocation` record.
+   */
+  public static readonly revocationPath = 'grant/revocation';
+
+  /**
+   * The definition of the Permissions protocol.
+   */
+  public static readonly definition: ProtocolDefinition = {
+    published : true,
+    protocol  : PermissionsProtocol.uri,
+    types     : {
+      request: {
+        dataFormats: ['application/json']
+      },
+      grant: {
+        dataFormats: ['application/json']
+      },
+      revocation: {
+        dataFormats: ['application/json']
+      }
+    },
+    structure: {
+      request: {
+        $size: {
+          max: 10000
+        },
+        $actions: [
+          {
+            who : 'anyone',
+            can : ['create']
+          }
+        ]
+      },
+      grant: {
+        $size: {
+          max: 10000
+        },
+        $actions: [
+          {
+            who : 'recipient',
+            of  : 'grant',
+            can : ['read', 'query']
+          }
+        ],
+        revocation: {
+          $size: {
+            max: 10000
+          },
+          $actions: [
+            {
+              who : 'anyone',
+              can : ['read']
+            }
+          ]
+        }
+      }
+    }
+  };
+
+  public static parseRequest(base64UrlEncodedRequest: string): PermissionRequestModel {
+    return Encoder.base64UrlToObject(base64UrlEncodedRequest);
+  }
+
+  public static createRequest(options: PermissionRequestCreateOptions): PermissionRequestModel {
+    const permissionRequestModel: PermissionRequestModel = {
+      dateRequested : options.dateRequested ?? Time.getCurrentTimestamp(),
+      description   : options.description,
+      grantedBy     : options.grantedBy,
+      grantedTo     : options.grantedTo,
+      delegated     : options.delegated ?? false,
+      scope         : options.scope,
+      conditions    : options.conditions,
+    };
+
+    return permissionRequestModel;
+  }
+
+  /**
+   * Create a permission grant.
+   */
+  public static createGrant(options: PermissionGrantCreateOptions): PermissionGrantModel {
+
+    const scope = { ...options.scope } as RecordsPermissionScope;
+    scope.protocol = scope.protocol !== undefined ? normalizeProtocolUrl(scope.protocol) : undefined;
+    scope.schema = scope.schema !== undefined ? normalizeSchemaUrl(scope.schema) : undefined;
+
+    const permissionGrantModel: PermissionGrantModel = {
+      dateGranted         : options.dateGranted ?? Time.getCurrentTimestamp(),
+      dateExpires         : options.dateExpires,
+      description         : options.description,
+      grantedBy           : options.grantedBy,
+      grantedTo           : options.grantedTo,
+      delegated           : options.delegated,
+      permissionRequestId : options.permissionRequestId,
+      scope               : scope,
+      conditions          : options.conditions,
+    };
+
+    return permissionGrantModel;
+  }
+
+  /**
+   * Create a permission revocation.
+   */
+  public static createRevocation(options: PermissionRevocationCreateOptions): PermissionRevocationModel {
+
+    const permissionRevocationModel: PermissionRevocationModel = {
+      dateRevoked       : options.dateRevoked ?? Time.getCurrentTimestamp(),
+      permissionGrantId : options.permissionGrantId,
+    };
+
+    return permissionRevocationModel;
+  }
+};

--- a/src/types/permissions-grant-descriptor.ts
+++ b/src/types/permissions-grant-descriptor.ts
@@ -48,17 +48,6 @@ export type PermissionsGrantDescriptor = {
  * The data model of a permission request.
  */
 export type PermissionRequestModel = {
-  dateRequested: string;
-
-  /**
-   * The granter, who will be either the DWN owner or an entity who the DWN owner has delegated permission to.
-   */
-  grantedBy: string;
-
-  /**
-   * The recipient of the grant. Usually this is the author of the PermissionsRequest message/
-   */
-  grantedTo: string;
 
   /**
    * If the grant is a delegated grant or not. If `true`, the `grantedTo` will be able to act as the `grantedBy` within the scope of this grant.
@@ -90,27 +79,12 @@ export type PermissionGrantModel = {
   /**
    * Optional CID of a permission request. This is optional because grants may be given without being officially requested
    * */
-  permissionRequestId?: string;
-
-  /**
-   * Timestamp at which this grant was granted.
-   */
-  dateGranted: string;
+  requestId?: string;
 
   /**
    * Timestamp at which this grant will no longer be active.
    */
   dateExpires: string;
-
-  /**
-   * The granter, who will be either the DWN owner or an entity who the DWN owner has delegated permission to.
-   */
-  grantedBy: string;
-
-  /**
-   * The recipient of the grant. Usually this is the author of the PermissionsRequest message
-   */
-  grantedTo: string;
 
   /**
    * Whether this grant is delegated or not. If `true`, the `grantedTo` will be able to act as the `grantedTo` within the scope of this grant.
@@ -130,14 +104,9 @@ export type PermissionGrantModel = {
  */
 export type PermissionRevocationModel = {
   /**
-   * CID of a permission grant.
-   * */
-  permissionGrantId: string;
-
-  /**
-   * Timestamp at which permission was revoked.
+   * Optional string that communicates the details of the revocation.
    */
-  dateRevoked: string;
+  description?: string;
 };
 
 /**

--- a/src/types/permissions-grant-descriptor.ts
+++ b/src/types/permissions-grant-descriptor.ts
@@ -44,13 +44,113 @@ export type PermissionsGrantDescriptor = {
   conditions?: PermissionConditions
 };
 
+/**
+ * The data model of a permission request.
+ */
+export type PermissionRequestModel = {
+  dateRequested: string;
 
+  /**
+   * The granter, who will be either the DWN owner or an entity who the DWN owner has delegated permission to.
+   */
+  grantedBy: string;
+
+  /**
+   * The recipient of the grant. Usually this is the author of the PermissionsRequest message/
+   */
+  grantedTo: string;
+
+  /**
+   * If the grant is a delegated grant or not. If `true`, the `grantedTo` will be able to act as the `grantedBy` within the scope of this grant.
+   */
+  delegated: boolean;
+
+  /**
+   * Optional string that communicates what the grant would be used for.
+   */
+  description?: string;
+
+  /**
+   * The scope of the allowed access.
+   */
+  scope: PermissionScope;
+
+  conditions?: PermissionConditions
+};
+
+/**
+ * The data model of a permission grant.
+ */
+export type PermissionGrantModel = {
+  /**
+   * Optional string that communicates what the grant would be used for
+   */
+  description?: string;
+
+  /**
+   * Optional CID of a permission request. This is optional because grants may be given without being officially requested
+   * */
+  permissionRequestId?: string;
+
+  /**
+   * Timestamp at which this grant was granted.
+   */
+  dateGranted: string;
+
+  /**
+   * Timestamp at which this grant will no longer be active.
+   */
+  dateExpires: string;
+
+  /**
+   * The granter, who will be either the DWN owner or an entity who the DWN owner has delegated permission to.
+   */
+  grantedBy: string;
+
+  /**
+   * The recipient of the grant. Usually this is the author of the PermissionsRequest message
+   */
+  grantedTo: string;
+
+  /**
+   * Whether this grant is delegated or not. If `true`, the `grantedTo` will be able to act as the `grantedTo` within the scope of this grant.
+   */
+  delegated?: boolean;
+
+  /**
+   * The scope of the allowed access.
+   */
+  scope: PermissionScope;
+
+  conditions?: PermissionConditions
+};
+
+/**
+ * The data model of a permission revocation.
+ */
+export type PermissionRevocationModel = {
+  /**
+   * CID of a permission grant.
+   * */
+  permissionGrantId: string;
+
+  /**
+   * Timestamp at which permission was revoked.
+   */
+  dateRevoked: string;
+};
+
+/**
+ * The data model for a permission scope.
+ */
 export type PermissionScope = {
   interface: DwnInterfaceName;
   method: DwnMethodName;
 } | RecordsPermissionScope;
 
-// Method-specific scopes
+/**
+ * The data model for a permission scope that is specific to the Records interface.
+ */
 export type RecordsPermissionScope = {
   interface: DwnInterfaceName.Records;
   method: DwnMethodName.Read | DwnMethodName.Write | DwnMethodName.Query | DwnMethodName.Subscribe | DwnMethodName.Delete;

--- a/src/types/protocols-types.ts
+++ b/src/types/protocols-types.ts
@@ -127,6 +127,7 @@ export type ProtocolRuleSet = {
     min?: number,
     max?: number
   }
+
   // JSON Schema verifies that properties other than properties prefixed with $ will actually have type ProtocolRuleSet
   [key: string]: any;
 };

--- a/tests/features/author-delegated-grant.spec.ts
+++ b/tests/features/author-delegated-grant.spec.ts
@@ -29,7 +29,7 @@ import { DwnInterfaceName, DwnMethodName, Encoder, Message, PermissionsGrant, Pe
 chai.use(chaiAsPromised);
 
 export function testAuthorDelegatedGrant(): void {
-  describe('author delegated grant tests', async () => {
+  describe('author delegated grant', async () => {
     let didResolver: DidResolver;
     let messageStore: MessageStore;
     let dataStore: DataStore;

--- a/tests/features/owner-delegated-grant.spec.ts
+++ b/tests/features/owner-delegated-grant.spec.ts
@@ -25,7 +25,7 @@ import { DwnInterfaceName, DwnMethodName, Encoder, Message, PermissionsGrant, Pe
 chai.use(chaiAsPromised);
 
 export function testOwnerDelegatedGrant(): void {
-  describe('owner delegated grant tests', async () => {
+  describe('owner delegated grant', async () => {
     let didResolver: DidResolver;
     let messageStore: MessageStore;
     let dataStore: DataStore;

--- a/tests/features/owner-signature.spec.ts
+++ b/tests/features/owner-signature.spec.ts
@@ -22,7 +22,7 @@ import { DidKey, UniversalResolver } from '@web5/dids';
 chai.use(chaiAsPromised);
 
 export function testOwnerSignature(): void {
-  describe('owner signature tests', async () => {
+  describe('owner signature', async () => {
     let didResolver: DidResolver;
     let messageStore: MessageStore;
     let dataStore: DataStore;

--- a/tests/features/permissions.spec.ts
+++ b/tests/features/permissions.spec.ts
@@ -1,0 +1,189 @@
+import type { DidResolver } from '@web5/dids';
+import type { EventStream } from '../../src/types/subscriptions.js';
+import type { PermissionScope } from '../../src/index.js';
+import type { DataStore, EventLog, MessageStore } from '../../src/index.js';
+
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+import chai, { expect } from 'chai';
+
+import { DataStream } from '../../src/utils/data-stream.js';
+import { Dwn } from '../../src/dwn.js';
+import { Jws } from '../../src/utils/jws.js';
+import { PermissionsProtocol } from '../../src/protocols/permissions.js';
+import { RecordsRead } from '../../src/interfaces/records-read.js';
+import { RecordsWrite } from '../../src/interfaces/records-write.js';
+import { TestDataGenerator } from '../utils/test-data-generator.js';
+import { TestEventStream } from '../test-event-stream.js';
+import { TestStores } from '../test-stores.js';
+import { DidKey, UniversalResolver } from '@web5/dids';
+import { DwnInterfaceName, DwnMethodName, Encoder, RecordsQuery, Time } from '../../src/index.js';
+
+chai.use(chaiAsPromised);
+
+export function testPermissions(): void {
+  describe('permission tests', async () => {
+    let didResolver: DidResolver;
+    let messageStore: MessageStore;
+    let dataStore: DataStore;
+    let eventLog: EventLog;
+    let eventStream: EventStream;
+    let dwn: Dwn;
+
+    // important to follow the `before` and `after` pattern to initialize and clean the stores in tests
+    // so that different test suites can reuse the same backend store for testing
+    before(async () => {
+      didResolver = new UniversalResolver({ didResolvers: [DidKey] });
+
+      const stores = TestStores.get();
+      messageStore = stores.messageStore;
+      dataStore = stores.dataStore;
+      eventLog = stores.eventLog;
+      eventStream = TestEventStream.get();
+
+      dwn = await Dwn.create({ didResolver, messageStore, dataStore, eventLog, eventStream });
+    });
+
+    beforeEach(async () => {
+      sinon.restore(); // wipe all previous stubs/spies/mocks/fakes
+
+      // clean up before each test rather than after so that a test does not depend on other tests to do the clean up
+      await messageStore.clear();
+      await dataStore.clear();
+      await eventLog.clear();
+    });
+
+    after(async () => {
+      await dwn.close();
+    });
+
+    it('', async () => {
+      // scenario:
+      // 1. Verify anyone (Bob) can send a permission request to Alice
+      // 2. Alice creates a permission grant for Bob in her DWN
+      // 3. Verify that Bob can read the permission grant from Alice's DWN (even though Alice can also send it directly to Bob)
+      // 4. Verify that any third-party can fetch revocation of the grant and find it is still active (not revoked)
+      // 5. Alice revokes the permission grant for Bob
+      // 6. Verify that any third-party can fetch the revocation status of the permission grant
+
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const bob = await TestDataGenerator.generateDidKeyPersona();
+
+      // 1. Verify anyone (Bob) can send a permission request to Alice
+      const permissionScope: PermissionScope = {
+        interface : DwnInterfaceName.Records,
+        method    : DwnMethodName.Write
+      };
+      const requestToAlice = PermissionsProtocol.createRequest({
+        description : `Requesting to write to Alice's DWN`,
+        grantedBy   : alice.did,
+        grantedTo   : bob.did,
+        scope       : permissionScope
+      });
+
+      const requestBytes = Encoder.objectToBytes(requestToAlice);
+      const requestWrite = await RecordsWrite.create({
+        signer       : Jws.createSigner(bob),
+        protocol     : PermissionsProtocol.uri,
+        protocolPath : PermissionsProtocol.requestPath,
+        dataFormat   : 'application/json',
+        data         : requestBytes,
+      });
+
+      const requestWriteReply = await dwn.processMessage(alice.did, requestWrite.message, { dataStream: DataStream.fromBytes(requestBytes) });
+      expect(requestWriteReply.status.code).to.equal(202);
+
+      // 2. Alice queries her DWN for new permission requests
+      const requestQuery = await RecordsQuery.create({
+        signer : Jws.createSigner(alice),
+        filter : {
+          protocolPath : PermissionsProtocol.requestPath,
+          protocol     : PermissionsProtocol.uri,
+          dateUpdated  : { from: Time.createOffsetTimestamp({ seconds: -1 * 60 * 60 * 24 }) }// last 24 hours
+        }
+      });
+
+      const requestQueryReply = await dwn.processMessage(alice.did, requestQuery.message);
+      const requestFromBob = requestQueryReply.entries?.[0]!;
+      expect(requestQueryReply.status.code).to.equal(200);
+      expect(requestQueryReply.entries?.length).to.equal(1);
+      expect(requestFromBob.recordId).to.equal(requestWrite.message.recordId);
+
+      // 2. Alice creates a permission grant for Bob in her DWN
+      const decodedRequest = PermissionsProtocol.parseRequest(requestFromBob.encodedData!);
+      const grantForBob = PermissionsProtocol.createGrant({
+        dateExpires : Time.createOffsetTimestamp({ seconds: 100 }),
+        description : 'Allow Bob to write',
+        grantedBy   : alice.did,
+        grantedTo   : bob.did,
+        scope       : decodedRequest.scope
+      });
+
+      const grantBytes = Encoder.objectToBytes(grantForBob);
+      const grantWrite = await RecordsWrite.create({
+        signer       : Jws.createSigner(alice),
+        recipient    : bob.did,
+        protocol     : PermissionsProtocol.uri,
+        protocolPath : PermissionsProtocol.grantPath,
+        dataFormat   : 'application/json',
+        data         : grantBytes,
+      });
+
+      const grantWriteReply = await dwn.processMessage(alice.did, grantWrite.message, { dataStream: DataStream.fromBytes(grantBytes) });
+      expect(grantWriteReply.status.code).to.equal(202);
+
+      // 4. Verify that any third-party can fetch revocation of the grant and find it is still active (not revoked)
+      const revocationRead = await RecordsRead.create({
+        signer : Jws.createSigner(bob),
+        filter : {
+          contextId    : grantWrite.message.contextId,
+          protocolPath : PermissionsProtocol.revocationPath
+        }
+      });
+
+      const revocationReadReply = await dwn.processMessage(alice.did, revocationRead.message);
+      expect(revocationReadReply.status.code).to.equal(404);
+
+      // Verify that non-owner cannot revoke the grant
+      const revocation = PermissionsProtocol.createRevocation({
+        permissionGrantId : grantWrite.message.recordId,
+        dateRevoked       : Time.getCurrentTimestamp()
+      });
+
+      const revokeBytes = Encoder.objectToBytes(revocation);
+      const unauthorizedRevokeWrite = await RecordsWrite.create({
+        parentContextId : grantWrite.message.contextId,
+        signer          : Jws.createSigner(bob),
+        protocol        : PermissionsProtocol.uri,
+        protocolPath    : PermissionsProtocol.revocationPath,
+        dataFormat      : 'application/json',
+        data            : revokeBytes,
+      });
+
+      const unauthorizedRevokeWriteReply = await dwn.processMessage(
+        alice.did,
+        unauthorizedRevokeWrite.message,
+        { dataStream: DataStream.fromBytes(revokeBytes) }
+      );
+      expect(unauthorizedRevokeWriteReply.status.code).to.equal(401);
+
+      // 5. Alice revokes the permission grant for Bob
+      const revokeWrite = await RecordsWrite.create({
+        parentContextId : grantWrite.message.contextId,
+        signer          : Jws.createSigner(alice),
+        protocol        : PermissionsProtocol.uri,
+        protocolPath    : PermissionsProtocol.revocationPath,
+        dataFormat      : 'application/json',
+        data            : revokeBytes,
+      });
+
+      const revokeWriteReply = await dwn.processMessage(alice.did, revokeWrite.message, { dataStream: DataStream.fromBytes(revokeBytes) });
+      expect(revokeWriteReply.status.code).to.equal(202);
+
+      // 6. Verify that any third-party can fetch the revocation status of the permission grant
+      const revocationReadReply2 = await dwn.processMessage(alice.did, revocationRead.message);
+      expect(revocationReadReply2.status.code).to.equal(200);
+      expect(revocationReadReply2.record?.recordId).to.equal(revokeWrite.message.recordId);
+    });
+  });
+}

--- a/tests/features/permissions.spec.ts
+++ b/tests/features/permissions.spec.ts
@@ -62,7 +62,7 @@ export function testPermissions(): void {
       // 2. Alice queries her DWN for new permission requests
       // 3. Verify a non-owner cannot create a grant for Bob in Alice's DWN
       // 4. Alice creates a permission grant for Bob in her DWN
-      // 5. Verify that Bob can read the permission grant from Alice's DWN (even though Alice can also send it directly to Bob)
+      // 5. Verify that Bob can query the permission grant from Alice's DWN (even though Alice can also send it directly to Bob)
       // 6. Verify that any third-party can fetch revocation of the grant and find it is still active (not revoked)
       // 7. Verify that non-owner cannot revoke the grant
       // 8. Alice revokes the permission grant for Bob
@@ -142,7 +142,7 @@ export function testPermissions(): void {
       );
       expect(grantWriteReply.status.code).to.equal(202);
 
-      // 5. Verify that Bob can read the permission grant from Alice's DWN (even though Alice can also send it directly to Bob)
+      // 5. Verify that Bob can query the permission grant from Alice's DWN (even though Alice can also send it directly to Bob)
       const grantQuery = await RecordsQuery.create({
         signer : Jws.createSigner(bob),
         filter : {

--- a/tests/test-suite.ts
+++ b/tests/test-suite.ts
@@ -13,6 +13,7 @@ import { testMessageStore } from './store/message-store.spec.js';
 import { testNestedRoleScenarios } from './scenarios/nested-roles.spec.js';
 import { testOwnerDelegatedGrant } from './features/owner-delegated-grant.spec.js';
 import { testOwnerSignature } from './features/owner-signature.spec.js';
+import { testPermissions } from './features/permissions.spec.js';
 import { testPermissionsGrantHandler } from './handlers/permissions-grant.spec.js';
 import { testPermissionsRequestHandler } from './handlers/permissions-request.spec.js';
 import { testProtocolCreateAction } from './features/protocol-create-action.spec.js';
@@ -66,6 +67,7 @@ export class TestSuite {
     testAuthorDelegatedGrant();
     testOwnerDelegatedGrant();
     testOwnerSignature();
+    testPermissions();
     testProtocolCreateAction();
     testProtocolDeleteAction();
     testProtocolUpdateAction();


### PR DESCRIPTION
This will replace the entire `Permissions` interface.

This PR only contains the support of permission life-cycle management through Request, Grant, and Revocation records.

The actual replacing/swapping out the existing logic that depends on `Permissions` messages will come in the next PR.