### PR TITLE
Permissions protocol final touch up

### DIFF
--- a/json-schemas/definitions.json
+++ b/json-schemas/definitions.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://identity.foundation/dwn/json-schemas/defs.json",
   "type": "object",
-  "definitions": {
+  "$defs": {
     "base64url": {
       "type": "string",
       "pattern": "^[A-Za-z0-9_-]+$"

--- a/json-schemas/general-jws.json
+++ b/json-schemas/general-jws.json
@@ -5,7 +5,7 @@
   "additionalProperties": false,
   "properties": {
     "payload": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/base64url"
+      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/base64url"
     },
     "signatures": {
       "type": "array",
@@ -14,10 +14,10 @@
         "type": "object",
         "properties": {
           "protected": {
-            "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/base64url"
+            "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/base64url"
           },
           "signature": {
-            "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/base64url"
+            "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/base64url"
           }
         }
       }

--- a/json-schemas/interface-methods/events-filter.json
+++ b/json-schemas/interface-methods/events-filter.json
@@ -30,7 +30,7 @@
       "type": "string"
     },
     "recipient": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/did"
+      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/did"
     },
     "contextId": {
       "type": "string"
@@ -56,10 +56,10 @@
       "additionalProperties": false,
       "properties": {
         "from": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "to": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         }
       }
     },
@@ -69,10 +69,10 @@
       "additionalProperties": false,
       "properties": {
         "from": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "to": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         }
       }
     },
@@ -82,10 +82,10 @@
       "additionalProperties": false,
       "properties": {
         "from": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "to": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         }
       }
     }

--- a/json-schemas/interface-methods/events-query.json
+++ b/json-schemas/interface-methods/events-query.json
@@ -34,7 +34,7 @@
           "type": "string"
         },
         "messageTimestamp": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "filters": {
           "type": "array",

--- a/json-schemas/interface-methods/messages-get.json
+++ b/json-schemas/interface-methods/messages-get.json
@@ -33,7 +33,7 @@
           "type": "string"
         },
         "messageTimestamp": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "messageCids": {
           "type": "array",

--- a/json-schemas/interface-methods/protocols-configure.json
+++ b/json-schemas/interface-methods/protocols-configure.json
@@ -34,7 +34,7 @@
           "type": "string"
         },
         "messageTimestamp": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "definition": {
           "$ref": "https://identity.foundation/dwn/json-schemas/protocol-definition.json"

--- a/json-schemas/interface-methods/protocols-query.json
+++ b/json-schemas/interface-methods/protocols-query.json
@@ -32,7 +32,7 @@
           "type": "string"
         },
         "messageTimestamp": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "filter": {
           "type": "object",
@@ -43,7 +43,7 @@
               "type": "string"
             },
             "recipient": {
-              "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/did"
+              "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/did"
             }
           }
         }

--- a/json-schemas/interface-methods/records-delete.json
+++ b/json-schemas/interface-methods/records-delete.json
@@ -34,7 +34,7 @@
           "type": "string"
         },
         "messageTimestamp": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "recordId": {
           "type": "string"

--- a/json-schemas/interface-methods/records-filter.json
+++ b/json-schemas/interface-methods/records-filter.json
@@ -12,13 +12,13 @@
       "type": "string"
     },
     "author": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/did"
+      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/did"
     },
     "attester": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/did"
+      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/did"
     },
     "recipient": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/did"
+      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/did"
     },
     "contextId": {
       "type": "string"
@@ -82,10 +82,10 @@
       "additionalProperties": false,
       "properties": {
         "from": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "to": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         }
       }
     },
@@ -95,10 +95,10 @@
       "additionalProperties": false,
       "properties": {
         "from": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "to": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         }
       }
     },
@@ -108,10 +108,10 @@
       "additionalProperties": false,
       "properties": {
         "from": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "to": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         }
       }
     }

--- a/json-schemas/interface-methods/records-query.json
+++ b/json-schemas/interface-methods/records-query.json
@@ -33,7 +33,7 @@
           "type": "string"
         },
         "messageTimestamp": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "filter": {
           "$ref": "https://identity.foundation/dwn/json-schemas/records-filter.json"

--- a/json-schemas/interface-methods/records-read.json
+++ b/json-schemas/interface-methods/records-read.json
@@ -33,7 +33,7 @@
           "type": "string"
         },
         "messageTimestamp": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "filter": {
           "$ref": "https://identity.foundation/dwn/json-schemas/records-filter.json"

--- a/json-schemas/interface-methods/records-subscribe.json
+++ b/json-schemas/interface-methods/records-subscribe.json
@@ -33,7 +33,7 @@
           "type": "string"
         },
         "messageTimestamp": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "filter": {
           "$ref": "https://identity.foundation/dwn/json-schemas/records-filter.json"

--- a/json-schemas/interface-methods/records-write-unidentified.json
+++ b/json-schemas/interface-methods/records-write-unidentified.json
@@ -29,7 +29,7 @@
           ]
         },
         "initializationVector": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/base64url"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/base64url"
         },
         "keyEncryption": {
           "type": "array",
@@ -59,16 +59,16 @@
                 ]
               },
               "encryptedKey": {
-                "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/base64url"
+                "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/base64url"
               },
               "initializationVector": {
-                "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/base64url"
+                "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/base64url"
               },
               "ephemeralPublicKey": {
                 "$ref": "https://identity.foundation/dwn/json-schemas/public-jwk.json"
               },
               "messageAuthenticationCode": {
-                "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/base64url"
+                "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/base64url"
               }
             },
             "additionalProperties": false,
@@ -107,7 +107,7 @@
           "type": "string"
         },
         "recipient": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/did"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/did"
         },
         "protocol": {
           "type": "string"
@@ -163,16 +163,16 @@
           "type": "number"
         },
         "dateCreated": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "messageTimestamp": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "published": {
           "type": "boolean"
         },
         "datePublished": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "dataFormat": {
           "type": "string"

--- a/json-schemas/jwk-verification-method.json
+++ b/json-schemas/jwk-verification-method.json
@@ -20,7 +20,7 @@
       ]
     },
     "controller": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/did"
+      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/did"
     },
     "publicKeyJwk": {
       "$ref": "https://identity.foundation/dwn/json-schemas/public-jwk.json"

--- a/json-schemas/permissions/permission-grant-data.json
+++ b/json-schemas/permissions/permission-grant-data.json
@@ -12,7 +12,7 @@
       "type": "string"
     },
     "dateExpires": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/date-time"
+      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
     },
     "requestId": {
       "type": "string"
@@ -21,10 +21,10 @@
       "type": "boolean"
     },
     "scope": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/definitions/scope"
+      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/$defs/scope"
     },
     "conditions": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/definitions/conditions"
+      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/$defs/conditions"
     }
   }
 }

--- a/json-schemas/permissions/permission-request-data.json
+++ b/json-schemas/permissions/permission-request-data.json
@@ -15,10 +15,10 @@
       "type": "boolean"
     },
     "scope": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/definitions/scope"
+      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/$defs/scope"
     },
     "conditions": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/definitions/conditions"
+      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/$defs/conditions"
     }
   }
 }

--- a/json-schemas/permissions/permissions-definitions.json
+++ b/json-schemas/permissions/permissions-definitions.json
@@ -2,35 +2,26 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://identity.foundation/dwn/json-schemas/permissions/defs.json",
   "type": "object",
