### PR TITLE
Added `prune` protocol action + `ProtocolAuthorization` refactoring

### DIFF
--- a/json-schemas/interface-methods/protocol-rule-set.json
+++ b/json-schemas/interface-methods/protocol-rule-set.json
@@ -47,9 +47,11 @@
                   "type": "string",
                   "enum": [
                     "co-delete",
+                    "co-prune",
                     "co-update",
                     "create",
                     "delete",
+                    "prune",
                     "read",
                     "update"
                   ]

--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -68,7 +68,7 @@ export enum DwnErrorCode {
   ProtocolAuthorizationMissingRuleSet = 'ProtocolAuthorizationMissingRuleSet',
   ProtocolAuthorizationParentlessIncorrectProtocolPath = 'ProtocolAuthorizationParentlessIncorrectProtocolPath',
   ProtocolAuthorizationNotARole = 'ProtocolAuthorizationNotARole',
-  ProtocolAuthorizationParentNotFoundConstructingAncestorChain = 'ProtocolAuthorizationParentNotFoundConstructingAncestorChain',
+  ProtocolAuthorizationParentNotFoundConstructingRecordChain = 'ProtocolAuthorizationParentNotFoundConstructingRecordChain',
   ProtocolAuthorizationProtocolNotFound = 'ProtocolAuthorizationProtocolNotFound',
   ProtocolAuthorizationQueryWithoutRole = 'ProtocolAuthorizationQueryWithoutRole',
   ProtocolAuthorizationRoleMissingRecipient = 'ProtocolAuthorizationRoleMissingRecipient',

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -206,7 +206,7 @@ export class ProtocolAuthorization {
       tenant,
       incomingMessage,
       ruleSet,
-      [], // record chain is not relevant to subscriptions
+      [], // record chain is not relevant to queries or subscriptions
       messageStore,
     );
   }

