### PR TITLE
Upgrade `@web5/dids` & release `0.3.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.2.24",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/dwn-sdk-js",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",
         "@js-temporal/polyfill": "0.4.4",
         "@noble/ed25519": "2.0.0",
         "@noble/secp256k1": "2.0.0",
-        "@web5/dids": "1.0.0",
+        "@web5/dids": "1.0.1",
         "abstract-level": "1.0.3",
         "ajv": "8.12.0",
         "blockstore-core": "4.2.0",
@@ -1050,9 +1050,9 @@
       }
     },
     "node_modules/@web5/dids": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-1.0.0.tgz",
-      "integrity": "sha512-TJPRyNIuS50Za3qMHBgNDgwbJQUcVVWXm3Uc3UsDtZIpTLjYb+4LRaynlKzjRPAOR44Q185a+59//5Lyffon+Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-1.0.1.tgz",
+      "integrity": "sha512-bAc+zwTDPvtFtd8T25XD0oUmSOBmeTpYSZyBz9w/EqZPKtZOFSc5oFS5qLtrh4YDkkcBqTG5ENQlE9fXs56zIQ==",
       "dependencies": {
         "@decentralized-identity/ion-sdk": "1.0.1",
         "@dnsquery/dns-packet": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.2.24",
+  "version": "0.3.0",
   "description": "A reference implementation of https://identity.foundation/decentralized-web-node/spec/",
   "repository": {
     "type": "git",
@@ -65,7 +65,7 @@
     "@js-temporal/polyfill": "0.4.4",
     "@noble/ed25519": "2.0.0",
     "@noble/secp256k1": "2.0.0",
-    "@web5/dids": "1.0.0",
+    "@web5/dids": "1.0.1",
     "abstract-level": "1.0.3",
     "ajv": "8.12.0",
     "blockstore-core": "4.2.0",


### PR DESCRIPTION
- upgrade `@web5/dids` package to `1.0.1` in order to not cache notFoudd records
- bump `dwn-sdk-js` to `0.3.0`