### PR TITLE
Signing and verifying with Secp256r1 keys

### DIFF
--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -152,6 +152,7 @@ export enum DwnErrorCode {
   SchemaValidatorSchemaNotFound = 'SchemaValidatorSchemaNotFound',
   SchemaValidationFailure = 'SchemaValidationFailure',
   Secp256k1KeyNotValid = 'Secp256k1KeyNotValid',
+  Secp256r1KeyNotValid = 'Secp256r1KeyNotValid',
   TimestampInvalid = 'TimestampInvalid',
   UrlProtocolNotNormalized = 'UrlProtocolNotNormalized',
   UrlProtocolNotNormalizable = 'UrlProtocolNotNormalizable',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,124 +1,33 @@
 // export everything that we want to be consumable
 export type { DwnConfig } from './dwn.js';
 export type { EventLog } from './types/event-log.js';
-export type {
-  EventsGetMessage,
-  EventsGetReply,
-  EventsQueryMessage,
-  EventsQueryReply,
-  EventsSubscribeDescriptor,
-  EventsSubscribeMessage,
-  EventsSubscribeReply,
-  MessageSubscriptionHandler as EventSubscriptionHandler,
-} from './types/events-types.js';
-export type {
-  EventStream,
-  MessageEvent,
-  SubscriptionReply,
-} from './types/subscriptions.js';
-export type {
-  GenericMessage,
-  GenericMessageReply,
-  MessageSort,
-  MessageSubscription,
-  Pagination,
-  QueryResultEntry,
-} from './types/message-types.js';
-export type {
-  MessagesGetMessage,
-  MessagesGetReply,
-  MessagesGetReplyEntry,
-} from './types/messages-types.js';
-export type {
-  Filter,
-  EqualFilter,
-  OneOfFilter,
-  RangeFilter,
-  RangeCriterion,
-  PaginationCursor,
-  QueryOptions,
-} from './types/query-types.js';
-export type {
-  PermissionConditions,
-  PermissionScope,
-  PermissionsGrantDescriptor,
-} from './types/permissions-grant-descriptor.js';
-export type {
-  PermissionsGrantMessage,
-  PermissionsRequestDescriptor,
-  PermissionsRequestMessage,
-  PermissionsRevokeDescriptor,
-  PermissionsRevokeMessage,
-} from './types/permissions-types.js';
-export type {
-  ProtocolsConfigureDescriptor,
-  ProtocolDefinition,
-  ProtocolTypes,
-  ProtocolRuleSet,
-  ProtocolsQueryFilter,
-  ProtocolsConfigureMessage,
-  ProtocolsQueryMessage,
-  ProtocolsQueryReply,
-} from './types/protocols-types.js';
-export type {
-  EncryptionProperty,
-  RecordsDeleteMessage,
-  RecordsQueryMessage,
-  RecordsQueryReply,
-  RecordsQueryReplyEntry,
-  RecordsReadMessage,
-  RecordsReadReply,
-  RecordsSubscribeDescriptor,
-  RecordsSubscribeMessage,
-  RecordsSubscribeReply,
-  RecordsWriteDescriptor,
-  RecordsWriteMessage,
-} from './types/records-types.js';
+export type { EventsGetMessage, EventsGetReply, EventsQueryMessage, EventsQueryReply, EventsSubscribeDescriptor, EventsSubscribeMessage, EventsSubscribeReply, MessageSubscriptionHandler as EventSubscriptionHandler } from './types/events-types.js';
+export type { EventStream, MessageEvent, SubscriptionReply } from './types/subscriptions.js';
+export type { GenericMessage, GenericMessageReply, MessageSort, MessageSubscription, Pagination, QueryResultEntry } from './types/message-types.js';
+export type { MessagesGetMessage, MessagesGetReply, MessagesGetReplyEntry } from './types/messages-types.js';
+export type { Filter, EqualFilter, OneOfFilter, RangeFilter, RangeCriterion, PaginationCursor, QueryOptions } from './types/query-types.js';
+export type { PermissionConditions, PermissionScope, PermissionsGrantDescriptor } from './types/permissions-grant-descriptor.js';
+export type { PermissionsGrantMessage, PermissionsRequestDescriptor, PermissionsRequestMessage, PermissionsRevokeDescriptor, PermissionsRevokeMessage } from './types/permissions-types.js';
+export type { ProtocolsConfigureDescriptor, ProtocolDefinition, ProtocolTypes, ProtocolRuleSet, ProtocolsQueryFilter, ProtocolsConfigureMessage, ProtocolsQueryMessage, ProtocolsQueryReply } from './types/protocols-types.js';
+export type { EncryptionProperty, RecordsDeleteMessage, RecordsQueryMessage, RecordsQueryReply, RecordsQueryReplyEntry, RecordsReadMessage, RecordsReadReply, RecordsSubscribeDescriptor, RecordsSubscribeMessage, RecordsSubscribeReply, RecordsWriteDescriptor, RecordsWriteMessage } from './types/records-types.js';
 export { authenticate } from './core/auth.js';
-export {
-  ActiveTenantCheckResult,
-  AllowAllTenantGate,
-  TenantGate,
-} from './core/tenant-gate.js';
+export { ActiveTenantCheckResult, AllowAllTenantGate, TenantGate } from './core/tenant-gate.js';
 export { Cid } from './utils/cid.js';
-export {
-  RecordsQuery,
-  RecordsQueryOptions,
-} from './interfaces/records-query.js';
-export {
-  DataStore,
-  DataStorePutResult,
-  DataStoreGetResult,
-} from './types/data-store.js';
+export { RecordsQuery, RecordsQueryOptions } from './interfaces/records-query.js';
+export { DataStore, DataStorePutResult, DataStoreGetResult } from './types/data-store.js';
 export { DataStream } from './utils/data-stream.js';
 export { DateSort } from './types/records-types.js';
-export {
-  DerivedPrivateJwk,
-  HdKey,
-  KeyDerivationScheme,
-} from './utils/hd-key.js';
+export { DerivedPrivateJwk, HdKey, KeyDerivationScheme } from './utils/hd-key.js';
 export { Dwn } from './dwn.js';
 export { DwnConstant } from './core/dwn-constant.js';
 export { DwnError, DwnErrorCode } from './core/dwn-error.js';
-export {
-  DwnInterfaceName,
-  DwnMethodName,
-} from './enums/dwn-interface-method.js';
+export { DwnInterfaceName, DwnMethodName } from './enums/dwn-interface-method.js';
 export { Encoder } from './utils/encoder.js';
 export { EventsGet, EventsGetOptions } from './interfaces/events-get.js';
 export { EventsQuery, EventsQueryOptions } from './interfaces/events-query.js';
-export {
-  EventsSubscribe,
-  EventsSubscribeOptions,
-} from './interfaces/events-subscribe.js';
+export { EventsSubscribe, EventsSubscribeOptions } from './interfaces/events-subscribe.js';
 export { Encryption, EncryptionAlgorithm } from './utils/encryption.js';
-export {
-  EncryptionInput,
-  KeyEncryptionInput,
-  RecordsWrite,
-  RecordsWriteOptions,
-  CreateFromOptions,
-} from './interfaces/records-write.js';
+export { EncryptionInput, KeyEncryptionInput, RecordsWrite, RecordsWriteOptions, CreateFromOptions } from './interfaces/records-write.js';
 export { executeUnlessAborted } from './utils/abort.js';
 export { Jws } from './utils/jws.js';
 export { KeyMaterial, PrivateJwk, PublicJwk } from './types/jose-types.js';
@@ -126,39 +35,18 @@ export { Message } from './core/message.js';
 export { MessagesGet, MessagesGetOptions } from './interfaces/messages-get.js';
 export { UnionMessageReply } from './core/message-reply.js';
 export { MessageStore, MessageStoreOptions } from './types/message-store.js';
-export {
-  PermissionsGrant,
-  PermissionsGrantOptions,
-} from './interfaces/permissions-grant.js';
-export {
-  PermissionsRequest,
-  PermissionsRequestOptions,
-} from './interfaces/permissions-request.js';
+export { PermissionsGrant, PermissionsGrantOptions } from './interfaces/permissions-grant.js';
+export { PermissionsRequest, PermissionsRequestOptions } from './interfaces/permissions-request.js';
 export { PermissionsProtocol } from './protocols/permissions.js';
-export {
-  PermissionsRevoke,
-  PermissionsRevokeOptions,
-} from './interfaces/permissions-revoke.js';
+export { PermissionsRevoke, PermissionsRevokeOptions } from './interfaces/permissions-revoke.js';
 export { PrivateKeySigner } from './utils/private-key-signer.js';
 export { Protocols } from './utils/protocols.js';
-export {
-  ProtocolsConfigure,
-  ProtocolsConfigureOptions,
-} from './interfaces/protocols-configure.js';
-export {
-  ProtocolsQuery,
-  ProtocolsQueryOptions,
-} from './interfaces/protocols-query.js';
+export { ProtocolsConfigure, ProtocolsConfigureOptions } from './interfaces/protocols-configure.js';
+export { ProtocolsQuery, ProtocolsQueryOptions } from './interfaces/protocols-query.js';
 export { Records } from './utils/records.js';
-export {
-  RecordsDelete,
-  RecordsDeleteOptions,
-} from './interfaces/records-delete.js';
+export { RecordsDelete, RecordsDeleteOptions } from './interfaces/records-delete.js';
 export { RecordsRead, RecordsReadOptions } from './interfaces/records-read.js';
-export {
-  RecordsSubscribe,
-  RecordsSubscribeOptions,
-} from './interfaces/records-subscribe.js';
+export { RecordsSubscribe, RecordsSubscribeOptions } from './interfaces/records-subscribe.js';
 export { Secp256k1 } from './utils/secp256k1.js';
 export { Secp256r1 } from './utils/secp256r1.js';
 export { Signer } from './types/signer.js';
@@ -172,7 +60,4 @@ export { MessageStoreLevel } from './store/message-store-level.js';
 export { EventEmitterStream } from './event-log/event-emitter-stream.js';
 
 // test library exports
-export {
-  Persona,
-  TestDataGenerator,
-} from '../tests/utils/test-data-generator.js';
+export { Persona, TestDataGenerator } from '../tests/utils/test-data-generator.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,33 +1,124 @@
 // export everything that we want to be consumable
 export type { DwnConfig } from './dwn.js';
 export type { EventLog } from './types/event-log.js';
-export type { EventsGetMessage, EventsGetReply, EventsQueryMessage, EventsQueryReply, EventsSubscribeDescriptor, EventsSubscribeMessage, EventsSubscribeReply, MessageSubscriptionHandler as EventSubscriptionHandler } from './types/events-types.js';
-export type { EventStream, MessageEvent, SubscriptionReply } from './types/subscriptions.js';
-export type { GenericMessage, GenericMessageReply, MessageSort, MessageSubscription, Pagination, QueryResultEntry } from './types/message-types.js';
-export type { MessagesGetMessage, MessagesGetReply, MessagesGetReplyEntry } from './types/messages-types.js';
-export type { Filter, EqualFilter, OneOfFilter, RangeFilter, RangeCriterion, PaginationCursor, QueryOptions } from './types/query-types.js';
-export type { PermissionConditions, PermissionScope, PermissionsGrantDescriptor } from './types/permissions-grant-descriptor.js';
-export type { PermissionsGrantMessage, PermissionsRequestDescriptor, PermissionsRequestMessage, PermissionsRevokeDescriptor, PermissionsRevokeMessage } from './types/permissions-types.js';
-export type { ProtocolsConfigureDescriptor, ProtocolDefinition, ProtocolTypes, ProtocolRuleSet, ProtocolsQueryFilter, ProtocolsConfigureMessage, ProtocolsQueryMessage, ProtocolsQueryReply } from './types/protocols-types.js';
-export type { EncryptionProperty, RecordsDeleteMessage, RecordsQueryMessage, RecordsQueryReply, RecordsQueryReplyEntry, RecordsReadMessage, RecordsReadReply, RecordsSubscribeDescriptor, RecordsSubscribeMessage, RecordsSubscribeReply, RecordsWriteDescriptor, RecordsWriteMessage } from './types/records-types.js';
+export type {
+  EventsGetMessage,
+  EventsGetReply,
+  EventsQueryMessage,
+  EventsQueryReply,
+  EventsSubscribeDescriptor,
+  EventsSubscribeMessage,
+  EventsSubscribeReply,
+  MessageSubscriptionHandler as EventSubscriptionHandler,
+} from './types/events-types.js';
+export type {
+  EventStream,
+  MessageEvent,
+  SubscriptionReply,
+} from './types/subscriptions.js';
+export type {
+  GenericMessage,
+  GenericMessageReply,
+  MessageSort,
+  MessageSubscription,
+  Pagination,
+  QueryResultEntry,
+} from './types/message-types.js';
+export type {
+  MessagesGetMessage,
+  MessagesGetReply,
+  MessagesGetReplyEntry,
+} from './types/messages-types.js';
+export type {
+  Filter,
+  EqualFilter,
+  OneOfFilter,
+  RangeFilter,
+  RangeCriterion,
+  PaginationCursor,
+  QueryOptions,
+} from './types/query-types.js';
+export type {
+  PermissionConditions,
+  PermissionScope,
+  PermissionsGrantDescriptor,
+} from './types/permissions-grant-descriptor.js';
+export type {
+  PermissionsGrantMessage,
+  PermissionsRequestDescriptor,
+  PermissionsRequestMessage,
+  PermissionsRevokeDescriptor,
+  PermissionsRevokeMessage,
+} from './types/permissions-types.js';
+export type {
+  ProtocolsConfigureDescriptor,
+  ProtocolDefinition,
+  ProtocolTypes,
+  ProtocolRuleSet,
+  ProtocolsQueryFilter,
+  ProtocolsConfigureMessage,
+  ProtocolsQueryMessage,
+  ProtocolsQueryReply,
+} from './types/protocols-types.js';
+export type {
+  EncryptionProperty,
+  RecordsDeleteMessage,
+  RecordsQueryMessage,
+  RecordsQueryReply,
+  RecordsQueryReplyEntry,
+  RecordsReadMessage,
+  RecordsReadReply,
+  RecordsSubscribeDescriptor,
+  RecordsSubscribeMessage,
+  RecordsSubscribeReply,
+  RecordsWriteDescriptor,
+  RecordsWriteMessage,
+} from './types/records-types.js';
 export { authenticate } from './core/auth.js';
-export { ActiveTenantCheckResult, AllowAllTenantGate, TenantGate } from './core/tenant-gate.js';
+export {
+  ActiveTenantCheckResult,
+  AllowAllTenantGate,
+  TenantGate,
+} from './core/tenant-gate.js';
 export { Cid } from './utils/cid.js';
-export { RecordsQuery, RecordsQueryOptions } from './interfaces/records-query.js';
-export { DataStore, DataStorePutResult, DataStoreGetResult } from './types/data-store.js';
+export {
+  RecordsQuery,
+  RecordsQueryOptions,
+} from './interfaces/records-query.js';
+export {
+  DataStore,
+  DataStorePutResult,
+  DataStoreGetResult,
+} from './types/data-store.js';
 export { DataStream } from './utils/data-stream.js';
 export { DateSort } from './types/records-types.js';
-export { DerivedPrivateJwk, HdKey, KeyDerivationScheme } from './utils/hd-key.js';
+export {
+  DerivedPrivateJwk,
+  HdKey,
+  KeyDerivationScheme,
+} from './utils/hd-key.js';
 export { Dwn } from './dwn.js';
 export { DwnConstant } from './core/dwn-constant.js';
 export { DwnError, DwnErrorCode } from './core/dwn-error.js';
-export { DwnInterfaceName, DwnMethodName } from './enums/dwn-interface-method.js';
+export {
+  DwnInterfaceName,
+  DwnMethodName,
+} from './enums/dwn-interface-method.js';
 export { Encoder } from './utils/encoder.js';
 export { EventsGet, EventsGetOptions } from './interfaces/events-get.js';
 export { EventsQuery, EventsQueryOptions } from './interfaces/events-query.js';
-export { EventsSubscribe, EventsSubscribeOptions } from './interfaces/events-subscribe.js';
+export {
+  EventsSubscribe,
+  EventsSubscribeOptions,
+} from './interfaces/events-subscribe.js';
 export { Encryption, EncryptionAlgorithm } from './utils/encryption.js';
-export { EncryptionInput, KeyEncryptionInput, RecordsWrite, RecordsWriteOptions, CreateFromOptions } from './interfaces/records-write.js';
+export {
+  EncryptionInput,
+  KeyEncryptionInput,
+  RecordsWrite,
+  RecordsWriteOptions,
+  CreateFromOptions,
+} from './interfaces/records-write.js';
 export { executeUnlessAborted } from './utils/abort.js';
 export { Jws } from './utils/jws.js';
 export { KeyMaterial, PrivateJwk, PublicJwk } from './types/jose-types.js';
@@ -35,19 +126,41 @@ export { Message } from './core/message.js';
 export { MessagesGet, MessagesGetOptions } from './interfaces/messages-get.js';
 export { UnionMessageReply } from './core/message-reply.js';
 export { MessageStore, MessageStoreOptions } from './types/message-store.js';
-export { PermissionsGrant, PermissionsGrantOptions } from './interfaces/permissions-grant.js';
-export { PermissionsRequest, PermissionsRequestOptions } from './interfaces/permissions-request.js';
+export {
+  PermissionsGrant,
+  PermissionsGrantOptions,
+} from './interfaces/permissions-grant.js';
+export {
+  PermissionsRequest,
+  PermissionsRequestOptions,
+} from './interfaces/permissions-request.js';
 export { PermissionsProtocol } from './protocols/permissions.js';
-export { PermissionsRevoke, PermissionsRevokeOptions } from './interfaces/permissions-revoke.js';
+export {
+  PermissionsRevoke,
+  PermissionsRevokeOptions,
+} from './interfaces/permissions-revoke.js';
 export { PrivateKeySigner } from './utils/private-key-signer.js';
 export { Protocols } from './utils/protocols.js';
-export { ProtocolsConfigure, ProtocolsConfigureOptions } from './interfaces/protocols-configure.js';
-export { ProtocolsQuery, ProtocolsQueryOptions } from './interfaces/protocols-query.js';
+export {
+  ProtocolsConfigure,
+  ProtocolsConfigureOptions,
+} from './interfaces/protocols-configure.js';
+export {
+  ProtocolsQuery,
+  ProtocolsQueryOptions,
+} from './interfaces/protocols-query.js';
 export { Records } from './utils/records.js';
-export { RecordsDelete, RecordsDeleteOptions } from './interfaces/records-delete.js';
+export {
+  RecordsDelete,
+  RecordsDeleteOptions,
+} from './interfaces/records-delete.js';
 export { RecordsRead, RecordsReadOptions } from './interfaces/records-read.js';
-export { RecordsSubscribe, RecordsSubscribeOptions } from './interfaces/records-subscribe.js';
+export {
+  RecordsSubscribe,
+  RecordsSubscribeOptions,
+} from './interfaces/records-subscribe.js';
 export { Secp256k1 } from './utils/secp256k1.js';
+export { Secp256r1 } from './utils/secp256r1.js';
 export { Signer } from './types/signer.js';
 export { SortDirection } from './types/query-types.js';
 export { Time } from './utils/time.js';
@@ -59,4 +172,7 @@ export { MessageStoreLevel } from './store/message-store-level.js';
 export { EventEmitterStream } from './event-log/event-emitter-stream.js';
 
 // test library exports
-export { Persona, TestDataGenerator } from '../tests/utils/test-data-generator.js';
+export {
+  Persona,
+  TestDataGenerator,
+} from '../tests/utils/test-data-generator.js';

--- a/src/jose/algorithms/signing/signature-algorithms.ts
+++ b/src/jose/algorithms/signing/signature-algorithms.ts
@@ -2,6 +2,7 @@ import type { SignatureAlgorithm } from '../../../types/jose-types.js';
 
 import { ed25519 } from './ed25519.js';
 import { Secp256k1 } from '../../../utils/secp256k1.js';
+import { Secp256r1 } from '../../../utils/secp256r1.js';
 
 // the key should be the appropriate `crv` value
 export const signatureAlgorithms: Record<string, SignatureAlgorithm> = {
@@ -11,5 +12,11 @@ export const signatureAlgorithms: Record<string, SignatureAlgorithm> = {
     verify          : Secp256k1.verify,
     generateKeyPair : Secp256k1.generateKeyPair,
     publicKeyToJwk  : Secp256k1.publicKeyToJwk
+  },
+  'P-256': {
+    sign            : Secp256r1.sign,
+    verify          : Secp256r1.verify,
+    generateKeyPair : Secp256r1.generateKeyPair,
+    publicKeyToJwk  : Secp256r1.publicKeyToJwk,
   },
 };

--- a/src/types/jose-types.ts
+++ b/src/types/jose-types.ts
@@ -19,7 +19,7 @@ export type PublicJwk = Jwk & {
   /** The "crv" (curve) parameter identifies the cryptographic curve used with the key.
    * MUST be present for all EC public keys
    */
-  crv: 'Ed25519' | 'secp256k1';
+  crv: 'Ed25519' | 'secp256k1' | 'P-256';
   /**
    * the x coordinate for the Elliptic Curve point.
    * Represented as the base64url encoding of the octet string representation of the coordinate.

--- a/src/utils/secp256r1.ts
+++ b/src/utils/secp256r1.ts
@@ -1,0 +1,150 @@
+import type { PrivateJwk, PublicJwk } from '../types/jose-types.js';
+
+import { p256, secp256r1 } from '@noble/curves/p256';
+
+import { Encoder } from './encoder.js';
+import { sha256 } from 'multiformats/hashes/sha2';
+import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
+import { fromString, toString } from 'uint8arrays';
+
+const u8a = { toString, fromString };
+
+/**
+ * Class containing SECP256R1 related utility methods.
+ */
+export class Secp256r1 {
+  /**
+   * Validates the given JWK is a SECP256R1 key.
+   * @throws {Error} if fails validation.
+   */
+  public static validateKey(jwk: PrivateJwk | PublicJwk): void {
+    if (jwk.kty !== 'EC' || jwk.crv !== 'P-256') {
+      throw new DwnError(
+        DwnErrorCode.Secp256r1KeyNotValid,
+        'Invalid SECP256R1 JWK: `kty` MUST be `EC`. `crv` MUST be `P-256`'
+      );
+    }
+  }
+
+  /**
+   * Converts a public key in bytes into a JWK.
+   */
+  public static async publicKeyToJwk(
+    publicKeyBytes: Uint8Array
+  ): Promise<PublicJwk> {
+    // ensure public key is in uncompressed format so we can convert it into both x and y value
+    let uncompressedPublicKeyBytes;
+    if (publicKeyBytes.byteLength === 33) {
+      // this means given key is compressed
+      const curvePoints = p256.ProjectivePoint.fromHex(publicKeyBytes);
+      uncompressedPublicKeyBytes = curvePoints.toRawBytes(false); // isCompressed = false
+    } else {
+      uncompressedPublicKeyBytes = publicKeyBytes;
+    }
+
+    // the first byte is a header that indicates whether the key is uncompressed (0x04 if uncompressed), we can safely ignore
+    // bytes 1 - 32 represent X
+    // bytes 33 - 64 represent Y
+
+    // skip the first byte because it's used as a header to indicate whether the key is uncompressed
+    const x = Encoder.bytesToBase64Url(
+      uncompressedPublicKeyBytes.subarray(1, 33)
+    );
+    const y = Encoder.bytesToBase64Url(
+      uncompressedPublicKeyBytes.subarray(33, 65)
+    );
+
+    const publicJwk: PublicJwk = {
+      alg : 'ES256',
+      kty : 'EC',
+      crv : 'P-256',
+      x,
+      y,
+    };
+
+    return publicJwk;
+  }
+
+  /**
+   * Creates a private key in raw bytes from the given SECP256R1 JWK.
+   */
+  public static privateJwkToBytes(privateJwk: PrivateJwk): Uint8Array {
+    const privateKey = Encoder.base64UrlToBytes(privateJwk.d);
+    return privateKey;
+  }
+
+  /**
+   * Signs the provided content using the provided JWK.
+   * Signature that is outputted is JWS format, not DER.
+   */
+  public static async sign(
+    content: Uint8Array,
+    privateJwk: PrivateJwk
+  ): Promise<Uint8Array> {
+    Secp256r1.validateKey(privateJwk);
+
+    const hashedContent = await sha256.encode(content);
+    const privateKeyBytes = Secp256r1.privateJwkToBytes(privateJwk);
+
+    return Promise.resolve(
+      p256.sign(hashedContent, privateKeyBytes).toCompactRawBytes()
+    );
+  }
+
+  /**
+   * Verifies a signature against the provided payload hash and public key.
+   * @param signature - the signature to verify. Can be in either DER or compact format. If using Oracle Cloud KMS, keys will be DER formatted.
+   * @returns a boolean indicating whether the signature is valid.
+   */
+  public static async verify(
+    content: Uint8Array,
+    signature: Uint8Array,
+    publicJwk: PublicJwk
+  ): Promise<boolean> {
+    Secp256r1.validateKey(publicJwk);
+
+    // handle DER vs compact signature formats
+    let sig;
+    if (signature.length === 64) {
+      sig = p256.Signature.fromCompact(signature);
+    } else {
+      sig = p256.Signature.fromDER(signature);
+    }
+    const hashedContent = await sha256.encode(content);
+    const keyBytes = p256.ProjectivePoint.fromAffine({
+      x : Secp256r1.bytesToBigInt(Secp256r1.base64ToBytes(publicJwk.x)),
+      y : Secp256r1.bytesToBigInt(Secp256r1.base64ToBytes(publicJwk.y!)),
+    }).toRawBytes(false);
+
+    return p256.verify(sig, hashedContent, keyBytes);
+  }
+
+  /**
+   * Generates a random key pair in JWK format.
+   */
+  public static async generateKeyPair(): Promise<{
+    publicJwk: PublicJwk;
+    privateJwk: PrivateJwk;
+  }> {
+    const privateKeyBytes = p256.utils.randomPrivateKey();
+    const publicKeyBytes = secp256r1.getPublicKey(privateKeyBytes, false); // `false` = uncompressed
+
+    const d = Encoder.bytesToBase64Url(privateKeyBytes);
+    const publicJwk: PublicJwk = await Secp256r1.publicKeyToJwk(publicKeyBytes);
+    const privateJwk: PrivateJwk = { ...publicJwk, d };
+
+    return { publicJwk, privateJwk };
+  }
+
+  public static base64ToBytes(s: string): Uint8Array {
+    const inputBase64Url = s
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=/g, '');
+    return u8a.fromString(inputBase64Url, 'base64url');
+  }
+
+  public static bytesToBigInt(b: Uint8Array): bigint {
+    return BigInt(`0x` + u8a.toString(b, 'base16'));
+  }
+}

--- a/src/utils/secp256r1.ts
+++ b/src/utils/secp256r1.ts
@@ -112,8 +112,8 @@ export class Secp256r1 {
     }
     const hashedContent = await sha256.encode(content);
     const keyBytes = p256.ProjectivePoint.fromAffine({
-      x : Secp256r1.bytesToBigInt(Secp256r1.base64ToBytes(publicJwk.x)),
-      y : Secp256r1.bytesToBigInt(Secp256r1.base64ToBytes(publicJwk.y!)),
+      x : Secp256r1.bytesToBigInt(Encoder.base64UrlToBytes(publicJwk.x)),
+      y : Secp256r1.bytesToBigInt(Encoder.base64UrlToBytes(publicJwk.y!)),
     }).toRawBytes(false);
 
     return p256.verify(sig, hashedContent, keyBytes);
@@ -134,14 +134,6 @@ export class Secp256r1 {
     const privateJwk: PrivateJwk = { ...publicJwk, d };
 
     return { publicJwk, privateJwk };
-  }
-
-  public static base64ToBytes(s: string): Uint8Array {
-    const inputBase64Url = s
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_')
-      .replace(/=/g, '');
-    return u8a.fromString(inputBase64Url, 'base64url');
   }
 
   public static bytesToBigInt(b: Uint8Array): bigint {

--- a/tests/utils/secp256r1.spec.ts
+++ b/tests/utils/secp256r1.spec.ts
@@ -1,0 +1,73 @@
+import { base64url } from 'multiformats/bases/base64';
+import { DwnErrorCode } from '../../src/core/dwn-error.js';
+import { expect } from 'chai';
+import { p256 } from '@noble/curves/p256';
+import { Secp256r1 } from '../../src/utils/secp256r1.js';
+import { TestDataGenerator } from './test-data-generator.js';
+
+describe('Secp256r1', () => {
+  describe('validateKey()', () => {
+    it('should throw if key is not a valid SECP256R1 key', async () => {
+      const validKey = (await Secp256r1.generateKeyPair()).publicJwk;
+
+      expect(() =>
+        Secp256r1.validateKey({ ...validKey, kty: 'invalidKty' as any })
+      ).to.throw(DwnErrorCode.Secp256r1KeyNotValid);
+      expect(() =>
+        Secp256r1.validateKey({ ...validKey, crv: 'invalidCrv' as any })
+      ).to.throw(DwnErrorCode.Secp256r1KeyNotValid);
+    });
+  });
+
+  describe('publicKeyToJwk()', () => {
+    it('should generate the same JWK regardless of compressed or uncompressed public key bytes given', async () => {
+      const compressedPublicKeyBase64UrlString =
+        'Aom0shYia6t0cNMRQDRzPgCxdMWQamrfX3UJfOroLHo_';
+      const uncompressedPublicKeyBase64UrlString =
+        'BIm0shYia6t0cNMRQDRzPgCxdMWQamrfX3UJfOroLHo_cSITyng0NN1lt2BtZVXH4PE9Gerxq_mw2_CpbBHsWUI';
+
+      const compressedPublicKey = base64url.baseDecode(
+        compressedPublicKeyBase64UrlString
+      );
+
+      const uncompressedPublicKey = base64url.baseDecode(
+        uncompressedPublicKeyBase64UrlString
+      );
+
+      const publicJwk1 = await Secp256r1.publicKeyToJwk(compressedPublicKey);
+      const publicJwk2 = await Secp256r1.publicKeyToJwk(uncompressedPublicKey);
+
+      expect(publicJwk1.x).to.equal(publicJwk2.x);
+      expect(publicJwk1.y).to.equal(publicJwk2.y);
+    });
+  });
+
+  describe('verify()', () => {
+    it('should correctly handle DER formatted signatures', async () => {
+      const { privateJwk, publicJwk } = await Secp256r1.generateKeyPair();
+
+      const content = TestDataGenerator.randomBytes(16);
+
+      const signature = await Secp256r1.sign(content, privateJwk);
+
+      // Convert the signature to DER format
+      const derSignature =
+        p256.Signature.fromCompact(signature).toDERRawBytes();
+
+      const result = await Secp256r1.verify(content, derSignature, publicJwk);
+
+      expect(result).to.equal(true);
+    });
+  });
+
+  describe('sign()', () => {
+    it('should generate the signature in compact format', async () => {
+      const { privateJwk } = await Secp256r1.generateKeyPair();
+
+      const contentBytes = TestDataGenerator.randomBytes(16);
+      const signatureBytes = await Secp256r1.sign(contentBytes, privateJwk);
+
+      expect(signatureBytes.length).to.equal(64); // DER format would be 70 bytes
+    });
+  });
+});


### PR DESCRIPTION
Added support for signing and verifying keys with Secp256r1 curve. Oracle KMS utilizes these keys and we needed the verification piece for our implementation, so thought we would share with the TBD team how we went about it and extend to cover the signing piece as well.

Uses @noble/curves/p256 package in approach similar to utils/secp256k1.ts. I have included tests with 100% code coverage of the secp256r1.ts file and also tested locally with the generated key pairs for end-to-end signing and verifying in the context of our implementation. Open to any suggestions for improving the implementation/excited to hear your thoughts!