--- a/src/core/protocol-authorization.ts
+++ b/src/core/protocol-authorization.ts
@@ -83,7 +83,7 @@ export class ProtocolAuthorization {
     if (existingInitialWrite === undefined) {
       // NOTE: we can assume this message is an initial write because an existing initial write does not exist.
       // Additionally, we check further down in the `RecordsWriteHandler` if the incoming message is an initialWrite,
-      // so we don't check explicitly here to avoid an unnecessary duplicate check.  
+      // so we don't check explicitly here to avoid an unnecessary duplicate check.
       recordChain = await ProtocolAuthorization.constructRecordChain(tenant, incomingMessage.message.descriptor.parentId, messageStore);
     } else {
       recordChain = await ProtocolAuthorization.constructRecordChain(tenant, incomingMessage.message.recordId, messageStore);

--- a/src/handlers/records-delete.ts
+++ b/src/handlers/records-delete.ts
@@ -116,21 +116,26 @@ export class RecordsDeleteHandler implements MethodHandler {
     return messageReply;
   };
 
+  /**
+   * Authorizes a RecordsDelete message.
+   *
+   * @param newestRecordsWrite Newest RecordsWrite of the record to be deleted.
+   */
   private static async authorizeRecordsDelete(
     tenant: string,
     recordsDelete: RecordsDelete,
-    recordsWriteToDelete: RecordsWrite,
+    newestRecordsWrite: RecordsWrite,
     messageStore: MessageStore
   ): Promise<void> {
 
     if (Message.isSignedByAuthorDelegate(recordsDelete.message)) {
-      await recordsDelete.authorizeDelegate(recordsWriteToDelete.message, messageStore);
+      await recordsDelete.authorizeDelegate(newestRecordsWrite.message, messageStore);
     }
 
     if (recordsDelete.author === tenant) {
       return;
-    } else if (recordsWriteToDelete.message.descriptor.protocol !== undefined) {
-      await ProtocolAuthorization.authorizeDelete(tenant, recordsDelete, recordsWriteToDelete, messageStore);
+    } else if (newestRecordsWrite.message.descriptor.protocol !== undefined) {
+      await ProtocolAuthorization.authorizeDelete(tenant, recordsDelete, newestRecordsWrite, messageStore);
     } else {
       throw new DwnError(
         DwnErrorCode.RecordsDeleteAuthorizationFailed,

--- a/src/interfaces/protocols-configure.ts
+++ b/src/interfaces/protocols-configure.ts
@@ -183,7 +183,7 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
         );
       }
 
-      // Validate that if `who === recipient` and `of === undefined`, then `can` can only contain `co-delete` and `co-update`
+      // Validate that if `who === recipient` and `of === undefined`, then `can` can only contain `co-update`, `co-delete`, and `co-prune`.
       // We do not allow `read`, `write`, or `query` in the `can` array because:
       // - `read` - Recipients are always allowed to `read`.
       // - `write` - Entails ability to create and update.
@@ -192,11 +192,14 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
       // - `query` - Only authorized using roles, so allowing direct recipients to query is outside the scope.
       if (actionRule.who === ProtocolActor.Recipient && actionRule.of === undefined) {
 
-        // throw if `can` contains a value that is not `co-update` or `co-delete`
-        if (actionRule.can.some((allowedAction) => ![ProtocolAction.CoUpdate, ProtocolAction.CoDelete].includes(allowedAction as ProtocolAction))) {
+        // throw if `can` contains a value that is not `co-update`, `co-delete`, or `co-prune`
+        const hasDisallowedAction = actionRule.can.some(
+          action => ![ProtocolAction.CoUpdate, ProtocolAction.CoDelete, ProtocolAction.CoPrune].includes(action as ProtocolAction)
+        );
+        if (hasDisallowedAction) {
           throw new DwnError(
             DwnErrorCode.ProtocolsConfigureInvalidRecipientOfAction,
-            'Rules for `recipient` without `of` property must have `can` containing only `co-update` or `co-delete`'
+            'Rules for `recipient` without `of` property must have `can` containing only `co-update`, `co-delete`, and `co-prune`.'
           );
         }
       }

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -1022,7 +1022,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
   }
 
   /**
-   * Gets the DID of the author of the given message.
+   * Gets the DID of the attesters of the given message.
    */
   public static getAttesters(message: InternalRecordsWriteMessage): string[] {
     const attestationSignatures = message.attestation?.signatures ?? [];

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -978,7 +978,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
   }
 
   /**
-   * Gets the initial write from the given list of `RecordWrite`.
+   * Gets the initial write from the given list of `RecordsWrite`.
    */
   public static async getInitialWrite(messages: GenericMessage[]): Promise<RecordsWriteMessage> {
     for (const message of messages) {

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -978,7 +978,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
   }
 
   /**
-   * Gets the initial write from the given list or record write.
+   * Gets the initial write from the given list of `RecordWrite`.
    */
   public static async getInitialWrite(messages: GenericMessage[]): Promise<RecordsWriteMessage> {
     for (const message of messages) {
@@ -987,7 +987,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
       }
     }
 
-    throw new DwnError(DwnErrorCode.RecordsWriteGetInitialWriteNotFound, `initial write is not found`);
+    throw new DwnError(DwnErrorCode.RecordsWriteGetInitialWriteNotFound, `Initial write is not found.`);
   }
 
   /**

--- a/src/types/protocols-types.ts
+++ b/src/types/protocols-types.ts
@@ -38,9 +38,11 @@ export enum ProtocolActor {
 
 export enum ProtocolAction {
   CoDelete = 'co-delete',
+  CoPrune = 'co-prune',
   CoUpdate = 'co-update',
   Create = 'create',
   Delete = 'delete',
+  Prune = 'prune',
   Query = 'query',
   Read = 'read',
   Subscribe = 'subscribe',

--- a/src/utils/records.ts
+++ b/src/utils/records.ts
@@ -480,7 +480,7 @@ export class Records {
    * Checks if the filter supports returning published records.
    */
   static filterIncludesPublishedRecords(filter: RecordsFilter): boolean {
-    // When `published` and `datePublished` range are both undefined, published records can be returned.
+    // NOTE: published records should still be returned when `published` and `datePublished` range are both undefined.
     return filter.datePublished !== undefined || filter.published !== false;
   }
 

--- a/tests/core/protocol-authorization.spec.ts
+++ b/tests/core/protocol-authorization.spec.ts
@@ -21,7 +21,7 @@ describe('ProtocolAuthorization', () => {
       messageStoreStub.query.resolves({ messages: [] }); // simulate parent not in message store
 
       await expect(ProtocolAuthorization.authorizeWrite(alice.did, recordsWrite, messageStoreStub)).to.be.rejectedWith(
-        DwnErrorCode.ProtocolAuthorizationParentNotFoundConstructingAncestorChain
+        DwnErrorCode.ProtocolAuthorizationParentNotFoundConstructingRecordChain
       );
     });
   });

--- a/tests/features/records-prune.spec.ts
+++ b/tests/features/records-prune.spec.ts
@@ -226,13 +226,8 @@ export function testRecordsPrune(): void {
           protocol  : 'http://post-protocol.xyz',
           published : true,
           types     : {
-            post: {
-              schema      : 'eph',
-              dataFormats : [
-                'application/json'
-              ]
-            },
-            attachment: { }
+            post       : { },
+            attachment : { }
           },
           structure: {
             post: {
@@ -241,14 +236,9 @@ export function testRecordsPrune(): void {
                   who : 'anyone',
                   can : [
                     'create',
+                    'prune', // allowing author to prune, but not delete
                     'read'
                   ]
-                },
-                {
-                  // allowing author to prune, but not delete
-                  who : 'author',
-                  of  : 'post',
-                  can : ['prune']
                 }
               ],
               attachment: {
@@ -280,8 +270,7 @@ export function testRecordsPrune(): void {
           signer       : Jws.createSigner(bob),
           protocol     : protocolDefinition.protocol,
           protocolPath : 'post',
-          schema       : protocolDefinition.types.post.schema,
-          dataFormat   : protocolDefinition.types.post.dataFormats[0],
+          dataFormat   : 'application/json',
           data         : postData
         };
 
@@ -418,13 +407,8 @@ export function testRecordsPrune(): void {
           protocol  : 'http://post-protocol.xyz',
           published : true,
           types     : {
-            post: {
-              schema      : 'eph',
-              dataFormats : [
-                'application/json'
-              ]
-            },
-            attachment: { }
+            post       : { },
+            attachment : { }
           },
           structure: {
             post: {
@@ -465,8 +449,7 @@ export function testRecordsPrune(): void {
           signer       : Jws.createSigner(bob),
           protocol     : protocolDefinition.protocol,
           protocolPath : 'post',
-          schema       : protocolDefinition.types.post.schema,
-          dataFormat   : protocolDefinition.types.post.dataFormats[0],
+          dataFormat   : 'application/json',
           data         : postData
         };
 
@@ -534,13 +517,8 @@ export function testRecordsPrune(): void {
           protocol  : 'http://post-protocol.xyz',
           published : true,
           types     : {
-            post: {
-              schema      : 'eph',
-              dataFormats : [
-                'application/json'
-              ]
-            },
-            attachment: { }
+            post       : { },
+            attachment : { }
           },
           structure: {
             post: {
@@ -549,14 +527,9 @@ export function testRecordsPrune(): void {
                   who : 'anyone',
                   can : [
                     'create',
+                    'prune', // allowing author to prune, but not delete
                     'read'
                   ]
-                },
-                {
-                  // allowing author to prune, but not delete
-                  who : 'author',
-                  of  : 'post',
-                  can : ['prune']
                 }
               ],
               attachment: {
@@ -588,8 +561,7 @@ export function testRecordsPrune(): void {
           signer       : Jws.createSigner(bob),
           protocol     : protocolDefinition.protocol,
           protocolPath : 'post',
-          schema       : protocolDefinition.types.post.schema,
-          dataFormat   : protocolDefinition.types.post.dataFormats[0],
+          dataFormat   : 'application/json',
           data         : postData
         };
 
@@ -646,13 +618,8 @@ export function testRecordsPrune(): void {
           protocol  : 'http://post-protocol.xyz',
           published : true,
           types     : {
-            post: {
-              schema      : 'eph',
-              dataFormats : [
-                'application/json'
-              ]
-            },
-            attachment: { }
+            post       : { },
+            attachment : { }
           },
           structure: {
             post: {
@@ -693,8 +660,7 @@ export function testRecordsPrune(): void {
           signer       : Jws.createSigner(bob),
           protocol     : protocolDefinition.protocol,
           protocolPath : 'post',
-          schema       : protocolDefinition.types.post.schema,
-          dataFormat   : protocolDefinition.types.post.dataFormats[0],
+          dataFormat   : 'application/json',
           data         : postData
         };
 

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -928,7 +928,7 @@ export function testRecordsWriteHandler(): void {
           const reply = await dwn.processMessage(tenant, message, { dataStream });
 
           expect(reply.status.code).to.equal(400);
-          expect(reply.status.detail).to.contain('initial write is not found');
+          expect(reply.status.detail).to.contain(DwnErrorCode.RecordsWriteGetInitialWriteNotFound);
         });
 
         it('should return 400 if `dateCreated` and `messageTimestamp` are not the same in an initial write', async () => {

--- a/tests/vectors/protocol-definitions/free-for-all.json
+++ b/tests/vectors/protocol-definitions/free-for-all.json
@@ -7,7 +7,8 @@
       "dataFormats": [
         "application/json"
       ]
-    }
+    },
+    "attachment": { }
   },
   "structure": {
     "post": {
@@ -17,11 +18,28 @@
           "can": [
             "create",
             "update",
+            "delete",
+            "prune",
             "read",
-            "co-delete"
+            "co-delete",
+            "co-prune"
           ]
         }
-      ]
+      ],
+      "attachment": {
+        "$actions": [
+          {
+            "who": "anyone",
+            "can": [
+              "create",
+              "update",
+              "delete",
+              "read",
+              "co-delete"
+            ]
+          }
+        ]
+      }
     }
   }
 }

--- a/tests/vectors/protocol-definitions/message.json
+++ b/tests/vectors/protocol-definitions/message.json
@@ -7,7 +7,8 @@
       "dataFormats": [
         "text/plain"
       ]
-    }
+    },
+    "attachment": { }
   },
   "structure": {
     "message": {
@@ -19,7 +20,18 @@
             "update"
           ]
         }
-      ]
+      ],
+      "attachment": {
+        "$actions": [
+          {
+            "who": "anyone",
+            "can": [
+              "create",
+              "update"
+            ]
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
1. Added support for `prune` protocol action.
1. Renamed "ancestor chain" to "record chain" because the chain often contains not just the ancestor records, but also record in concern which leads to confusion.
1. Simplified context and implementation of `constructRecordChain()` 
1. Refactored `authorizeAgainstAllowedActions()` to make it more easily understood.