### PR TITLE
Replaced bespoke key derivation algorithm to use RFC 5869 HKDF

### DIFF
--- a/json-schemas/interface-methods/protocol-rule-set.json
+++ b/json-schemas/interface-methods/protocol-rule-set.json
@@ -14,7 +14,11 @@
         "publicKeyJwk": {
           "$ref": "https://identity.foundation/dwn/json-schemas/public-jwk.json"
         }
-      }
+      },
+      "required": [
+        "rootKeyId",
+        "publicKeyJwk"
+      ]
     },
     "$actions": {
       "type": "array",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",
         "@js-temporal/polyfill": "0.4.4",
+        "@noble/ciphers": "0.5.3",
         "@noble/ed25519": "2.0.0",
         "@noble/secp256k1": "2.0.0",
         "@web5/dids": "1.0.2",
@@ -75,7 +76,7 @@
         "mockdate": "3.0.5",
         "ms": "2.1.3",
         "node-stdlib-browser": "1.2.0",
-        "playwright": "1.43.1",
+        "playwright": "^1.44.0",
         "rimraf": "^3.0.2",
         "search-index": "3.4.0",
         "sinon": "13.0.1",
@@ -445,9 +446,9 @@
       }
     },
     "node_modules/@noble/ciphers": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.3.0.tgz",
