### PR TITLE
Update error message to include reference to the correct `parentContextId`

### DIFF
--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -357,7 +357,7 @@ export class ProtocolAuthorization {
       if (declaredProtocolPath !== declaredTypeName) {
         throw new DwnError(
           DwnErrorCode.ProtocolAuthorizationParentlessIncorrectProtocolPath,
-          `Declared protocol path '${declaredProtocolPath}' is not valid for records with no parentContextId'.`
+          `Declared protocol path '${declaredProtocolPath}' is not valid for records with no parent'.`
         );
       }
 

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -357,7 +357,7 @@ export class ProtocolAuthorization {
       if (declaredProtocolPath !== declaredTypeName) {
         throw new DwnError(
           DwnErrorCode.ProtocolAuthorizationParentlessIncorrectProtocolPath,
-          `Declared protocol path '${declaredProtocolPath}' is not valid for records with no parentId'.`
+          `Declared protocol path '${declaredProtocolPath}' is not valid for records with no parentContextId'.`
         );
       }
 

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -2479,7 +2479,7 @@ export function testRecordsWriteHandler(): void {
           const reply = await dwn.processMessage(alice.did, credentialApplication.message, { dataStream: credentialApplication.dataStream });
           expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationParentlessIncorrectProtocolPath);
-          expect(reply.status.detail).to.contain('is not valid for records with no parentContextId');
+          expect(reply.status.detail).to.contain('is not valid for records with no parent');
         });
 
         it('#690 - should only allow data format of a protocol-space record to be updated to any value allowed by the protocol configuration', async () => {

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -2479,6 +2479,7 @@ export function testRecordsWriteHandler(): void {
           const reply = await dwn.processMessage(alice.did, credentialApplication.message, { dataStream: credentialApplication.dataStream });
           expect(reply.status.code).to.equal(400);
           expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationParentlessIncorrectProtocolPath);
+          expect(reply.status.detail).to.contain('is not valid for records with no parentContextId');
         });
 
         it('#690 - should only allow data format of a protocol-space record to be updated to any value allowed by the protocol configuration', async () => {


### PR DESCRIPTION
The error message that comes back with `DwnErrorCode.ProtocolAuthorizationParentlessIncorrectProtocolPath` contained a reference to the incorrect `parentId`. This PR updates the value to the correct `parentContextId` to help with debugging.