### PR TITLE
release `v0.3.3` of `dwn-sdk-js`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/dwn-sdk-js",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A reference implementation of https://identity.foundation/decentralized-web-node/spec/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release `v0.3.3` which includes:
- util updates to `getAuthor` of `Record` to support both `RecordsWrite` and `RecordsDelete`
- bump dependency version for `@web5/dids` to `v1.0.2`
- Protocol rules associated with pruning records.