-  "definitions": {
-    "grantedTo": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/did"
-    },
-    "grantedBy": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/did"
-    },
-    "grantedFor": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/definitions/did"
-    },
+  "$defs": {
     "scope": {
       "oneOf": [
         {
-          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/definitions/protocols-query-scope"
+          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/$defs/protocols-query-scope"
         },
         {
-          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/definitions/records-read-scope"
+          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/$defs/records-read-scope"
         },
         {
-          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/definitions/records-delete-scope"
+          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/$defs/records-delete-scope"
         },
         {
-          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/definitions/records-write-scope"
+          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/$defs/records-write-scope"
         },
         {
-          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/definitions/records-query-scope"
+          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/$defs/records-query-scope"
         },
         {
-          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/definitions/records-subscribe-scope"
+          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/$defs/records-subscribe-scope"
         }
       ]
     },

--- a/json-schemas/permissions/scopes.json
+++ b/json-schemas/permissions/scopes.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json",
   "type": "object",
-  "definitions": {
+  "$defs": {
     "protocols-query-scope": {
       "type": "object",
       "properties": {

--- a/json-schemas/signature-payloads/generic-signature-payload.json
+++ b/json-schemas/signature-payloads/generic-signature-payload.json
@@ -13,7 +13,7 @@
     "delegatedGrantId": {
       "type": "string"
     },
-    "permissionsGrantId": {
+    "permissionGrantId": {
       "type": "string"
     },
     "protocolRole": {

--- a/json-schemas/signature-payloads/records-write-signature-payload.json
+++ b/json-schemas/signature-payloads/records-write-signature-payload.json
@@ -26,7 +26,7 @@
     "delegatedGrantId": {
       "type": "string"
     },
-    "permissionsGrantId": {
+    "permissionGrantId": {
       "type": "string"
     },
     "protocolRole": {

--- a/src/core/grant-authorization.ts
+++ b/src/core/grant-authorization.ts
@@ -93,7 +93,7 @@ export class GrantAuthorization {
       // grant is not yet active
       throw new DwnError(
         DwnErrorCode.GrantAuthorizationGrantNotYetActive,
-        `The message has a timestamp before the associated PermissionsGrant becomes active`,
+        `The message has a timestamp before the associated permission grant becomes active`,
       );
     }
 
@@ -124,7 +124,7 @@ export class GrantAuthorization {
 
   /**
    * Verify that the `interface` and `method` grant scopes match the incoming message
-   * @param permissionsGrantId Purely being passed for logging purposes.
+   * @param permissionGrantId Purely being passed for logging purposes.
    * @throws {DwnError} if the `interface` and `method` of the incoming message do not match the scope of the PermissionsGrant
    */
   private static async verifyGrantScopeInterfaceAndMethod(

--- a/src/core/grant-authorization.ts
+++ b/src/core/grant-authorization.ts
@@ -9,7 +9,7 @@ export class GrantAuthorization {
 
   /**
    * Performs base permissions-grant-based authorization against the given message:
-   * 1. Validates the `expectedGrantor` and `expectedGrantee` values against the actual values in given permissions grant.
+   * 1. Validates the `expectedGrantor` and `expectedGrantee` values against the actual values in given permission grant.
    * 2. Verifies that the incoming message is within the allowed time frame of the grant, and the grant has not been revoked.
    * 3. Verifies that the `interface` and `method` grant scopes match the incoming message.
    *
@@ -50,7 +50,7 @@ export class GrantAuthorization {
 
   /**
    * Verifies the given `expectedGrantor` and `expectedGrantee` values against
-   * the actual signer and recipient in given permissions grant.
+   * the actual signer and recipient in given permission grant.
    * @throws {DwnError} if `expectedGrantor` or `expectedGrantee` do not match the actual values in the grant.
    */
   private static verifyExpectedGrantorAndGrantee(
@@ -63,7 +63,7 @@ export class GrantAuthorization {
     if (expectedGrantee !== actualGrantee) {
       throw new DwnError(
         DwnErrorCode.GrantAuthorizationNotGrantedToAuthor,
-        `Permissions grant is granted to ${actualGrantee}, but need to be granted to ${expectedGrantee}`
+        `Permission grant is granted to ${actualGrantee}, but need to be granted to ${expectedGrantee}`
       );
     }
 
@@ -71,7 +71,7 @@ export class GrantAuthorization {
     if (expectedGrantor !== actualGrantor) {
       throw new DwnError(
         DwnErrorCode.GrantAuthorizationNotGrantedForTenant,
-        `Permissions grant is granted by ${actualGrantor}, but need to be granted by ${expectedGrantor}`
+        `Permission grant is granted by ${actualGrantor}, but need to be granted by ${expectedGrantor}`
       );
     }
   }
@@ -117,7 +117,7 @@ export class GrantAuthorization {
     if (oldestExistingRevoke !== undefined && oldestExistingRevoke.descriptor.messageTimestamp <= incomingMessageTimestamp) {
       throw new DwnError(
         DwnErrorCode.GrantAuthorizationGrantRevoked,
-        `Permissions grant with CID ${permissionGrant.id} has been revoked`,
+        `Permission grant with CID ${permissionGrant.id} has been revoked`,
       );
     }
   }

--- a/src/core/grant-authorization.ts
+++ b/src/core/grant-authorization.ts
@@ -8,7 +8,7 @@ import { DwnError, DwnErrorCode } from './dwn-error.js';
 export class GrantAuthorization {
 
   /**
-   * Performs base PermissionsGrant-based authorization against the given message:
+   * Performs base permissions-grant-based authorization against the given message:
    * 1. Validates the `expectedGrantor` and `expectedGrantee` values against the actual values in given permissions grant.
    * 2. Verifies that the incoming message is within the allowed time frame of the grant, and the grant has not been revoked.
    * 3. Verifies that the `interface` and `method` grant scopes match the incoming message.
@@ -101,7 +101,7 @@ export class GrantAuthorization {
       // grant has expired
       throw new DwnError(
         DwnErrorCode.GrantAuthorizationGrantExpired,
-        `The message has timestamp after the expiry of the associated PermissionsGrant`,
+        `The message has timestamp after the expiry of the associated permission grant`,
       );
     }
 
@@ -117,7 +117,7 @@ export class GrantAuthorization {
     if (oldestExistingRevoke !== undefined && oldestExistingRevoke.descriptor.messageTimestamp <= incomingMessageTimestamp) {
       throw new DwnError(
         DwnErrorCode.GrantAuthorizationGrantRevoked,
-        `PermissionsGrant with CID ${permissionGrant.id} has been revoked`,
+        `Permissions grant with CID ${permissionGrant.id} has been revoked`,
       );
     }
   }
@@ -125,7 +125,7 @@ export class GrantAuthorization {
   /**
    * Verify that the `interface` and `method` grant scopes match the incoming message
    * @param permissionGrantId Purely being passed for logging purposes.
-   * @throws {DwnError} if the `interface` and `method` of the incoming message do not match the scope of the PermissionsGrant
+   * @throws {DwnError} if the `interface` and `method` of the incoming message do not match the scope of the permission grant.
    */
   private static async verifyGrantScopeInterfaceAndMethod(
     dwnInterface: string,

--- a/src/core/message.ts
+++ b/src/core/message.ts
@@ -80,17 +80,17 @@ export class Message {
     descriptor: Descriptor,
     signer: Signer,
     delegatedGrant?: RecordsWriteMessage,
-    permissionsGrantId?: string,
+    permissionGrantId?: string,
     protocolRole?: string
   }): Promise<AuthorizationModel> {
-    const { descriptor, signer, delegatedGrant, permissionsGrantId, protocolRole } = input;
+    const { descriptor, signer, delegatedGrant, permissionGrantId, protocolRole } = input;
 
     let delegatedGrantId;
     if (delegatedGrant !== undefined) {
       delegatedGrantId = await Message.getCid(delegatedGrant);
     }
 
-    const signature = await Message.createSignature(descriptor, signer, { delegatedGrantId, permissionsGrantId, protocolRole });
+    const signature = await Message.createSignature(descriptor, signer, { delegatedGrantId, permissionGrantId, protocolRole });
 
     const authorization: AuthorizationModel = {
       signature
@@ -110,7 +110,7 @@ export class Message {
   public static async createSignature(
     descriptor: Descriptor,
     signer: Signer,
-    additionalPayloadProperties?: { delegatedGrantId?: string, permissionsGrantId?: string, protocolRole?: string }
+    additionalPayloadProperties?: { delegatedGrantId?: string, permissionGrantId?: string, protocolRole?: string }
   ): Promise<GeneralJws> {
     const descriptorCid = await Cid.computeCid(descriptor);
 

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -603,7 +603,7 @@ export class ProtocolAuthorization {
     const author = incomingMessage.author;
     const actionRules = ruleSet.$actions;
 
-    // We have already checked that the message is not from tenant, owner, or permissionsGrant
+    // We have already checked that the message is not from tenant, owner, or permission grant authorized
     if (actionRules === undefined) {
       throw new DwnError(
         DwnErrorCode.ProtocolAuthorizationActionRulesNotFound,

--- a/src/core/records-grant-authorization.ts
+++ b/src/core/records-grant-authorization.ts
@@ -65,7 +65,7 @@ export class RecordsGrantAuthorization {
   }
 
   /**
-   * Authorizes the scope of a PermissionsGrant for RecordsQuery or RecordsSubscribe.
+   * Authorizes the scope of a permission grant for RecordsQuery or RecordsSubscribe.
    * @param messageStore Used to check if the grant has been revoked.
    */
   public static async authorizeQueryOrSubscribe(input: {
@@ -101,7 +101,7 @@ export class RecordsGrantAuthorization {
   }
 
   /**
-   * Authorizes the scope of a PermissionsGrant for RecordsDelete.
+   * Authorizes the scope of a permission grant for RecordsDelete.
    * @param messageStore Used to check if the grant has been revoked.
    */
   public static async authorizeDelete(input: {
@@ -208,7 +208,7 @@ export class RecordsGrantAuthorization {
       if (grantScope.schema !== recordsWriteMessage.descriptor.schema) {
         throw new DwnError(
           DwnErrorCode.RecordsGrantAuthorizationScopeSchema,
-          `Record does not have schema in PermissionsGrant scope with schema '${grantScope.schema}'`
+          `Record does not have schema in permission grant scope with schema '${grantScope.schema}'`
         );
       }
     }

--- a/src/core/records-grant-authorization.ts
+++ b/src/core/records-grant-authorization.ts
@@ -37,7 +37,7 @@ export class RecordsGrantAuthorization {
   }
 
   /**
-   * Authorizes a RecordsReadMessage using the given PermissionsGrant.
+   * Authorizes a RecordsReadMessage using the given permission grant.
    * @param messageStore Used to check if the given grant has been revoked.
    */
   public static async authorizeRead(input: {
@@ -224,7 +224,7 @@ export class RecordsGrantAuthorization {
     if (conditions?.publication === PermissionConditionPublication.Required && !recordsWriteMessage.descriptor.published) {
       throw new DwnError(
         DwnErrorCode.RecordsGrantAuthorizationConditionPublicationRequired,
-        'PermissionsGrant requires message to be published'
+        'Permission grant requires message to be published'
       );
     }
 
@@ -232,7 +232,7 @@ export class RecordsGrantAuthorization {
     if (conditions?.publication === PermissionConditionPublication.Prohibited && recordsWriteMessage.descriptor.published) {
       throw new DwnError(
         DwnErrorCode.RecordsGrantAuthorizationConditionPublicationProhibited,
-        'PermissionsGrant prohibits message from being published'
+        'Permission grant prohibits message from being published'
       );
     }
   }

--- a/src/handlers/records-read.ts
+++ b/src/handlers/records-read.ts
@@ -132,8 +132,8 @@ export class RecordsReadHandler implements MethodHandler {
     } else if (recordsRead.author !== undefined && recordsRead.author === descriptor.recipient) {
       // The recipient of a message may always read it
       return;
-    } else if (recordsRead.author !== undefined && recordsRead.signaturePayload!.permissionsGrantId !== undefined) {
-      const permissionGrant = await PermissionsProtocol.fetchGrant(tenant, messageStore, recordsRead.signaturePayload!.permissionsGrantId);
+    } else if (recordsRead.author !== undefined && recordsRead.signaturePayload!.permissionGrantId !== undefined) {
+      const permissionGrant = await PermissionsProtocol.fetchGrant(tenant, messageStore, recordsRead.signaturePayload!.permissionGrantId);
       await RecordsGrantAuthorization.authorizeRead({
         recordsReadMessage          : recordsRead.message,
         recordsWriteMessageToBeRead : matchedRecordsWrite.message,

--- a/src/handlers/records-write.ts
+++ b/src/handlers/records-write.ts
@@ -185,14 +185,14 @@ export class RecordsWriteHandler implements MethodHandler {
     // TODO: https://github.com/TBD54566975/dwn-sdk-js/issues/716
     // This code is a direct copy and paste from the original PermissionsRevokeHandler (no longer exists),
     // but it appears that there was no test for it and it does not look like the code worked:
-    // - not seeing `permissionsGrantId` being an index
+    // - not seeing `permissionGrantId` being an index
     // - not seeing `this.dataStore` being called to delete actual data
     // - test coverage is missing for the main delete logic
     if (recordsWrite.message.descriptor.protocol === PermissionsProtocol.uri &&
       recordsWrite.message.descriptor.protocolPath === PermissionsProtocol.revocationPath) {
-      const permissionsGrantId = recordsWrite.message.descriptor.parentId!;
+      const permissionGrantId = recordsWrite.message.descriptor.parentId!;
       const grantAuthorizedMessagesQuery = {
-        permissionsGrantId,
+        permissionGrantId,
         dateCreated: { gte: recordsWrite.message.descriptor.messageTimestamp },
       };
       const { messages: grantAuthorizedMessagesAfterRevoke } = await this.messageStore.query(tenant, [ grantAuthorizedMessagesQuery ]);
@@ -348,8 +348,8 @@ export class RecordsWriteHandler implements MethodHandler {
     } else if (recordsWrite.author === tenant) {
       // if author is the same as the target tenant, we can directly grant access
       return;
-    } else if (recordsWrite.author !== undefined && recordsWrite.signaturePayload!.permissionsGrantId !== undefined) {
-      const permissionGrant = await PermissionsProtocol.fetchGrant(tenant, messageStore, recordsWrite.signaturePayload!.permissionsGrantId);
+    } else if (recordsWrite.author !== undefined && recordsWrite.signaturePayload!.permissionGrantId !== undefined) {
+      const permissionGrant = await PermissionsProtocol.fetchGrant(tenant, messageStore, recordsWrite.signaturePayload!.permissionGrantId);
       await RecordsGrantAuthorization.authorizeWrite({
         recordsWriteMessage : recordsWrite.message,
         expectedGrantor     : tenant,

--- a/src/interfaces/protocols-configure.ts
+++ b/src/interfaces/protocols-configure.ts
@@ -13,7 +13,7 @@ export type ProtocolsConfigureOptions = {
   messageTimestamp?: string;
   definition: ProtocolDefinition;
   signer: Signer;
-  permissionsGrantId?: string;
+  permissionGrantId?: string;
 };
 
 export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessage> {
@@ -36,8 +36,8 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
 
     const authorization = await Message.createAuthorization({
       descriptor,
-      signer             : options.signer,
-      permissionsGrantId : options.permissionsGrantId
+      signer            : options.signer,
+      permissionGrantId : options.permissionGrantId
     });
     const message = { descriptor, authorization };
 

--- a/src/interfaces/protocols-query.ts
+++ b/src/interfaces/protocols-query.ts
@@ -18,7 +18,7 @@ export type ProtocolsQueryOptions = {
   messageTimestamp?: string;
   filter?: ProtocolsQueryFilter,
   signer?: Signer;
-  permissionsGrantId?: string;
+  permissionGrantId?: string;
 };
 
 export class ProtocolsQuery extends AbstractMessage<ProtocolsQueryMessage> {
@@ -54,8 +54,8 @@ export class ProtocolsQuery extends AbstractMessage<ProtocolsQueryMessage> {
     if (options.signer !== undefined) {
       authorization = await Message.createAuthorization({
         descriptor,
-        signer             : options.signer,
-        permissionsGrantId : options.permissionsGrantId
+        signer            : options.signer,
+        permissionGrantId : options.permissionGrantId
       });
     }
 
@@ -78,8 +78,8 @@ export class ProtocolsQuery extends AbstractMessage<ProtocolsQueryMessage> {
     // if author is the same as the target tenant, we can directly grant access
     if (this.author === tenant) {
       return;
-    } else if (this.author !== undefined && this.signaturePayload!.permissionsGrantId) {
-      const permissionGrant = await PermissionsProtocol.fetchGrant(tenant, messageStore, this.signaturePayload!.permissionsGrantId);
+    } else if (this.author !== undefined && this.signaturePayload!.permissionGrantId) {
+      const permissionGrant = await PermissionsProtocol.fetchGrant(tenant, messageStore, this.signaturePayload!.permissionGrantId);
       await GrantAuthorization.performBaseValidation({
         incomingMessage : this.message,
         expectedGrantor : tenant,

--- a/src/interfaces/records-read.ts
+++ b/src/interfaces/records-read.ts
@@ -15,7 +15,7 @@ export type RecordsReadOptions = {
   filter: RecordsFilter;
   messageTimestamp?: string;
   signer?: Signer;
-  permissionsGrantId?: string;
+  permissionGrantId?: string;
   /**
    * Used when authorizing protocol records.
    * The protocol path to the role record type whose recipient is the author of this RecordsRead
@@ -52,7 +52,7 @@ export class RecordsRead extends AbstractMessage<RecordsReadMessage> {
    * @throws {DwnError} when a combination of required RecordsReadOptions are missing
    */
   public static async create(options: RecordsReadOptions): Promise<RecordsRead> {
-    const { filter, signer, permissionsGrantId, protocolRole } = options;
+    const { filter, signer, permissionGrantId, protocolRole } = options;
     const currentTime = Time.getCurrentTimestamp();
 
     const descriptor: RecordsReadDescriptor = {
@@ -70,7 +70,7 @@ export class RecordsRead extends AbstractMessage<RecordsReadMessage> {
       authorization = await Message.createAuthorization({
         descriptor,
         signer,
-        permissionsGrantId,
+        permissionGrantId,
         protocolRole,
         delegatedGrant: options.delegatedGrant
       });

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -390,10 +390,10 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
 
     if (options.signer !== undefined) {
       await recordsWrite.sign({
-        signer             : options.signer,
-        delegatedGrant     : options.delegatedGrant,
+        signer            : options.signer,
+        delegatedGrant    : options.delegatedGrant,
         permissionGrantId : options.permissionGrantId,
-        protocolRole       : options.protocolRole
+        protocolRole      : options.protocolRole
       });
     }
 

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -70,7 +70,7 @@ export type RecordsWriteOptions = {
 
   attestationSigners?: Signer[];
   encryptionInput?: EncryptionInput;
-  permissionsGrantId?: string;
+  permissionGrantId?: string;
 };
 
 /**
@@ -392,7 +392,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
       await recordsWrite.sign({
         signer             : options.signer,
         delegatedGrant     : options.delegatedGrant,
-        permissionsGrantId : options.permissionsGrantId,
+        permissionGrantId : options.permissionGrantId,
         protocolRole       : options.protocolRole
       });
     }
@@ -498,10 +498,10 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
   public async sign(options: {
     signer: Signer,
     delegatedGrant?: RecordsWriteMessage,
-    permissionsGrantId?: string,
+    permissionGrantId?: string,
     protocolRole?: string
   }): Promise<void> {
-    const { signer, delegatedGrant, permissionsGrantId, protocolRole } = options;
+    const { signer, delegatedGrant, permissionGrantId, protocolRole } = options;
 
     // compute delegated grant ID and author if delegated grant is given
     let delegatedGrantId;
@@ -540,7 +540,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
       encryption  : this._message.encryption,
       signer,
       delegatedGrantId,
-      permissionsGrantId,
+      permissionGrantId,
       protocolRole
     });
 
@@ -948,10 +948,10 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
     encryption: EncryptionProperty | undefined,
     signer: Signer,
     delegatedGrantId?: string,
-    permissionsGrantId?: string,
+    permissionGrantId?: string,
     protocolRole?: string
   }): Promise<GeneralJws> {
-    const { recordId, contextId, descriptorCid, attestation, encryption, signer, delegatedGrantId, permissionsGrantId, protocolRole } = input;
+    const { recordId, contextId, descriptorCid, attestation, encryption, signer, delegatedGrantId, permissionGrantId, protocolRole } = input;
 
     const attestationCid = attestation ? await Cid.computeCid(attestation) : undefined;
     const encryptionCid = encryption ? await Cid.computeCid(encryption) : undefined;
@@ -963,7 +963,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
       attestationCid,
       encryptionCid,
       delegatedGrantId,
-      permissionsGrantId,
+      permissionGrantId,
       protocolRole
     };
     removeUndefinedProperties(signaturePayload);

--- a/src/protocols/permission-grant.ts
+++ b/src/protocols/permission-grant.ts
@@ -1,6 +1,6 @@
 import type { RecordsQueryReplyEntry, RecordsWriteMessage } from '../types/records-types.js';
 
-import type { PermissionConditions, PermissionGrantModel, PermissionScope } from '../types/permission-types.js';
+import type { PermissionConditions, PermissionGrantData, PermissionScope } from '../types/permission-types.js';
 
 import { Encoder } from '../utils/encoder.js';
 import { Message } from '../core/message.js';
@@ -78,7 +78,7 @@ export class PermissionGrant {
 
     // properties from the data payload itself.
     const permissionGrantEncoded = (message as RecordsQueryReplyEntry).encodedData!;
-    const permissionGrant = Encoder.base64UrlToObject(permissionGrantEncoded) as PermissionGrantModel;
+    const permissionGrant = Encoder.base64UrlToObject(permissionGrantEncoded) as PermissionGrantData;
     this.dateExpires = permissionGrant.dateExpires;
     this.delegated = permissionGrant.delegated;
     this.description = permissionGrant.description;

--- a/src/protocols/permission-grant.ts
+++ b/src/protocols/permission-grant.ts
@@ -77,14 +77,14 @@ export class PermissionGrant {
     this.dateGranted = message.descriptor.dateCreated;
 
     // properties from the data payload itself.
-    const permissionsGrantEncoded = (message as RecordsQueryReplyEntry).encodedData!;
-    const permissionsGrant = Encoder.base64UrlToObject(permissionsGrantEncoded) as PermissionGrantModel;
-    this.dateExpires = permissionsGrant.dateExpires;
-    this.delegated = permissionsGrant.delegated;
-    this.description = permissionsGrant.description;
-    this.requestId = permissionsGrant.requestId;
-    this.scope = permissionsGrant.scope;
-    this.conditions = permissionsGrant.conditions;
+    const permissionGrantEncoded = (message as RecordsQueryReplyEntry).encodedData!;
+    const permissionGrant = Encoder.base64UrlToObject(permissionGrantEncoded) as PermissionGrantModel;
+    this.dateExpires = permissionGrant.dateExpires;
+    this.delegated = permissionGrant.delegated;
+    this.description = permissionGrant.description;
+    this.requestId = permissionGrant.requestId;
+    this.scope = permissionGrant.scope;
+    this.conditions = permissionGrant.conditions;
   }
 }
 

--- a/src/protocols/permissions.ts
+++ b/src/protocols/permissions.ts
@@ -300,11 +300,11 @@ export class PermissionsProtocol {
   public static async fetchGrant(
     tenant: string,
     messageStore: MessageStore,
-    permissionsGrantId: string,
+    permissionGrantId: string,
   ): Promise<PermissionGrant> {
 
     const grantQuery = {
-      recordId          : permissionsGrantId,
+      recordId          : permissionGrantId,
       isLatestBaseState : true
     };
     const { messages } = await messageStore.query(tenant, [grantQuery]);
@@ -318,7 +318,7 @@ export class PermissionsProtocol {
         (possibleGrantMessage as RecordsWriteMessage).descriptor.protocolPath !== PermissionsProtocol.grantPath) {
       throw new DwnError(
         DwnErrorCode.GrantAuthorizationGrantMissing,
-        `Could not find permission grant with record ID ${permissionsGrantId}.`
+        `Could not find permission grant with record ID ${permissionGrantId}.`
       );
     }
 

--- a/src/protocols/permissions.ts
+++ b/src/protocols/permissions.ts
@@ -3,7 +3,7 @@ import type { MessageStore } from '../types/message-store.js';
 import type { ProtocolDefinition } from '../types/protocols-types.js';
 import type { Signer } from '../types/signer.js';
 import type { DataEncodedRecordsWriteMessage, RecordsWriteMessage } from '../types/records-types.js';
-import type { PermissionConditions, PermissionGrantModel, PermissionRequestModel, PermissionRevocationModel, PermissionScope, RecordsPermissionScope } from '../types/permission-types.js';
+import type { PermissionConditions, PermissionGrantData, PermissionRequestData, PermissionRevocationData, PermissionScope, RecordsPermissionScope } from '../types/permission-types.js';
 
 import { Encoder } from '../utils/encoder.js';
 import { PermissionGrant } from './permission-grant.js';
@@ -152,7 +152,7 @@ export class PermissionsProtocol {
     }
   };
 
-  public static parseRequest(base64UrlEncodedRequest: string): PermissionRequestModel {
+  public static parseRequest(base64UrlEncodedRequest: string): PermissionRequestData {
     return Encoder.base64UrlToObject(base64UrlEncodedRequest);
   }
 
@@ -161,19 +161,19 @@ export class PermissionsProtocol {
    */
   public static async createRequest(options: PermissionRequestCreateOptions): Promise<{
     recordsWrite: RecordsWrite,
-    permissionRequestModel: PermissionRequestModel,
+    permissionRequestData: PermissionRequestData,
     permissionRequestBytes: Uint8Array
   }> {
     const scope = PermissionsProtocol.normalizePermissionScope(options.scope);
 
-    const permissionRequestModel: PermissionRequestModel = {
+    const permissionRequestData: PermissionRequestData = {
       description : options.description,
       delegated   : options.delegated,
       scope,
       conditions  : options.conditions,
     };
 
-    const permissionRequestBytes = Encoder.objectToBytes(permissionRequestModel);
+    const permissionRequestBytes = Encoder.objectToBytes(permissionRequestData);
     const recordsWrite = await RecordsWrite.create({
       signer           : options.signer,
       messageTimestamp : options.dateRequested,
@@ -185,7 +185,7 @@ export class PermissionsProtocol {
 
     return {
       recordsWrite,
-      permissionRequestModel,
+      permissionRequestData,
       permissionRequestBytes
     };
   }
@@ -195,13 +195,13 @@ export class PermissionsProtocol {
    */
   public static async createGrant(options: PermissionGrantCreateOptions): Promise<{
     recordsWrite: RecordsWrite,
-    permissionGrantModel: PermissionGrantModel,
+    permissionGrantData: PermissionGrantData,
     permissionGrantBytes: Uint8Array,
     dataEncodedMessage: DataEncodedRecordsWriteMessage,
   }> {
     const scope = PermissionsProtocol.normalizePermissionScope(options.scope);
 
-    const permissionGrantModel: PermissionGrantModel = {
+    const permissionGrantData: PermissionGrantData = {
       dateExpires : options.dateExpires,
       requestId   : options.requestId,
       description : options.description,
@@ -210,7 +210,7 @@ export class PermissionsProtocol {
       conditions  : options.conditions,
     };
 
-    const permissionGrantBytes = Encoder.objectToBytes(permissionGrantModel);
+    const permissionGrantBytes = Encoder.objectToBytes(permissionGrantData);
     const recordsWrite = await RecordsWrite.create({
       signer           : options.signer,
       messageTimestamp : options.dateGranted,
@@ -229,7 +229,7 @@ export class PermissionsProtocol {
 
     return {
       recordsWrite,
-      permissionGrantModel,
+      permissionGrantData,
       permissionGrantBytes,
       dataEncodedMessage
     };
@@ -240,14 +240,14 @@ export class PermissionsProtocol {
    */
   public static async createRevocation(options: PermissionRevocationCreateOptions): Promise<{
     recordsWrite: RecordsWrite,
-    permissionRevocationModel: PermissionRevocationModel,
+    permissionRevocationData: PermissionRevocationData,
     permissionRevocationBytes: Uint8Array
   }> {
-    const permissionRevocationModel: PermissionRevocationModel = {
+    const permissionRevocationData: PermissionRevocationData = {
       description: options.description,
     };
 
-    const permissionRevocationBytes = Encoder.objectToBytes(permissionRevocationModel);
+    const permissionRevocationBytes = Encoder.objectToBytes(permissionRevocationData);
     const recordsWrite = await RecordsWrite.create({
       signer          : options.signer,
       parentContextId : options.grantId, // NOTE: since the grant is the root record, its record ID is also the context ID
@@ -259,7 +259,7 @@ export class PermissionsProtocol {
 
     return {
       recordsWrite,
-      permissionRevocationModel,
+      permissionRevocationData,
       permissionRevocationBytes
     };
   }
@@ -276,7 +276,7 @@ export class PermissionsProtocol {
       validateJsonSchema('PermissionGrantData', dataObject);
 
       // more nuanced validation that are annoying/difficult to do using JSON schema
-      const permissionGrantData = dataObject as PermissionGrantModel;
+      const permissionGrantData = dataObject as PermissionGrantData;
       PermissionsProtocol.validateScope(permissionGrantData.scope);
       Time.validateTimestamp(permissionGrantData.dateExpires);
     } else if (recordsWriteMessage.descriptor.protocolPath === PermissionsProtocol.revocationPath) {

--- a/src/types/message-types.ts
+++ b/src/types/message-types.ts
@@ -69,7 +69,7 @@ type DelegatedGrantRecordsWriteMessage = {
  */
 export type GenericSignaturePayload = {
   descriptorCid: string;
-  permissionsGrantId?: string;
+  permissionGrantId?: string;
 
   /**
    * Record ID of a permission grant DWN `RecordsWrite` with `delegated` set to `true`.

--- a/src/types/permission-types.ts
+++ b/src/types/permission-types.ts
@@ -1,9 +1,9 @@
 import type { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
 
 /**
- * The data model of a permission request.
+ * Type for the data payload of a permission request message.
  */
-export type PermissionRequestModel = {
+export type PermissionRequestData = {
 
   /**
    * If the grant is a delegated grant or not. If `true`, the `grantedTo` will be able to act as the `grantedBy` within the scope of this grant.
@@ -24,9 +24,9 @@ export type PermissionRequestModel = {
 };
 
 /**
- * The data model of a permission grant.
+ * Type for the data payload of a permission grant message.
  */
-export type PermissionGrantModel = {
+export type PermissionGrantData = {
   /**
    * Optional string that communicates what the grant would be used for
    */
@@ -56,9 +56,9 @@ export type PermissionGrantModel = {
 };
 
 /**
- * The data model of a permission revocation.
+ * Type for the data payload of a permission revocation message.
  */
-export type PermissionRevocationModel = {
+export type PermissionRevocationData = {
   /**
    * Optional string that communicates the details of the revocation.
    */

--- a/tests/features/author-delegated-grant.spec.ts
+++ b/tests/features/author-delegated-grant.spec.ts
@@ -1177,8 +1177,12 @@ export function testAuthorDelegatedGrant(): void {
         signer      : Jws.createSigner(alice)
       });
       const deviceXGrantDataStream = DataStream.fromBytes(deviceXGrant.permissionGrantBytes);
-      const permissionsGrantReply = await dwn.processMessage(alice.did, deviceXGrant.recordsWrite.message, { dataStream: deviceXGrantDataStream });
-      expect(permissionsGrantReply.status.code).to.equal(202);
+      const permissionGrantWriteReply = await dwn.processMessage(
+        alice.did,
+        deviceXGrant.recordsWrite.message,
+        { dataStream: deviceXGrantDataStream }
+      );
+      expect(permissionGrantWriteReply.status.code).to.equal(202);
 
       // 3. Alice revokes the grant
       const permissionRevoke = await PermissionsProtocol.createRevocation({

--- a/tests/features/owner-delegated-grant.spec.ts
+++ b/tests/features/owner-delegated-grant.spec.ts
@@ -593,8 +593,8 @@ export function testOwnerDelegatedGrant(): void {
         signer      : Jws.createSigner(alice)
       });
       const grantDataStream = DataStream.fromBytes(appXGrant.permissionGrantBytes);
-      const permissionsGrantReply = await dwn.processMessage(alice.did, appXGrant.recordsWrite.message, { dataStream: grantDataStream });
-      expect(permissionsGrantReply.status.code).to.equal(202);
+      const permissionGrantWriteReply = await dwn.processMessage(alice.did, appXGrant.recordsWrite.message, { dataStream: grantDataStream });
+      expect(permissionGrantWriteReply.status.code).to.equal(202);
 
       // 3. Alice revokes the grant
       const permissionRevoke = await PermissionsProtocol.createRevocation({

--- a/tests/handlers/protocols-configure.spec.ts
+++ b/tests/handlers/protocols-configure.spec.ts
@@ -278,7 +278,7 @@ export function testProtocolsConfigureHandler(): void {
       });
 
       it('rejects non-tenant non-granted ProtocolsConfigures with 401', async () => {
-        // Bob tries to ProtocolsConfigure to Alice's DWN without a PermissionsGrant
+        // Bob tries to ProtocolsConfigure to Alice's DWN without a permission grant
         const alice = await TestDataGenerator.generateDidKeyPersona();
         const bob = await TestDataGenerator.generateDidKeyPersona();
 

--- a/tests/handlers/protocols-query.spec.ts
+++ b/tests/handlers/protocols-query.spec.ts
@@ -247,10 +247,10 @@ export function testProtocolsQueryHandler(): void {
           expect(grantRecordsWriteReply.status.code).to.equal(202);
 
           // 2. Verify Bob can perform a ProtocolsQuery
-          const permissionsGrantId = permissionGrant.recordsWrite.message.recordId;
+          const permissionGrantId = permissionGrant.recordsWrite.message.recordId;
           const protocolsQuery = await TestDataGenerator.generateProtocolsQuery({
             author: bob,
-            permissionsGrantId,
+            permissionGrantId,
           });
           const protocolsQueryReply = await dwn.processMessage(alice.did, protocolsQuery.message);
           expect(protocolsQueryReply.status.code).to.equal(200);
@@ -258,7 +258,7 @@ export function testProtocolsQueryHandler(): void {
           // 3. Verify that Mallory cannot to use Bob's permission grant to gain access to Alice's DWN
           const malloryProtocolsQuery = await TestDataGenerator.generateProtocolsQuery({
             author: mallory,
-            permissionsGrantId,
+            permissionGrantId,
           });
           const malloryProtocolsQueryReply = await dwn.processMessage(alice.did, malloryProtocolsQuery.message);
           expect(malloryProtocolsQueryReply.status.code).to.equal(401);
@@ -267,7 +267,7 @@ export function testProtocolsQueryHandler(): void {
           // 4. Alice revokes Bob's grant
           const revokeWrite = await PermissionsProtocol.createRevocation({
             signer      : Jws.createSigner(alice),
-            grantId     : permissionsGrantId,
+            grantId     : permissionGrantId,
             dateRevoked : Time.getCurrentTimestamp()
           });
 
@@ -281,7 +281,7 @@ export function testProtocolsQueryHandler(): void {
           // 5. Verify Bob cannot perform ProtocolsQuery with the revoked grant
           const unauthorizedProtocolsQuery = await TestDataGenerator.generateProtocolsQuery({
             author: bob,
-            permissionsGrantId,
+            permissionGrantId,
           });
           const unauthorizedProtocolsQueryReply = await dwn.processMessage(alice.did, unauthorizedProtocolsQuery.message);
           expect(unauthorizedProtocolsQueryReply.status.code).to.equal(401);
@@ -309,7 +309,7 @@ export function testProtocolsQueryHandler(): void {
           // Bob does ProtocolsQuery after the grant has expired
           const protocolsQuery = await TestDataGenerator.generateProtocolsQuery({
             author             : bob,
-            permissionsGrantId : permissionGrant.recordsWrite.message.recordId,
+            permissionGrantId : permissionGrant.recordsWrite.message.recordId,
           });
           const protocolsQueryReply = await dwn.processMessage(alice.did, protocolsQuery.message);
           expect(protocolsQueryReply.status.code).to.equal(401);
@@ -343,7 +343,7 @@ export function testProtocolsQueryHandler(): void {
           const protocolsQuery = await TestDataGenerator.generateProtocolsQuery({
             author             : bob,
             messageTimestamp   : protocolsQueryTimestamp,
-            permissionsGrantId : permissionGrant.recordsWrite.message.recordId,
+            permissionGrantId : permissionGrant.recordsWrite.message.recordId,
           });
           const protocolsQueryReply = await dwn.processMessage(alice.did, protocolsQuery.message);
           expect(protocolsQueryReply.status.code).to.equal(401);
@@ -371,7 +371,7 @@ export function testProtocolsQueryHandler(): void {
           // Bob tries to ProtocolsQuery
           const protocolsQuery = await TestDataGenerator.generateProtocolsQuery({
             author             : bob,
-            permissionsGrantId : permissionGrant.recordsWrite.message.recordId,
+            permissionGrantId : permissionGrant.recordsWrite.message.recordId,
           });
           const protocolsQueryReply = await dwn.processMessage(alice.did, protocolsQuery.message);
           expect(protocolsQueryReply.status.code).to.equal(401);
@@ -379,7 +379,7 @@ export function testProtocolsQueryHandler(): void {
         });
 
         it('rejects with 401 if the permission grant cannot be found', async () => {
-          // scenario: Bob uses a permissionsGrantId to ProtocolsQuery, but no PermissionsGrant can be found.
+          // scenario: Bob uses a permissionGrantId to ProtocolsQuery, but no permission grant can be found.
 
           const alice = await TestDataGenerator.generateDidKeyPersona();
           const bob = await TestDataGenerator.generateDidKeyPersona();
@@ -387,7 +387,7 @@ export function testProtocolsQueryHandler(): void {
           // Bob tries to ProtocolsQuery
           const protocolsQuery = await TestDataGenerator.generateProtocolsQuery({
             author             : bob,
-            permissionsGrantId : await TestDataGenerator.randomCborSha256Cid(),
+            permissionGrantId : await TestDataGenerator.randomCborSha256Cid(),
           });
           const protocolsQueryReply = await dwn.processMessage(alice.did, protocolsQuery.message);
           expect(protocolsQueryReply.status.code).to.equal(401);
@@ -420,10 +420,10 @@ export function testProtocolsQueryHandler(): void {
           expect(grantRecordsWriteReply.status.code).to.equal(202);
 
           // 3. Verify that Carol cannot use permission grant to gain access to Bob's DWN
-          const permissionsGrantId = permissionGrant.recordsWrite.message.recordId;
+          const permissionGrantId = permissionGrant.recordsWrite.message.recordId;
           const protocolsQuery = await TestDataGenerator.generateProtocolsQuery({
             author: carol,
-            permissionsGrantId,
+            permissionGrantId,
           });
           const protocolsQueryReply = await dwn.processMessage(bob.did, protocolsQuery.message);
           expect(protocolsQueryReply.status.code).to.equal(401);

--- a/tests/handlers/protocols-query.spec.ts
+++ b/tests/handlers/protocols-query.spec.ts
@@ -303,12 +303,12 @@ export function testProtocolsQueryHandler(): void {
           });
           const dataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
 
-          const permissionsGrantReply = await dwn.processMessage(alice.did, permissionGrant.recordsWrite.message, { dataStream });
-          expect(permissionsGrantReply.status.code).to.equal(202);
+          const permissionGrantWriteReply = await dwn.processMessage(alice.did, permissionGrant.recordsWrite.message, { dataStream });
+          expect(permissionGrantWriteReply.status.code).to.equal(202);
 
           // Bob does ProtocolsQuery after the grant has expired
           const protocolsQuery = await TestDataGenerator.generateProtocolsQuery({
-            author             : bob,
+            author            : bob,
             permissionGrantId : permissionGrant.recordsWrite.message.recordId,
           });
           const protocolsQueryReply = await dwn.processMessage(alice.did, protocolsQuery.message);
@@ -336,13 +336,13 @@ export function testProtocolsQueryHandler(): void {
           });
           const dataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
 
-          const permissionsGrantReply = await dwn.processMessage(alice.did, permissionGrant.recordsWrite.message, { dataStream });
-          expect(permissionsGrantReply.status.code).to.equal(202);
+          const permissionGrantWriteReply = await dwn.processMessage(alice.did, permissionGrant.recordsWrite.message, { dataStream });
+          expect(permissionGrantWriteReply.status.code).to.equal(202);
 
           // Bob does ProtocolsQuery but his message has timestamp before the grant is active
           const protocolsQuery = await TestDataGenerator.generateProtocolsQuery({
-            author             : bob,
-            messageTimestamp   : protocolsQueryTimestamp,
+            author            : bob,
+            messageTimestamp  : protocolsQueryTimestamp,
             permissionGrantId : permissionGrant.recordsWrite.message.recordId,
           });
           const protocolsQueryReply = await dwn.processMessage(alice.did, protocolsQuery.message);
@@ -370,7 +370,7 @@ export function testProtocolsQueryHandler(): void {
 
           // Bob tries to ProtocolsQuery
           const protocolsQuery = await TestDataGenerator.generateProtocolsQuery({
-            author             : bob,
+            author            : bob,
             permissionGrantId : permissionGrant.recordsWrite.message.recordId,
           });
           const protocolsQueryReply = await dwn.processMessage(alice.did, protocolsQuery.message);
@@ -386,7 +386,7 @@ export function testProtocolsQueryHandler(): void {
 
           // Bob tries to ProtocolsQuery
           const protocolsQuery = await TestDataGenerator.generateProtocolsQuery({
-            author             : bob,
+            author            : bob,
             permissionGrantId : await TestDataGenerator.randomCborSha256Cid(),
           });
           const protocolsQueryReply = await dwn.processMessage(alice.did, protocolsQuery.message);

--- a/tests/handlers/records-read.spec.ts
+++ b/tests/handlers/records-read.spec.ts
@@ -804,7 +804,7 @@ export function testRecordsReadHandler(): void {
           const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
           expect(recordsWriteReply.status.code).to.equal(202);
 
-          // Alice gives Bob a PermissionsGrant with scope RecordsRead
+          // Alice gives Bob a permission grant with scope RecordsRead
           const permissionsGrant = await PermissionsProtocol.createGrant({
             signer      : Jws.createSigner(alice),
             grantedTo   : bob.did,
@@ -824,7 +824,7 @@ export function testRecordsReadHandler(): void {
               recordId: recordsWrite.message.recordId,
             },
             signer             : Jws.createSigner(bob),
-            permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+            permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
           });
           const recordsReadReply = await dwn.processMessage(alice.did, recordsRead.message);
           expect(recordsReadReply.status.code).to.equal(401);
@@ -845,7 +845,7 @@ export function testRecordsReadHandler(): void {
           const writeReply = await dwn.processMessage(alice.did, message, { dataStream });
           expect(writeReply.status.code).to.equal(202);
 
-          // Alice issues a PermissionsGrant allowing Bob to read any record in her DWN
+          // Alice issues a permission grant allowing Bob to read any record in her DWN
           const permissionsGrant = await PermissionsProtocol.createGrant({
             signer      : Jws.createSigner(alice),
             grantedTo   : bob.did,
@@ -866,7 +866,7 @@ export function testRecordsReadHandler(): void {
               recordId: message.recordId,
             },
             signer             : Jws.createSigner(bob),
-            permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+            permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
           });
           const readReply = await dwn.processMessage(alice.did, recordsRead.message);
           expect(readReply.status.code).to.equal(200);
@@ -899,7 +899,7 @@ export function testRecordsReadHandler(): void {
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
             expect(recordsWriteReply.status.code).to.equal(202);
 
-            // Alice gives Bob a PermissionsGrant with scope RecordsRead
+            // Alice gives Bob a permission grant with scope RecordsRead
             const permissionsGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
@@ -931,7 +931,7 @@ export function testRecordsReadHandler(): void {
                 recordId: recordsWrite.message.recordId,
               },
               signer             : Jws.createSigner(bob),
-              permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithGrantReply = await dwn.processMessage(alice.did, recordsReadWithGrant.message);
             expect(recordsReadWithGrantReply.status.code).to.equal(200);
@@ -963,7 +963,7 @@ export function testRecordsReadHandler(): void {
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
             expect(recordsWriteReply.status.code).to.equal(202);
 
-            // Alice gives Bob a PermissionsGrant with scope RecordsRead
+            // Alice gives Bob a permission grant with scope RecordsRead
             const permissionsGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
@@ -995,7 +995,7 @@ export function testRecordsReadHandler(): void {
                 recordId: recordsWrite.message.recordId,
               },
               signer             : Jws.createSigner(bob),
-              permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithGrantReply = await dwn.processMessage(alice.did, recordsReadWithGrant.message);
             expect(recordsReadWithGrantReply.status.code).to.equal(200);
@@ -1027,7 +1027,7 @@ export function testRecordsReadHandler(): void {
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
             expect(recordsWriteReply.status.code).to.equal(202);
 
-            // Alice gives Bob a PermissionsGrant with scope RecordsRead
+            // Alice gives Bob a permission grant with scope RecordsRead
             const permissionsGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
@@ -1048,7 +1048,7 @@ export function testRecordsReadHandler(): void {
                 recordId: recordsWrite.message.recordId,
               },
               signer             : Jws.createSigner(bob),
-              permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(401);
@@ -1081,7 +1081,7 @@ export function testRecordsReadHandler(): void {
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
             expect(recordsWriteReply.status.code).to.equal(202);
 
-            // Alice gives Bob a PermissionsGrant with scope RecordsRead
+            // Alice gives Bob a permission grant with scope RecordsRead
             const permissionsGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
@@ -1102,7 +1102,7 @@ export function testRecordsReadHandler(): void {
                 recordId: recordsWrite.message.recordId,
               },
               signer             : Jws.createSigner(bob),
-              permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(401);
@@ -1134,7 +1134,7 @@ export function testRecordsReadHandler(): void {
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
             expect(recordsWriteReply.status.code).to.equal(202);
 
-            // Alice gives Bob a PermissionsGrant with scope RecordsRead
+            // Alice gives Bob a permission grant with scope RecordsRead
             const permissionsGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
@@ -1156,7 +1156,7 @@ export function testRecordsReadHandler(): void {
                 recordId: recordsWrite.message.recordId,
               },
               signer             : Jws.createSigner(bob),
-              permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(200);
@@ -1187,7 +1187,7 @@ export function testRecordsReadHandler(): void {
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
             expect(recordsWriteReply.status.code).to.equal(202);
 
-            // Alice gives Bob a PermissionsGrant with scope RecordsRead
+            // Alice gives Bob a permission grant with scope RecordsRead
             const permissionsGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
@@ -1209,7 +1209,7 @@ export function testRecordsReadHandler(): void {
                 recordId: recordsWrite.message.recordId,
               },
               signer             : Jws.createSigner(bob),
-              permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(401);
@@ -1241,7 +1241,7 @@ export function testRecordsReadHandler(): void {
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
             expect(recordsWriteReply.status.code).to.equal(202);
 
-            // Alice gives Bob a PermissionsGrant with scope RecordsRead
+            // Alice gives Bob a permission grant with scope RecordsRead
             const permissionsGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
@@ -1263,7 +1263,7 @@ export function testRecordsReadHandler(): void {
                 recordId: recordsWrite.message.recordId,
               },
               signer             : Jws.createSigner(bob),
-              permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(200);
@@ -1294,7 +1294,7 @@ export function testRecordsReadHandler(): void {
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
             expect(recordsWriteReply.status.code).to.equal(202);
 
-            // Alice gives Bob a PermissionsGrant with scope RecordsRead
+            // Alice gives Bob a permission grant with scope RecordsRead
             const permissionsGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
@@ -1316,7 +1316,7 @@ export function testRecordsReadHandler(): void {
                 recordId: recordsWrite.message.recordId,
               },
               signer             : Jws.createSigner(bob),
-              permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(401);
@@ -1340,7 +1340,7 @@ export function testRecordsReadHandler(): void {
             const writeReply = await dwn.processMessage(alice.did, message, { dataStream });
             expect(writeReply.status.code).to.equal(202);
 
-            // Alice issues a PermissionsGrant allowing Bob to read a specific recordId
+            // Alice issues a permission grant allowing Bob to read a specific recordId
             const permissionsGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
@@ -1361,7 +1361,7 @@ export function testRecordsReadHandler(): void {
                 recordId: message.recordId,
               },
               signer             : Jws.createSigner(bob),
-              permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const readReply = await dwn.processMessage(alice.did, recordsRead.message);
             expect(readReply.status.code).to.equal(200);
@@ -1383,7 +1383,7 @@ export function testRecordsReadHandler(): void {
             const writeReply = await dwn.processMessage(alice.did, message, { dataStream });
             expect(writeReply.status.code).to.equal(202);
 
-            // Alice issues a PermissionsGrant allowing Bob to read a specific recordId
+            // Alice issues a permission grant allowing Bob to read a specific recordId
             const scopeSchema = 'scope-schema';
             const permissionsGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
@@ -1405,7 +1405,7 @@ export function testRecordsReadHandler(): void {
                 recordId: message.recordId,
               },
               signer             : Jws.createSigner(bob),
-              permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const readReply = await dwn.processMessage(alice.did, recordsRead.message);
             expect(readReply.status.code).to.equal(401);

--- a/tests/handlers/records-read.spec.ts
+++ b/tests/handlers/records-read.spec.ts
@@ -815,15 +815,19 @@ export function testRecordsReadHandler(): void {
             }
           });
           const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-          const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-          expect(permissionsGrantReply.status.code).to.equal(202);
+          const permissionGrantWriteReply = await dwn.processMessage(
+            alice.did,
+            permissionsGrant.recordsWrite.message,
+            { dataStream: grantDataStream }
+          );
+          expect(permissionGrantWriteReply.status.code).to.equal(202);
 
           // Bob tries to RecordsRead
           const recordsRead = await RecordsRead.create({
             filter: {
               recordId: recordsWrite.message.recordId,
             },
-            signer             : Jws.createSigner(bob),
+            signer            : Jws.createSigner(bob),
             permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
           });
           const recordsReadReply = await dwn.processMessage(alice.did, recordsRead.message);
@@ -865,7 +869,7 @@ export function testRecordsReadHandler(): void {
             filter: {
               recordId: message.recordId,
             },
-            signer             : Jws.createSigner(bob),
+            signer            : Jws.createSigner(bob),
             permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
           });
           const readReply = await dwn.processMessage(alice.did, recordsRead.message);
@@ -910,8 +914,12 @@ export function testRecordsReadHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             // Bob is unable to read the record without using the PermissionsGrant
             const recordsReadWithoutGrant = await RecordsRead.create({
@@ -930,7 +938,7 @@ export function testRecordsReadHandler(): void {
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
-              signer             : Jws.createSigner(bob),
+              signer            : Jws.createSigner(bob),
               permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithGrantReply = await dwn.processMessage(alice.did, recordsReadWithGrant.message);
@@ -975,8 +983,12 @@ export function testRecordsReadHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             // Bob is unable to read the record without using the PermissionsGrant
             const recordsReadWithoutGrant = await RecordsRead.create({
@@ -994,7 +1006,7 @@ export function testRecordsReadHandler(): void {
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
-              signer             : Jws.createSigner(bob),
+              signer            : Jws.createSigner(bob),
               permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithGrantReply = await dwn.processMessage(alice.did, recordsReadWithGrant.message);
@@ -1039,15 +1051,19 @@ export function testRecordsReadHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             // Bob is unable to read the record using the mismatched PermissionsGrant
             const recordsReadWithoutGrant = await RecordsRead.create({
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
-              signer             : Jws.createSigner(bob),
+              signer            : Jws.createSigner(bob),
               permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
@@ -1093,15 +1109,19 @@ export function testRecordsReadHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             // Bob is unable to read the record using the mismatched PermissionsGrant
             const recordsReadWithoutGrant = await RecordsRead.create({
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
-              signer             : Jws.createSigner(bob),
+              signer            : Jws.createSigner(bob),
               permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
@@ -1147,15 +1167,19 @@ export function testRecordsReadHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             // Bob is unable to read the record using the mismatched PermissionsGrant
             const recordsReadWithoutGrant = await RecordsRead.create({
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
-              signer             : Jws.createSigner(bob),
+              signer            : Jws.createSigner(bob),
               permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
@@ -1200,15 +1224,19 @@ export function testRecordsReadHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             // Bob is unable to read the record using the mismatched PermissionsGrant
             const recordsReadWithoutGrant = await RecordsRead.create({
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
-              signer             : Jws.createSigner(bob),
+              signer            : Jws.createSigner(bob),
               permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
@@ -1254,15 +1282,19 @@ export function testRecordsReadHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             // Bob is unable to read the record using the mismatched PermissionsGrant
             const recordsReadWithoutGrant = await RecordsRead.create({
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
-              signer             : Jws.createSigner(bob),
+              signer            : Jws.createSigner(bob),
               permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
@@ -1307,15 +1339,19 @@ export function testRecordsReadHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             // Bob is unable to read the record using the mismatched PermissionsGrant
             const recordsReadWithoutGrant = await RecordsRead.create({
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
-              signer             : Jws.createSigner(bob),
+              signer            : Jws.createSigner(bob),
               permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
@@ -1360,7 +1396,7 @@ export function testRecordsReadHandler(): void {
               filter: {
                 recordId: message.recordId,
               },
-              signer             : Jws.createSigner(bob),
+              signer            : Jws.createSigner(bob),
               permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const readReply = await dwn.processMessage(alice.did, recordsRead.message);
@@ -1404,7 +1440,7 @@ export function testRecordsReadHandler(): void {
               filter: {
                 recordId: message.recordId,
               },
-              signer             : Jws.createSigner(bob),
+              signer            : Jws.createSigner(bob),
               permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const readReply = await dwn.processMessage(alice.did, recordsRead.message);

--- a/tests/handlers/records-read.spec.ts
+++ b/tests/handlers/records-read.spec.ts
@@ -805,7 +805,7 @@ export function testRecordsReadHandler(): void {
           expect(recordsWriteReply.status.code).to.equal(202);
 
           // Alice gives Bob a permission grant with scope RecordsRead
-          const permissionsGrant = await PermissionsProtocol.createGrant({
+          const permissionGrant = await PermissionsProtocol.createGrant({
             signer      : Jws.createSigner(alice),
             grantedTo   : bob.did,
             dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -814,10 +814,10 @@ export function testRecordsReadHandler(): void {
               method    : DwnMethodName.Write,
             }
           });
-          const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+          const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
           const permissionGrantWriteReply = await dwn.processMessage(
             alice.did,
-            permissionsGrant.recordsWrite.message,
+            permissionGrant.recordsWrite.message,
             { dataStream: grantDataStream }
           );
           expect(permissionGrantWriteReply.status.code).to.equal(202);
@@ -828,7 +828,7 @@ export function testRecordsReadHandler(): void {
               recordId: recordsWrite.message.recordId,
             },
             signer            : Jws.createSigner(bob),
-            permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+            permissionGrantId : permissionGrant.recordsWrite.message.recordId,
           });
           const recordsReadReply = await dwn.processMessage(alice.did, recordsRead.message);
           expect(recordsReadReply.status.code).to.equal(401);
@@ -850,7 +850,7 @@ export function testRecordsReadHandler(): void {
           expect(writeReply.status.code).to.equal(202);
 
           // Alice issues a permission grant allowing Bob to read any record in her DWN
-          const permissionsGrant = await PermissionsProtocol.createGrant({
+          const permissionGrant = await PermissionsProtocol.createGrant({
             signer      : Jws.createSigner(alice),
             grantedTo   : bob.did,
             dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -860,8 +860,8 @@ export function testRecordsReadHandler(): void {
               // No further restrictions on grant scope
             }
           });
-          const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-          const grantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
+          const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
+          const grantReply = await dwn.processMessage(alice.did, permissionGrant.recordsWrite.message, { dataStream: grantDataStream });
           expect(grantReply.status.code).to.equal(202);
 
           // Bob invokes that grant to read a record from Alice's DWN
@@ -870,7 +870,7 @@ export function testRecordsReadHandler(): void {
               recordId: message.recordId,
             },
             signer            : Jws.createSigner(bob),
-            permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+            permissionGrantId : permissionGrant.recordsWrite.message.recordId,
           });
           const readReply = await dwn.processMessage(alice.did, recordsRead.message);
           expect(readReply.status.code).to.equal(200);
@@ -904,7 +904,7 @@ export function testRecordsReadHandler(): void {
             expect(recordsWriteReply.status.code).to.equal(202);
 
             // Alice gives Bob a permission grant with scope RecordsRead
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -913,15 +913,15 @@ export function testRecordsReadHandler(): void {
                 method    : DwnMethodName.Read,
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
 
-            // Bob is unable to read the record without using the PermissionsGrant
+            // Bob is unable to read the record without using the permission grant
             const recordsReadWithoutGrant = await RecordsRead.create({
               filter: {
 
@@ -933,13 +933,13 @@ export function testRecordsReadHandler(): void {
             expect(recordsReadWithoutGrantReply.status.code).to.equal(401);
             expect(recordsReadWithoutGrantReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationActionRulesNotFound);
 
-            // Bob is able to read the record when he uses the PermissionsGrant
+            // Bob is able to read the record when he uses the permission grant
             const recordsReadWithGrant = await RecordsRead.create({
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
               signer            : Jws.createSigner(bob),
-              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithGrantReply = await dwn.processMessage(alice.did, recordsReadWithGrant.message);
             expect(recordsReadWithGrantReply.status.code).to.equal(200);
@@ -972,7 +972,7 @@ export function testRecordsReadHandler(): void {
             expect(recordsWriteReply.status.code).to.equal(202);
 
             // Alice gives Bob a permission grant with scope RecordsRead
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -982,15 +982,15 @@ export function testRecordsReadHandler(): void {
                 protocol  : protocolDefinition.protocol,
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
 
-            // Bob is unable to read the record without using the PermissionsGrant
+            // Bob is unable to read the record without using the permission grant
             const recordsReadWithoutGrant = await RecordsRead.create({
               filter: {
                 recordId: recordsWrite.message.recordId,
@@ -1001,13 +1001,13 @@ export function testRecordsReadHandler(): void {
             expect(recordsReadWithoutGrantReply.status.code).to.equal(401);
             expect(recordsReadWithoutGrantReply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationActionRulesNotFound);
 
-            // Bob is able to read the record when he uses the PermissionsGrant
+            // Bob is able to read the record when he uses the permission grant
             const recordsReadWithGrant = await RecordsRead.create({
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
               signer            : Jws.createSigner(bob),
-              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithGrantReply = await dwn.processMessage(alice.did, recordsReadWithGrant.message);
             expect(recordsReadWithGrantReply.status.code).to.equal(200);
@@ -1040,7 +1040,7 @@ export function testRecordsReadHandler(): void {
             expect(recordsWriteReply.status.code).to.equal(202);
 
             // Alice gives Bob a permission grant with scope RecordsRead
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -1050,21 +1050,21 @@ export function testRecordsReadHandler(): void {
                 protocol  : 'a-different-protocol'
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
 
-            // Bob is unable to read the record using the mismatched PermissionsGrant
+            // Bob is unable to read the record using the mismatched permission grant
             const recordsReadWithoutGrant = await RecordsRead.create({
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
               signer            : Jws.createSigner(bob),
-              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(401);
@@ -1098,7 +1098,7 @@ export function testRecordsReadHandler(): void {
             expect(recordsWriteReply.status.code).to.equal(202);
 
             // Alice gives Bob a permission grant with scope RecordsRead
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -1108,21 +1108,21 @@ export function testRecordsReadHandler(): void {
                 schema    : 'some-schema'
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
 
-            // Bob is unable to read the record using the mismatched PermissionsGrant
+            // Bob is unable to read the record using the mismatched permission grant
             const recordsReadWithoutGrant = await RecordsRead.create({
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
               signer            : Jws.createSigner(bob),
-              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(401);
@@ -1155,7 +1155,7 @@ export function testRecordsReadHandler(): void {
             expect(recordsWriteReply.status.code).to.equal(202);
 
             // Alice gives Bob a permission grant with scope RecordsRead
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -1166,21 +1166,21 @@ export function testRecordsReadHandler(): void {
                 contextId : recordsWrite.message.contextId,
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
 
-            // Bob is unable to read the record using the mismatched PermissionsGrant
+            // Bob is unable to read the record using the mismatched permission grant
             const recordsReadWithoutGrant = await RecordsRead.create({
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
               signer            : Jws.createSigner(bob),
-              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(200);
@@ -1212,7 +1212,7 @@ export function testRecordsReadHandler(): void {
             expect(recordsWriteReply.status.code).to.equal(202);
 
             // Alice gives Bob a permission grant with scope RecordsRead
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -1223,21 +1223,21 @@ export function testRecordsReadHandler(): void {
                 contextId : await TestDataGenerator.randomCborSha256Cid(), // different contextId than what Bob will try to read
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
 
-            // Bob is unable to read the record using the mismatched PermissionsGrant
+            // Bob is unable to read the record using the mismatched permission grant
             const recordsReadWithoutGrant = await RecordsRead.create({
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
               signer            : Jws.createSigner(bob),
-              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(401);
@@ -1270,7 +1270,7 @@ export function testRecordsReadHandler(): void {
             expect(recordsWriteReply.status.code).to.equal(202);
 
             // Alice gives Bob a permission grant with scope RecordsRead
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -1281,21 +1281,21 @@ export function testRecordsReadHandler(): void {
                 protocolPath : recordsWrite.message.descriptor.protocolPath,
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
 
-            // Bob is unable to read the record using the mismatched PermissionsGrant
+            // Bob is unable to read the record using the mismatched permission grant
             const recordsReadWithoutGrant = await RecordsRead.create({
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
               signer            : Jws.createSigner(bob),
-              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(200);
@@ -1327,7 +1327,7 @@ export function testRecordsReadHandler(): void {
             expect(recordsWriteReply.status.code).to.equal(202);
 
             // Alice gives Bob a permission grant with scope RecordsRead
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -1338,21 +1338,21 @@ export function testRecordsReadHandler(): void {
                 protocolPath : 'different-protocol-path', // different protocol path than what Bob will try to read
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
 
-            // Bob is unable to read the record using the mismatched PermissionsGrant
+            // Bob is unable to read the record using the mismatched permission grant
             const recordsReadWithoutGrant = await RecordsRead.create({
               filter: {
                 recordId: recordsWrite.message.recordId,
               },
               signer            : Jws.createSigner(bob),
-              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionGrant.recordsWrite.message.recordId,
             });
             const recordsReadWithoutGrantReply = await dwn.processMessage(alice.did, recordsReadWithoutGrant.message);
             expect(recordsReadWithoutGrantReply.status.code).to.equal(401);
@@ -1377,7 +1377,7 @@ export function testRecordsReadHandler(): void {
             expect(writeReply.status.code).to.equal(202);
 
             // Alice issues a permission grant allowing Bob to read a specific recordId
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -1387,8 +1387,8 @@ export function testRecordsReadHandler(): void {
                 schema    : message.descriptor.schema
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const grantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
+            const grantReply = await dwn.processMessage(alice.did, permissionGrant.recordsWrite.message, { dataStream: grantDataStream });
             expect(grantReply.status.code).to.equal(202);
 
             // Bob invokes that grant to read a record from Alice's DWN
@@ -1397,7 +1397,7 @@ export function testRecordsReadHandler(): void {
                 recordId: message.recordId,
               },
               signer            : Jws.createSigner(bob),
-              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionGrant.recordsWrite.message.recordId,
             });
             const readReply = await dwn.processMessage(alice.did, recordsRead.message);
             expect(readReply.status.code).to.equal(200);
@@ -1421,7 +1421,7 @@ export function testRecordsReadHandler(): void {
 
             // Alice issues a permission grant allowing Bob to read a specific recordId
             const scopeSchema = 'scope-schema';
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -1431,8 +1431,8 @@ export function testRecordsReadHandler(): void {
                 schema    : scopeSchema // different schema than the record Bob will try to read
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const grantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
+            const grantReply = await dwn.processMessage(alice.did, permissionGrant.recordsWrite.message, { dataStream: grantDataStream });
             expect(grantReply.status.code).to.equal(202);
 
             // Bob invokes that grant to read a record from Alice's DWN
@@ -1441,7 +1441,7 @@ export function testRecordsReadHandler(): void {
                 recordId: message.recordId,
               },
               signer            : Jws.createSigner(bob),
-              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionGrant.recordsWrite.message.recordId,
             });
             const readReply = await dwn.processMessage(alice.did, recordsRead.message);
             expect(readReply.status.code).to.equal(401);

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -3580,14 +3580,18 @@ export function testRecordsWriteHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             // Bob invokes the grant in order to write a record to the protocol
             const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({
-              author             : bob,
-              protocol           : protocolDefinition.protocol,
-              protocolPath       : 'foo',
+              author            : bob,
+              protocol          : protocolDefinition.protocol,
+              protocolPath      : 'foo',
               permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
@@ -3623,14 +3627,18 @@ export function testRecordsWriteHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             // Bob invokes the grant, failing to write to a different protocol than the grant allows
             const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({
-              author             : bob,
-              protocol           : protocolDefinition.protocol,
-              protocolPath       : 'foo',
+              author            : bob,
+              protocol          : protocolDefinition.protocol,
+              protocolPath      : 'foo',
               permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
@@ -3667,14 +3675,18 @@ export function testRecordsWriteHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             // Bob invokes the grant, failing to write to a different protocol than the grant allows
             const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({
-              author             : bob,
-              protocol           : protocolDefinition.protocol,
-              protocolPath       : 'foo',
+              author            : bob,
+              protocol          : protocolDefinition.protocol,
+              protocolPath      : 'foo',
               permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
@@ -3725,17 +3737,21 @@ export function testRecordsWriteHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             // Bob invokes the grant in order to write a record to the protocol
             const bobsRecordsWrite = await TestDataGenerator.generateRecordsWrite({
-              author             : bob,
-              protocol           : protocolDefinition.protocol,
-              protocolPath       : 'email/email',
-              schema             : protocolDefinition.types.email.schema,
-              dataFormat         : protocolDefinition.types.email.dataFormats![0],
-              parentContextId    : alicesRecordsWrite.message.contextId,
+              author            : bob,
+              protocol          : protocolDefinition.protocol,
+              protocolPath      : 'email/email',
+              schema            : protocolDefinition.types.email.schema,
+              dataFormat        : protocolDefinition.types.email.dataFormats![0],
+              parentContextId   : alicesRecordsWrite.message.contextId,
               permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const bobsRecordsWriteReply = await dwn.processMessage(alice.did, bobsRecordsWrite.message, { dataStream: bobsRecordsWrite.dataStream });
@@ -3785,17 +3801,21 @@ export function testRecordsWriteHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             // Bob invokes the grant in order to write a record to the protocol
             const bobsRecordsWrite = await TestDataGenerator.generateRecordsWrite({
-              author             : bob,
-              protocol           : protocolDefinition.protocol,
-              protocolPath       : 'email/email',
-              schema             : protocolDefinition.types.email.schema,
-              dataFormat         : protocolDefinition.types.email.dataFormats![0],
-              parentContextId    : alicesRecordsWrite.message.contextId,
+              author            : bob,
+              protocol          : protocolDefinition.protocol,
+              protocolPath      : 'email/email',
+              schema            : protocolDefinition.types.email.schema,
+              dataFormat        : protocolDefinition.types.email.dataFormats![0],
+              parentContextId   : alicesRecordsWrite.message.contextId,
               permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const bobsRecordsWriteReply = await dwn.processMessage(alice.did, bobsRecordsWrite.message, { dataStream: bobsRecordsWrite.dataStream });
@@ -3833,14 +3853,18 @@ export function testRecordsWriteHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             // Bob invokes the grant in order to write a record to the protocol
             const bobsRecordsWrite = await TestDataGenerator.generateRecordsWrite({
-              author             : bob,
-              protocol           : protocolDefinition.protocol,
-              protocolPath       : 'foo',
+              author            : bob,
+              protocol          : protocolDefinition.protocol,
+              protocolPath      : 'foo',
               permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const bobsRecordsWriteReply = await dwn.processMessage(alice.did, bobsRecordsWrite.message, { dataStream: bobsRecordsWrite.dataStream });
@@ -3877,14 +3901,18 @@ export function testRecordsWriteHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             // Bob invokes the grant in order to write a record to the protocol
             const bobsRecordsWrite = await TestDataGenerator.generateRecordsWrite({
-              author             : bob,
-              protocol           : protocolDefinition.protocol,
-              protocolPath       : 'foo',
+              author            : bob,
+              protocol          : protocolDefinition.protocol,
+              protocolPath      : 'foo',
               permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const bobsRecordsWriteReply = await dwn.processMessage(alice.did, bobsRecordsWrite.message, { dataStream: bobsRecordsWrite.dataStream });
@@ -3914,12 +3942,16 @@ export function testRecordsWriteHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             // Bob invokes the grant to write a record
             const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({
-              author             : bob,
+              author            : bob,
               schema,
               permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
@@ -3947,13 +3979,17 @@ export function testRecordsWriteHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             // Bob invokes the grant, failing write a record
             const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({
-              author             : bob,
-              schema             : 'some-other-schema',
+              author            : bob,
+              schema            : 'some-other-schema',
               permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
@@ -3984,8 +4020,12 @@ export function testRecordsWriteHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             const permissionGrantId = permissionsGrant.recordsWrite.message.recordId;
 
@@ -4035,8 +4075,12 @@ export function testRecordsWriteHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             const permissionGrantId = permissionsGrant.recordsWrite.message.recordId;
 
@@ -4086,8 +4130,12 @@ export function testRecordsWriteHandler(): void {
               }
             });
             const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
-            const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
-            expect(permissionsGrantReply.status.code).to.equal(202);
+            const permissionGrantWriteReply = await dwn.processMessage(
+              alice.did,
+              permissionsGrant.recordsWrite.message,
+              { dataStream: grantDataStream }
+            );
+            expect(permissionGrantWriteReply.status.code).to.equal(202);
 
             const permissionGrantId = permissionsGrant.recordsWrite.message.recordId;
 

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -3516,7 +3516,7 @@ export function testRecordsWriteHandler(): void {
           const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message);
           expect(protocolsConfigureReply.status.code).to.equal(202);
 
-          // Alice issues Bob a PermissionsGrant for unrestricted RecordsWrite access
+          // Alice issues Bob a permission grant for unrestricted RecordsWrite access
           const permissionGrant = await PermissionsProtocol.createGrant({
             signer      : Jws.createSigner(alice),
             grantedTo   : bob.did,
@@ -3529,12 +3529,12 @@ export function testRecordsWriteHandler(): void {
           expect(grantRecordsWriteReply.status.code).to.equal(202);
 
           // Bob invokes the grant to write a protocol record to Alice's DWN
-          const permissionsGrantId = permissionGrant.recordsWrite.message.recordId;
+          const permissionGrantId = permissionGrant.recordsWrite.message.recordId;
           const protocolRecordsWrite = await TestDataGenerator.generateRecordsWrite({
             author       : bob,
             protocol     : protocolDefinition.protocol,
             protocolPath : 'foo',
-            permissionsGrantId,
+            permissionGrantId,
           });
           const recordsWriteReply =
             await dwn.processMessage(alice.did, protocolRecordsWrite.message, { dataStream: protocolRecordsWrite.dataStream });
@@ -3543,7 +3543,7 @@ export function testRecordsWriteHandler(): void {
           // Bob writes a non-protocol record to Alice's DWN
           const nonProtocolRecordsWrite = await TestDataGenerator.generateRecordsWrite({
             author: bob,
-            permissionsGrantId,
+            permissionGrantId,
           });
           const recordsWriteReply2 =
             await dwn.processMessage(alice.did, nonProtocolRecordsWrite.message, { dataStream: nonProtocolRecordsWrite.dataStream });
@@ -3588,7 +3588,7 @@ export function testRecordsWriteHandler(): void {
               author             : bob,
               protocol           : protocolDefinition.protocol,
               protocolPath       : 'foo',
-              permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
             expect(recordsWriteReply.status.code).to.equal(202);
@@ -3611,7 +3611,7 @@ export function testRecordsWriteHandler(): void {
             const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message);
             expect(protocolsConfigureReply.status.code).to.equal(202);
 
-            // Alice gives Bob a PermissionsGrant with a different protocol than what Bob will try to write to
+            // Alice gives Bob a permission grant with a different protocol than what Bob will try to write to
             const permissionsGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
@@ -3631,7 +3631,7 @@ export function testRecordsWriteHandler(): void {
               author             : bob,
               protocol           : protocolDefinition.protocol,
               protocolPath       : 'foo',
-              permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
             expect(recordsWriteReply.status.code).to.equal(401);
@@ -3655,7 +3655,7 @@ export function testRecordsWriteHandler(): void {
             const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message);
             expect(protocolsConfigureReply.status.code).to.equal(202);
 
-            // Alice gives Bob a PermissionsGrant with a non-protocol scope
+            // Alice gives Bob a permission grant with a non-protocol scope
             const permissionsGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
@@ -3675,7 +3675,7 @@ export function testRecordsWriteHandler(): void {
               author             : bob,
               protocol           : protocolDefinition.protocol,
               protocolPath       : 'foo',
-              permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
             expect(recordsWriteReply.status.code).to.equal(401);
@@ -3736,7 +3736,7 @@ export function testRecordsWriteHandler(): void {
               schema             : protocolDefinition.types.email.schema,
               dataFormat         : protocolDefinition.types.email.dataFormats![0],
               parentContextId    : alicesRecordsWrite.message.contextId,
-              permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const bobsRecordsWriteReply = await dwn.processMessage(alice.did, bobsRecordsWrite.message, { dataStream: bobsRecordsWrite.dataStream });
             expect(bobsRecordsWriteReply.status.code).to.equal(202);
@@ -3796,7 +3796,7 @@ export function testRecordsWriteHandler(): void {
               schema             : protocolDefinition.types.email.schema,
               dataFormat         : protocolDefinition.types.email.dataFormats![0],
               parentContextId    : alicesRecordsWrite.message.contextId,
-              permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const bobsRecordsWriteReply = await dwn.processMessage(alice.did, bobsRecordsWrite.message, { dataStream: bobsRecordsWrite.dataStream });
             expect(bobsRecordsWriteReply.status.code).to.equal(401);
@@ -3841,7 +3841,7 @@ export function testRecordsWriteHandler(): void {
               author             : bob,
               protocol           : protocolDefinition.protocol,
               protocolPath       : 'foo',
-              permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const bobsRecordsWriteReply = await dwn.processMessage(alice.did, bobsRecordsWrite.message, { dataStream: bobsRecordsWrite.dataStream });
             expect(bobsRecordsWriteReply.status.code).to.equal(202);
@@ -3885,7 +3885,7 @@ export function testRecordsWriteHandler(): void {
               author             : bob,
               protocol           : protocolDefinition.protocol,
               protocolPath       : 'foo',
-              permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const bobsRecordsWriteReply = await dwn.processMessage(alice.did, bobsRecordsWrite.message, { dataStream: bobsRecordsWrite.dataStream });
             expect(bobsRecordsWriteReply.status.code).to.equal(401);
@@ -3901,7 +3901,7 @@ export function testRecordsWriteHandler(): void {
             const alice = await TestDataGenerator.generateDidKeyPersona();
             const bob = await TestDataGenerator.generateDidKeyPersona();
 
-            // Alice gives Bob a PermissionsGrant for a certain schema
+            // Alice gives Bob a permission grant for a certain schema
             const schema = 'http://example.com/schema';
             const permissionsGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
@@ -3921,7 +3921,7 @@ export function testRecordsWriteHandler(): void {
             const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({
               author             : bob,
               schema,
-              permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
             expect(recordsWriteReply.status.code).to.equal(202);
@@ -3935,7 +3935,7 @@ export function testRecordsWriteHandler(): void {
             const bob = await TestDataGenerator.generateDidKeyPersona();
 
 
-            // Alice gives Bob a PermissionsGrant for a certain schema
+            // Alice gives Bob a permission grant for a certain schema
             const permissionsGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
@@ -3954,7 +3954,7 @@ export function testRecordsWriteHandler(): void {
             const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({
               author             : bob,
               schema             : 'some-other-schema',
-              permissionsGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
             });
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
             expect(recordsWriteReply.status.code).to.equal(401);
@@ -3987,13 +3987,13 @@ export function testRecordsWriteHandler(): void {
             const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
             expect(permissionsGrantReply.status.code).to.equal(202);
 
-            const permissionsGrantId = permissionsGrant.recordsWrite.message.recordId;
+            const permissionGrantId = permissionsGrant.recordsWrite.message.recordId;
 
             // Bob is able to write a published record
             const publishedRecordsWrite = await TestDataGenerator.generateRecordsWrite({
               author    : bob,
               published : true,
-              permissionsGrantId
+              permissionGrantId
             });
             const publishedRecordsWriteReply = await dwn.processMessage(
               alice.did,
@@ -4006,7 +4006,7 @@ export function testRecordsWriteHandler(): void {
             const unpublishedRecordsWrite = await TestDataGenerator.generateRecordsWrite({
               author    : bob,
               published : false,
-              permissionsGrantId
+              permissionGrantId
             });
             const unpublishedRecordsWriteReply =
               await dwn.processMessage(alice.did, unpublishedRecordsWrite.message, { dataStream: unpublishedRecordsWrite.dataStream });
@@ -4038,13 +4038,13 @@ export function testRecordsWriteHandler(): void {
             const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
             expect(permissionsGrantReply.status.code).to.equal(202);
 
-            const permissionsGrantId = permissionsGrant.recordsWrite.message.recordId;
+            const permissionGrantId = permissionsGrant.recordsWrite.message.recordId;
 
             // Bob not is able to write a published record
             const publishedRecordsWrite = await TestDataGenerator.generateRecordsWrite({
               author    : bob,
               published : true,
-              permissionsGrantId
+              permissionGrantId
             });
             const publishedRecordsWriteReply = await dwn.processMessage(
               alice.did,
@@ -4058,7 +4058,7 @@ export function testRecordsWriteHandler(): void {
             const unpublishedRecordsWrite = await TestDataGenerator.generateRecordsWrite({
               author    : bob,
               published : false,
-              permissionsGrantId
+              permissionGrantId
             });
             const unpublishedRecordsWriteReply =
               await dwn.processMessage(alice.did, unpublishedRecordsWrite.message, { dataStream: unpublishedRecordsWrite.dataStream });
@@ -4089,13 +4089,13 @@ export function testRecordsWriteHandler(): void {
             const permissionsGrantReply = await dwn.processMessage(alice.did, permissionsGrant.recordsWrite.message, { dataStream: grantDataStream });
             expect(permissionsGrantReply.status.code).to.equal(202);
 
-            const permissionsGrantId = permissionsGrant.recordsWrite.message.recordId;
+            const permissionGrantId = permissionsGrant.recordsWrite.message.recordId;
 
             // Bob is able to write a published record
             const publishedRecordsWrite = await TestDataGenerator.generateRecordsWrite({
               author    : bob,
               published : true,
-              permissionsGrantId
+              permissionGrantId
             });
             const publishedRecordsWriteReply = await dwn.processMessage(
               alice.did,
@@ -4108,7 +4108,7 @@ export function testRecordsWriteHandler(): void {
             const unpublishedRecordsWrite = await TestDataGenerator.generateRecordsWrite({
               author    : bob,
               published : false,
-              permissionsGrantId
+              permissionGrantId
             });
             const unpublishedRecordsWriteReply =
               await dwn.processMessage(alice.did, unpublishedRecordsWrite.message, { dataStream: unpublishedRecordsWrite.dataStream });

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -3568,8 +3568,8 @@ export function testRecordsWriteHandler(): void {
             const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message);
             expect(protocolsConfigureReply.status.code).to.equal(202);
 
-            // Alice gives Bob a PermissionsGrant
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            // Alice gives Bob a permission grant
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -3579,10 +3579,10 @@ export function testRecordsWriteHandler(): void {
                 protocol  : protocolDefinition.protocol,
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
@@ -3592,7 +3592,7 @@ export function testRecordsWriteHandler(): void {
               author            : bob,
               protocol          : protocolDefinition.protocol,
               protocolPath      : 'foo',
-              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionGrant.recordsWrite.message.recordId,
             });
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
             expect(recordsWriteReply.status.code).to.equal(202);
@@ -3616,7 +3616,7 @@ export function testRecordsWriteHandler(): void {
             expect(protocolsConfigureReply.status.code).to.equal(202);
 
             // Alice gives Bob a permission grant with a different protocol than what Bob will try to write to
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -3626,10 +3626,10 @@ export function testRecordsWriteHandler(): void {
                 protocol  : 'some-other-protocol',
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
@@ -3639,7 +3639,7 @@ export function testRecordsWriteHandler(): void {
               author            : bob,
               protocol          : protocolDefinition.protocol,
               protocolPath      : 'foo',
-              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionGrant.recordsWrite.message.recordId,
             });
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
             expect(recordsWriteReply.status.code).to.equal(401);
@@ -3664,7 +3664,7 @@ export function testRecordsWriteHandler(): void {
             expect(protocolsConfigureReply.status.code).to.equal(202);
 
             // Alice gives Bob a permission grant with a non-protocol scope
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -3674,10 +3674,10 @@ export function testRecordsWriteHandler(): void {
                 schema    : 'some-schema',
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
@@ -3687,7 +3687,7 @@ export function testRecordsWriteHandler(): void {
               author            : bob,
               protocol          : protocolDefinition.protocol,
               protocolPath      : 'foo',
-              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionGrant.recordsWrite.message.recordId,
             });
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
             expect(recordsWriteReply.status.code).to.equal(401);
@@ -3724,8 +3724,8 @@ export function testRecordsWriteHandler(): void {
               await dwn.processMessage(alice.did, alicesRecordsWrite.message, { dataStream: alicesRecordsWrite.dataStream });
             expect(alicesRecordsWriteReply.status.code).to.equal(202);
 
-            // Alice gives Bob a PermissionsGrant
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            // Alice gives Bob a permission grant
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -3736,10 +3736,10 @@ export function testRecordsWriteHandler(): void {
                 contextId : alicesRecordsWrite.message.contextId,
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
@@ -3752,7 +3752,7 @@ export function testRecordsWriteHandler(): void {
               schema            : protocolDefinition.types.email.schema,
               dataFormat        : protocolDefinition.types.email.dataFormats![0],
               parentContextId   : alicesRecordsWrite.message.contextId,
-              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionGrant.recordsWrite.message.recordId,
             });
             const bobsRecordsWriteReply = await dwn.processMessage(alice.did, bobsRecordsWrite.message, { dataStream: bobsRecordsWrite.dataStream });
             expect(bobsRecordsWriteReply.status.code).to.equal(202);
@@ -3788,8 +3788,8 @@ export function testRecordsWriteHandler(): void {
               await dwn.processMessage(alice.did, alicesRecordsWrite.message, { dataStream: alicesRecordsWrite.dataStream });
             expect(alicesRecordsWriteReply.status.code).to.equal(202);
 
-            // Alice gives Bob a PermissionsGrant
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            // Alice gives Bob a permission grant
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -3800,10 +3800,10 @@ export function testRecordsWriteHandler(): void {
                 contextId : await TestDataGenerator.randomCborSha256Cid(), // different contextId than what Bob will try to write to
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
@@ -3816,7 +3816,7 @@ export function testRecordsWriteHandler(): void {
               schema            : protocolDefinition.types.email.schema,
               dataFormat        : protocolDefinition.types.email.dataFormats![0],
               parentContextId   : alicesRecordsWrite.message.contextId,
-              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionGrant.recordsWrite.message.recordId,
             });
             const bobsRecordsWriteReply = await dwn.processMessage(alice.did, bobsRecordsWrite.message, { dataStream: bobsRecordsWrite.dataStream });
             expect(bobsRecordsWriteReply.status.code).to.equal(401);
@@ -3840,8 +3840,8 @@ export function testRecordsWriteHandler(): void {
             const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message);
             expect(protocolsConfigureReply.status.code).to.equal(202);
 
-            // Alice gives Bob a PermissionsGrant
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            // Alice gives Bob a permission grant
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -3852,10 +3852,10 @@ export function testRecordsWriteHandler(): void {
                 protocolPath : 'foo',
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
@@ -3865,7 +3865,7 @@ export function testRecordsWriteHandler(): void {
               author            : bob,
               protocol          : protocolDefinition.protocol,
               protocolPath      : 'foo',
-              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionGrant.recordsWrite.message.recordId,
             });
             const bobsRecordsWriteReply = await dwn.processMessage(alice.did, bobsRecordsWrite.message, { dataStream: bobsRecordsWrite.dataStream });
             expect(bobsRecordsWriteReply.status.code).to.equal(202);
@@ -3888,8 +3888,8 @@ export function testRecordsWriteHandler(): void {
             const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message);
             expect(protocolsConfigureReply.status.code).to.equal(202);
 
-            // Alice gives Bob a PermissionsGrant
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            // Alice gives Bob a permission grant
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -3900,10 +3900,10 @@ export function testRecordsWriteHandler(): void {
                 protocolPath : 'some-other-protocol-path',
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
@@ -3913,7 +3913,7 @@ export function testRecordsWriteHandler(): void {
               author            : bob,
               protocol          : protocolDefinition.protocol,
               protocolPath      : 'foo',
-              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionGrant.recordsWrite.message.recordId,
             });
             const bobsRecordsWriteReply = await dwn.processMessage(alice.did, bobsRecordsWrite.message, { dataStream: bobsRecordsWrite.dataStream });
             expect(bobsRecordsWriteReply.status.code).to.equal(401);
@@ -3931,7 +3931,7 @@ export function testRecordsWriteHandler(): void {
 
             // Alice gives Bob a permission grant for a certain schema
             const schema = 'http://example.com/schema';
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -3941,10 +3941,10 @@ export function testRecordsWriteHandler(): void {
                 schema,
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
@@ -3953,7 +3953,7 @@ export function testRecordsWriteHandler(): void {
             const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({
               author            : bob,
               schema,
-              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionGrant.recordsWrite.message.recordId,
             });
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
             expect(recordsWriteReply.status.code).to.equal(202);
@@ -3968,7 +3968,7 @@ export function testRecordsWriteHandler(): void {
 
 
             // Alice gives Bob a permission grant for a certain schema
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -3978,10 +3978,10 @@ export function testRecordsWriteHandler(): void {
                 schema    : 'some-schema',
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
@@ -3990,7 +3990,7 @@ export function testRecordsWriteHandler(): void {
             const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({
               author            : bob,
               schema            : 'some-other-schema',
-              permissionGrantId : permissionsGrant.recordsWrite.message.recordId,
+              permissionGrantId : permissionGrant.recordsWrite.message.recordId,
             });
             const recordsWriteReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
             expect(recordsWriteReply.status.code).to.equal(401);
@@ -4007,7 +4007,7 @@ export function testRecordsWriteHandler(): void {
             const bob = await TestDataGenerator.generateDidKeyPersona();
 
             // Alice creates a grant for Bob with `published` === required
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -4019,15 +4019,15 @@ export function testRecordsWriteHandler(): void {
                 publication: PermissionConditionPublication.Required,
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
 
-            const permissionGrantId = permissionsGrant.recordsWrite.message.recordId;
+            const permissionGrantId = permissionGrant.recordsWrite.message.recordId;
 
             // Bob is able to write a published record
             const publishedRecordsWrite = await TestDataGenerator.generateRecordsWrite({
@@ -4062,7 +4062,7 @@ export function testRecordsWriteHandler(): void {
             const bob = await TestDataGenerator.generateDidKeyPersona();
 
             // Alice creates a grant for Bob with `published` === prohibited
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -4074,15 +4074,15 @@ export function testRecordsWriteHandler(): void {
                 publication: PermissionConditionPublication.Prohibited
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
 
-            const permissionGrantId = permissionsGrant.recordsWrite.message.recordId;
+            const permissionGrantId = permissionGrant.recordsWrite.message.recordId;
 
             // Bob not is able to write a published record
             const publishedRecordsWrite = await TestDataGenerator.generateRecordsWrite({
@@ -4117,7 +4117,7 @@ export function testRecordsWriteHandler(): void {
             const bob = await TestDataGenerator.generateDidKeyPersona();
 
             // Alice creates a grant for Bob with `published` === prohibited
-            const permissionsGrant = await PermissionsProtocol.createGrant({
+            const permissionGrant = await PermissionsProtocol.createGrant({
               signer      : Jws.createSigner(alice),
               grantedTo   : bob.did,
               dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }), // 24 hours
@@ -4129,15 +4129,15 @@ export function testRecordsWriteHandler(): void {
                 // publication: '', // intentionally undefined
               }
             });
-            const grantDataStream = DataStream.fromBytes(permissionsGrant.permissionGrantBytes);
+            const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
             const permissionGrantWriteReply = await dwn.processMessage(
               alice.did,
-              permissionsGrant.recordsWrite.message,
+              permissionGrant.recordsWrite.message,
               { dataStream: grantDataStream }
             );
             expect(permissionGrantWriteReply.status.code).to.equal(202);
 
-            const permissionGrantId = permissionsGrant.recordsWrite.message.recordId;
+            const permissionGrantId = permissionGrant.recordsWrite.message.recordId;
 
             // Bob is able to write a published record
             const publishedRecordsWrite = await TestDataGenerator.generateRecordsWrite({

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -305,7 +305,7 @@ export class TestDataGenerator {
     const signer = Jws.createSigner(author);
 
     const options: ProtocolsConfigureOptions = {
-      messageTimestamp   : input?.messageTimestamp,
+      messageTimestamp  : input?.messageTimestamp,
       definition,
       signer,
       permissionGrantId : input?.permissionGrantId
@@ -330,8 +330,8 @@ export class TestDataGenerator {
     const signer = Jws.createSigner(author);
 
     const options: ProtocolsQueryOptions = {
-      messageTimestamp   : input?.messageTimestamp,
-      filter             : input?.filter,
+      messageTimestamp  : input?.messageTimestamp,
+      filter            : input?.filter,
       signer,
       permissionGrantId : input?.permissionGrantId,
     };
@@ -371,25 +371,25 @@ export class TestDataGenerator {
     }
 
     const options: RecordsWriteOptions = {
-      recipient          : input?.recipient,
-      protocol           : input?.protocol,
-      protocolPath       : input?.protocolPath,
-      protocolRole       : input?.protocolRole,
-      schema             : input?.schema ?? `http://${TestDataGenerator.randomString(20)}`,
-      tags               : input?.tags,
-      recordId           : input?.recordId,
-      parentContextId    : input?.parentContextId,
-      published          : input?.published,
-      dataFormat         : input?.dataFormat ?? 'application/json',
-      dateCreated        : input?.dateCreated,
-      messageTimestamp   : input?.messageTimestamp,
-      datePublished      : input?.datePublished,
-      data               : dataBytes,
+      recipient         : input?.recipient,
+      protocol          : input?.protocol,
+      protocolPath      : input?.protocolPath,
+      protocolRole      : input?.protocolRole,
+      schema            : input?.schema ?? `http://${TestDataGenerator.randomString(20)}`,
+      tags              : input?.tags,
+      recordId          : input?.recordId,
+      parentContextId   : input?.parentContextId,
+      published         : input?.published,
+      dataFormat        : input?.dataFormat ?? 'application/json',
+      dateCreated       : input?.dateCreated,
+      messageTimestamp  : input?.messageTimestamp,
+      datePublished     : input?.datePublished,
+      data              : dataBytes,
       dataCid,
       dataSize,
       signer,
       attestationSigners,
-      encryptionInput    : input?.encryptionInput,
+      encryptionInput   : input?.encryptionInput,
       permissionGrantId : input?.permissionGrantId,
     };
 

--- a/tests/utils/test-data-generator.ts
+++ b/tests/utils/test-data-generator.ts
@@ -70,7 +70,7 @@ export type GenerateProtocolsConfigureInput = {
   author?: Persona;
   messageTimestamp?: string;
   protocolDefinition?: ProtocolDefinition;
-  permissionsGrantId?: string;
+  permissionGrantId?: string;
 };
 
 export type GenerateProtocolsConfigureOutput = {
@@ -82,7 +82,7 @@ export type GenerateProtocolsConfigureOutput = {
 export type GenerateProtocolsQueryInput = {
   author?: Persona;
   messageTimestamp?: string;
-  permissionsGrantId?: string;
+  permissionGrantId?: string;
   filter?: {
     protocol: string;
   }
@@ -115,7 +115,7 @@ export type GenerateRecordsWriteInput = {
   messageTimestamp?: string;
   datePublished?: string;
   encryptionInput?: EncryptionInput;
-  permissionsGrantId?: string;
+  permissionGrantId?: string;
 };
 
 export type GenerateFromRecordsWriteInput = {
@@ -308,7 +308,7 @@ export class TestDataGenerator {
       messageTimestamp   : input?.messageTimestamp,
       definition,
       signer,
-      permissionsGrantId : input?.permissionsGrantId
+      permissionGrantId : input?.permissionGrantId
     };
 
     const protocolsConfigure = await ProtocolsConfigure.create(options);
@@ -333,7 +333,7 @@ export class TestDataGenerator {
       messageTimestamp   : input?.messageTimestamp,
       filter             : input?.filter,
       signer,
-      permissionsGrantId : input?.permissionsGrantId,
+      permissionGrantId : input?.permissionGrantId,
     };
     removeUndefinedProperties(options);
 
@@ -390,7 +390,7 @@ export class TestDataGenerator {
       signer,
       attestationSigners,
       encryptionInput    : input?.encryptionInput,
-      permissionsGrantId : input?.permissionsGrantId,
+      permissionGrantId : input?.permissionGrantId,
     };
 
     const recordsWrite = await RecordsWrite.create(options);

--- a/tests/validation/json-schemas/definitions.spec.ts
+++ b/tests/validation/json-schemas/definitions.spec.ts
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 describe('date-time schema', async () => {
 
   const ajv = new Ajv.default();
-  const validateDateTime = ajv.compile(definitions.definitions['date-time']);
+  const validateDateTime = ajv.compile(definitions.$defs['date-time']);
 
   it('should accept ISO 8601 date-time strings accepted by DWN', () => {
     expect(validateDateTime('2022-04-29T10:30:00.123456Z')).to.be.true;


### PR DESCRIPTION
1. Replaced deprecated keyword 'definitions' in JSON schemas in v2020-12 standard.
1. PermissionsGrant -> PermissionGrant renaming.
1. Renamed PermissionXyzModel -> PermissionXyzData to be less misleading.
