### PR TITLE
upgrade `@web5/dids` to `v1.0.2` which includes `did:ion` updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@js-temporal/polyfill": "0.4.4",
         "@noble/ed25519": "2.0.0",
         "@noble/secp256k1": "2.0.0",
-        "@web5/dids": "1.0.1",
+        "@web5/dids": "1.0.2",
         "abstract-level": "1.0.3",
         "ajv": "8.12.0",
         "blockstore-core": "4.2.0",
@@ -129,15 +129,14 @@
       }
     },
     "node_modules/@decentralized-identity/ion-sdk": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@decentralized-identity/ion-sdk/-/ion-sdk-1.0.1.tgz",
-      "integrity": "sha512-+P+DXcRSFjsEsI5KIqUmVjpzgUT28B2lWpTO+IxiBcfibAN/1Sg20NebGTO/+serz2CnSZf95N2a1OZ6eXypGQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@decentralized-identity/ion-sdk/-/ion-sdk-1.0.4.tgz",
+      "integrity": "sha512-pOWrlTH5ChxUKRHOgfG2ZeTioWEFJXADyErCQOJ0BqYNDKfP+CM09Vss+9ei6PNOABQlcDn0mEDFZtpO+DXl8A==",
       "dependencies": {
         "@noble/ed25519": "^2.0.0",
         "@noble/secp256k1": "^2.0.0",
         "canonicalize": "^2.0.0",
-        "multiformats": "^12.0.1",
-        "multihashes": "^4.0.3",
+        "multiformats": "^12.1.3",
         "uri-js": "^4.4.1"
       }
     },
@@ -422,11 +421,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
-    },
-    "node_modules/@multiformats/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
     },
     "node_modules/@multiformats/murmur3": {
       "version": "2.1.5",
@@ -1370,11 +1364,11 @@
       }
     },
     "node_modules/@web5/dids": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-1.0.1.tgz",
-      "integrity": "sha512-bAc+zwTDPvtFtd8T25XD0oUmSOBmeTpYSZyBz9w/EqZPKtZOFSc5oFS5qLtrh4YDkkcBqTG5ENQlE9fXs56zIQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-1.0.2.tgz",
+      "integrity": "sha512-WhHHThdpouiexj8m+JbOd+emXc5o1G8u38HybYR2l4i8DHiCUVWWBYoDBYYAbgLy0ebddD/sne4yJBqxW1dyGQ==",
       "dependencies": {
-        "@decentralized-identity/ion-sdk": "1.0.1",
+        "@decentralized-identity/ion-sdk": "1.0.4",
         "@dnsquery/dns-packet": "6.1.1",
         "@web5/common": "1.0.0",
         "@web5/crypto": "1.0.0",
@@ -5898,19 +5892,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "node_modules/multibase": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-      "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "@multiformats/base-x": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/multiformats": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
@@ -5919,38 +5900,6 @@
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
-    },
-    "node_modules/multihashes": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
-      "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
-      "dependencies": {
-        "multibase": "^4.0.1",
-        "uint8arrays": "^3.0.0",
-        "varint": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/multihashes/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-    },
-    "node_modules/multihashes/node_modules/uint8arrays": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
-      "dependencies": {
-        "multiformats": "^9.4.2"
-      }
-    },
-    "node_modules/multihashes/node_modules/varint": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
     },
     "node_modules/murmurhash3js-revisited": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@js-temporal/polyfill": "0.4.4",
     "@noble/ed25519": "2.0.0",
     "@noble/secp256k1": "2.0.0",
-    "@web5/dids": "1.0.1",
+    "@web5/dids": "1.0.2",
     "abstract-level": "1.0.3",
     "ajv": "8.12.0",
     "blockstore-core": "4.2.0",


### PR DESCRIPTION
As per @shamilovtim there was an update to the ION pacakge within `@web5/dids`, this will allow bubbling it up to `@web5/agent`