### PR TITLE
upgrade dids package to latest v1.1.0, update release to v0.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/dwn-sdk-js",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",
@@ -14,7 +14,7 @@
         "@noble/ciphers": "0.5.3",
         "@noble/ed25519": "2.0.0",
         "@noble/secp256k1": "2.0.0",
-        "@web5/dids": "1.0.3",
+        "@web5/dids": "1.1.0",
         "abstract-level": "1.0.3",
         "ajv": "8.12.0",
         "blockstore-core": "4.2.0",
@@ -1365,9 +1365,9 @@
       }
     },
     "node_modules/@web5/dids": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-1.0.3.tgz",
-      "integrity": "sha512-XRqONYJg/uZmMpYMX2hNvdYWrlNgy8/wiKApzTRGausgiefXfkDSpBpYzGKThADBeim5Q6RTnS0VnSza4QeGEg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-1.1.0.tgz",
+      "integrity": "sha512-d9pKf/DW+ziUiV5g3McC71utyAhQyT1tYGPbQSYWt2ji6FHGNC6tffHMfLXXK/W+vbwV3eNTn06JqTXRaYhxBA==",
       "dependencies": {
         "@decentralized-identity/ion-sdk": "1.0.4",
         "@dnsquery/dns-packet": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/dwn-sdk-js",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A reference implementation of https://identity.foundation/decentralized-web-node/spec/",
   "repository": {
     "type": "git",
@@ -66,7 +66,7 @@
     "@noble/ciphers": "0.5.3",
     "@noble/ed25519": "2.0.0",
     "@noble/secp256k1": "2.0.0",
-    "@web5/dids": "1.0.3",
+    "@web5/dids": "1.1.0",
     "abstract-level": "1.0.3",
     "ajv": "8.12.0",
     "blockstore-core": "4.2.0",


### PR DESCRIPTION
- upgrade `@web5/dids` package to `v1.1.0` which allows for optionally setting `VM Key IDs`
- release `v0.3.5` of this package