### PR TITLE
Updated GitHub action versions

### DIFF
--- a/.github/workflows/document-gen.yml
+++ b/.github/workflows/document-gen.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
 
       - name: install dependencies
         run: |

--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -24,9 +24,9 @@ jobs:
   security-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js 18.16.0
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.16.0
       - run: npm audit
@@ -38,9 +38,9 @@ jobs:
       matrix:
         node-version: [18.16.0, 20.3.0]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       # https://docs.npmjs.com/cli/v8/commands/npm-ci
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/npm-publish-unstable.yml
+++ b/.github/workflows/npm-publish-unstable.yml
@@ -11,8 +11,8 @@ jobs:
   publish-npm-unstable:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.8.0
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,8 +11,8 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.8.0
           registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
An attempt to fix these warnings when GitHub actions are run:

<img width="1114" alt="image" src="https://github.com/TBD54566975/dwn-sdk-js/assets/17891086/b45aa920-bef6-4880-afcd-166d58dc0ce4">