-      "integrity": "sha512-ldbrnOjmNRwFdXcTM6uXDcxpMIFrbzAWNnpBPp4oTJTFF0XByGD6vf45WrehZGXRQTRVV+Zm8YP+EgEf+e4cWA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.5.3.tgz",
+      "integrity": "sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -2975,6 +2976,14 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/eciesjs/node_modules/@noble/ciphers": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.3.0.tgz",
+      "integrity": "sha512-ldbrnOjmNRwFdXcTM6uXDcxpMIFrbzAWNnpBPp4oTJTFF0XByGD6vf45WrehZGXRQTRVV+Zm8YP+EgEf+e4cWA==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/ee-first": {
@@ -6563,12 +6572,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.1.tgz",
-      "integrity": "sha512-V7SoH0ai2kNt1Md9E3Gwas5B9m8KR2GVvwZnAI6Pg0m3sh7UvgiYhRrhsziCmqMJNouPckiOhk8T+9bSAK0VIA==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
+      "integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.43.1"
+        "playwright-core": "1.44.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -6581,9 +6590,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.1.tgz",
-      "integrity": "sha512-EI36Mto2Vrx6VF7rm708qSnesVQKbxEWvPrfA1IPY6HgczBplDx7ENtx+K2n4kJ41sLLkuGfmb0ZLSSXlDhqPg==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
+      "integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@ipld/dag-cbor": "9.0.3",
     "@js-temporal/polyfill": "0.4.4",
+    "@noble/ciphers": "0.5.3",
     "@noble/ed25519": "2.0.0",
     "@noble/secp256k1": "2.0.0",
     "@web5/dids": "1.0.2",
@@ -127,7 +128,7 @@
     "mockdate": "3.0.5",
     "ms": "2.1.3",
     "node-stdlib-browser": "1.2.0",
-    "playwright": "1.43.1",
+    "playwright": "^1.44.0",
     "rimraf": "^3.0.2",
     "search-index": "3.4.0",
     "sinon": "13.0.1",

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -837,6 +837,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
 
   /**
    * Creates the `encryption` property if encryption input is given. Else `undefined` is returned.
+   * @param descriptor Descriptor of the `RecordsWrite` message which contains the information need by key path derivation schemes.
    */
   private static async createEncryptionProperty(
     descriptor: RecordsWriteDescriptor,

--- a/src/types/protocols-types.ts
+++ b/src/types/protocols-types.ts
@@ -103,6 +103,12 @@ export type ProtocolActionRule = {
  * Config for protocol-path encryption scheme.
  */
 export type ProtocolPathEncryption = {
+
+  /**
+   * The ID of the root key that derives the public key at this protocol path for encrypting the symmetric key used for data encryption.
+   */
+  rootKeyId: string;
+
   /**
    * Public key for encrypting the symmetric key used for data encryption.
    */

--- a/src/utils/hd-key.ts
+++ b/src/utils/hd-key.ts
@@ -115,8 +115,7 @@ export class HdKey {
   }
 
   /**
-   * Parses the given key derivation path.
-   * @returns Path segments if successfully validate the derivation path.
+   * Validates that no empty strings exist within the derivation path segments array.
    * @throws {DwnError} with `DwnErrorCode.HdKeyDerivationPathInvalid` if derivation path fails validation.
    */
   private static validateKeyDerivationPath(pathSegments: string[]): void {

--- a/src/utils/hd-key.ts
+++ b/src/utils/hd-key.ts
@@ -72,7 +72,6 @@ export class HdKey {
       currentPrivateKey = await HdKey.deriveKeyUsingHkdf({
         hashAlgorithm      : 'SHA-256',
         initialKeyMaterial : currentPrivateKey,
-        salt               : undefined,
         info               : segmentBytes, // use the segment as the application specific info for key derivation
         keyLengthInBytes   : 32 // 32 bytes = 256 bits
       });
@@ -88,12 +87,10 @@ export class HdKey {
   public static async deriveKeyUsingHkdf(params: {
     hashAlgorithm: 'SHA-256' | 'SHA-384' | 'SHA-512',
     initialKeyMaterial: Uint8Array,
-    salt: Uint8Array | undefined,
     info: Uint8Array,
     keyLengthInBytes: number
   }): Promise<Uint8Array> {
-    const { hashAlgorithm, initialKeyMaterial, salt, info, keyLengthInBytes } = params;
-    const finalSalt = salt ?? new Uint8Array(0); // if salt is not provided, use an empty array
+    const { hashAlgorithm, initialKeyMaterial, info, keyLengthInBytes } = params;
 
     const webCrypto = getWebcryptoSubtle() as SubtleCrypto;
 
@@ -102,7 +99,12 @@ export class HdKey {
 
     // Derive the bytes using the Web Crypto API.
     const derivedKeyBuffer = await crypto.subtle.deriveBits(
-      { name: 'HKDF', hash: hashAlgorithm, salt: finalSalt, info },
+      {
+        name : 'HKDF',
+        hash : hashAlgorithm,
+        salt : new Uint8Array(0), // `info` should be sufficient in our use case
+        info
+      },
       webCryptoKey,
       keyLengthInBytes * 8 // convert from bytes to bits
     );

--- a/src/utils/records.ts
+++ b/src/utils/records.ts
@@ -9,13 +9,13 @@ import { Encoder } from './encoder.js';
 import { Encryption } from './encryption.js';
 import { FilterUtility } from './filter.js';
 import { Jws } from './jws.js';
-import { KeyDerivationScheme } from './hd-key.js';
 import { Message } from '../core/message.js';
 import { PermissionGrant } from '../protocols/permission-grant.js';
 import { removeUndefinedProperties } from './object.js';
 import { Secp256k1 } from './secp256k1.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
+import { HdKey, KeyDerivationScheme } from './hd-key.js';
 import { normalizeProtocolUrl, normalizeSchemaUrl } from './url.js';
 
 /**
@@ -226,7 +226,7 @@ export class Records {
 
     const subDerivationPath = fullDescendantDerivationPath.slice(ancestorPrivateKeyDerivationPath.length);
     const ancestorPrivateKeyBytes = Secp256k1.privateJwkToBytes(ancestorPrivateKey.derivedPrivateKey);
-    const leafPrivateKey = await Secp256k1.derivePrivateKey(ancestorPrivateKeyBytes, subDerivationPath);
+    const leafPrivateKey = await HdKey.derivePrivateKeyBytes(ancestorPrivateKeyBytes, subDerivationPath);
 
     return leafPrivateKey;
   }

--- a/tests/utils/hd-key.spec.ts
+++ b/tests/utils/hd-key.spec.ts
@@ -1,0 +1,31 @@
+import { ArrayUtility } from '../../src/utils/array.js';
+import { DwnErrorCode } from '../../src/core/dwn-error.js';
+import { expect } from 'chai';
+import { HdKey } from '../../src/utils/hd-key.js';
+import { Secp256k1 } from '../../src/utils/secp256k1.js';
+
+describe('HdKey', () => {
+  describe('derivePrivateKeyBytes()', () => {
+    it('should be able to derive same key using different ancestor along the chain path', async () => {
+      const { privateKey } = await Secp256k1.generateKeyPairRaw();
+
+      const fullPathToG = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
+      const fullPathToD = ['a', 'b', 'c', 'd'];
+      const relativePathFromDToG = ['e', 'f', 'g'];
+
+      // testing private key derivation from different ancestor in the same chain
+      const privateKeyG = await HdKey.derivePrivateKeyBytes(privateKey, fullPathToG);
+      const privateKeyD = await HdKey.derivePrivateKeyBytes(privateKey, fullPathToD);
+      const privateKeyGFromD = await HdKey.derivePrivateKeyBytes(privateKeyD, relativePathFromDToG);
+      expect(ArrayUtility.byteArraysEqual(privateKeyG, privateKeyGFromD)).to.be.true;
+    });
+
+    it('should throw if derivation path is invalid', async () => {
+      const { privateKey } = await Secp256k1.generateKeyPairRaw();
+
+      const invalidPath = ['should not have segment with empty string', ''];
+
+      await expect(HdKey.derivePrivateKeyBytes(privateKey, invalidPath)).to.be.rejectedWith(DwnErrorCode.HdKeyDerivationPathInvalid);
+    });
+  });
+});

--- a/tests/utils/secp256k1.spec.ts
+++ b/tests/utils/secp256k1.spec.ts
@@ -1,4 +1,3 @@
-import { ArrayUtility } from '../../src/utils/array.js';
 import { base64url } from 'multiformats/bases/base64';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
 import { expect } from 'chai';
@@ -46,36 +45,6 @@ describe('Secp256k1', () => {
       const signatureBytes = await Secp256k1.sign(contentBytes, privateJwk);
 
       expect(signatureBytes.length).to.equal(64); // DER format would be 70 bytes
-    });
-  });
-
-  describe('derivePublic/PrivateKey()', () => {
-    it('should be able to derive same key using different ancestor along the chain path', async () => {
-      const { privateKey } = await Secp256k1.generateKeyPairRaw();
-
-      const fullPathToG = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
-      const fullPathToD = ['a', 'b', 'c', 'd'];
-      const relativePathFromDToG = ['e', 'f', 'g'];
-
-      // testing private key derivation from different ancestor in the same chain
-      const privateKeyG = await Secp256k1.derivePrivateKey(privateKey, fullPathToG);
-      const privateKeyD = await Secp256k1.derivePrivateKey(privateKey, fullPathToD);
-      const privateKeyGFromD = await Secp256k1.derivePrivateKey(privateKeyD, relativePathFromDToG);
-      expect(ArrayUtility.byteArraysEqual(privateKeyG, privateKeyGFromD)).to.be.true;
-
-      // testing public key derivation from different ancestor private key in the same chain
-      const publicKeyG = await Secp256k1.derivePublicKey(privateKey, fullPathToG);
-      const publicKeyGFromD = await Secp256k1.derivePublicKey(privateKeyD, relativePathFromDToG);
-      expect(ArrayUtility.byteArraysEqual(publicKeyG, publicKeyGFromD)).to.be.true;
-    });
-
-    it('should throw if derivation path is invalid', async () => {
-      const { publicKey, privateKey } = await Secp256k1.generateKeyPairRaw();
-
-      const invalidPath = ['should not have segment with empty string', ''];
-
-      await expect(Secp256k1.derivePublicKey(publicKey, invalidPath)).to.be.rejectedWith(DwnErrorCode.HdKeyDerivationPathInvalid);
-      await expect(Secp256k1.derivePrivateKey(privateKey, invalidPath)).to.be.rejectedWith(DwnErrorCode.HdKeyDerivationPathInvalid);
     });
   });
 });


### PR DESCRIPTION
1. Replaced bespoke key derivation algorithm to use RFC 5869 HKDF to align with the encryption text in DWN spec (that I wrote yesterday and merged this morning 🤣)
2. Other minor updates to align with the DWN spec.
3. Refactoring.