### PR TITLE
RecordsPermissionScope Requests must be scoped to a protocol

### DIFF
--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -48,6 +48,7 @@ export enum DwnErrorCode {
   ParseCidCodecNotSupported = 'ParseCidCodecNotSupported',
   ParseCidMultihashNotSupported = 'ParseCidMultihashNotSupported',
   PermissionsProtocolCreateGrantRecordsScopeMissingProtocol = 'PermissionsProtocolCreateGrantRecordsScopeMissingProtocol',
+  PermissionsProtocolCreateRequestRecordsScopeMissingProtocol = 'PermissionsProtocolCreateRequestRecordsScopeMissingProtocol',
   PermissionsProtocolValidateSchemaUnexpectedRecord = 'PermissionsProtocolValidateSchemaUnexpectedRecord',
   PermissionsProtocolValidateScopeContextIdProhibitedProperties = 'PermissionsProtocolValidateScopeContextIdProhibitedProperties',
   PermissionsProtocolValidateScopeProtocolMismatch = 'PermissionsProtocolValidateScopeProtocolMismatch',

--- a/src/core/records-grant-authorization.ts
+++ b/src/core/records-grant-authorization.ts
@@ -31,7 +31,7 @@ export class RecordsGrantAuthorization {
     });
 
     // NOTE: validated the invoked permission is for Records in GrantAuthorization.performBaseValidation()
-    RecordsGrantAuthorization.verifyScope(recordsWriteMessage, permissionGrant.scope as RecordsPermissionScope);
+    RecordsGrantAuthorization.verifyProtocolRecordScope(recordsWriteMessage, permissionGrant.scope as RecordsPermissionScope);
 
     RecordsGrantAuthorization.verifyConditions(recordsWriteMessage, permissionGrant.conditions);
   }
@@ -61,7 +61,7 @@ export class RecordsGrantAuthorization {
     });
 
     // NOTE: validated the invoked permission is for Records in GrantAuthorization.performBaseValidation()
-    RecordsGrantAuthorization.verifyScope(recordsWriteMessageToBeRead, permissionGrant.scope as RecordsPermissionScope);
+    RecordsGrantAuthorization.verifyProtocolRecordScope(recordsWriteMessageToBeRead, permissionGrant.scope as RecordsPermissionScope);
   }
 
   /**
@@ -138,9 +138,9 @@ export class RecordsGrantAuthorization {
   }
 
   /**
-   * Verifies a record against the scope of the given grant.
+   * Verifies a protocol record against the scope of the given grant.
    */
-  private static verifyScope(
+  private static verifyProtocolRecordScope(
     recordsWriteMessage: RecordsWriteMessage,
     grantScope: RecordsPermissionScope
   ): void {

--- a/src/core/records-grant-authorization.ts
+++ b/src/core/records-grant-authorization.ts
@@ -31,7 +31,7 @@ export class RecordsGrantAuthorization {
     });
 
     // NOTE: validated the invoked permission is for Records in GrantAuthorization.performBaseValidation()
-    RecordsGrantAuthorization.verifyProtocolRecordScope(recordsWriteMessage, permissionGrant.scope as RecordsPermissionScope);
+    RecordsGrantAuthorization.verifyScope(recordsWriteMessage, permissionGrant.scope as RecordsPermissionScope);
 
     RecordsGrantAuthorization.verifyConditions(recordsWriteMessage, permissionGrant.conditions);
   }
@@ -61,7 +61,7 @@ export class RecordsGrantAuthorization {
     });
 
     // NOTE: validated the invoked permission is for Records in GrantAuthorization.performBaseValidation()
-    RecordsGrantAuthorization.verifyProtocolRecordScope(recordsWriteMessageToBeRead, permissionGrant.scope as RecordsPermissionScope);
+    RecordsGrantAuthorization.verifyScope(recordsWriteMessageToBeRead, permissionGrant.scope as RecordsPermissionScope);
   }
 
   /**
@@ -138,9 +138,9 @@ export class RecordsGrantAuthorization {
   }
 
   /**
-   * Verifies a protocol record against the scope of the given grant.
+   * Verifies a record against the scope of the given grant.
    */
-  private static verifyProtocolRecordScope(
+  private static verifyScope(
     recordsWriteMessage: RecordsWriteMessage,
     grantScope: RecordsPermissionScope
   ): void {

--- a/src/protocols/permissions.ts
+++ b/src/protocols/permissions.ts
@@ -304,6 +304,7 @@ export class PermissionsProtocol {
     const dataObject = JSON.parse(dataString);
     if (recordsWriteMessage.descriptor.protocolPath === PermissionsProtocol.requestPath) {
       validateJsonSchema('PermissionRequestData', dataObject);
+      PermissionsProtocol.validateScope(dataObject.scope, recordsWriteMessage);
     } else if (recordsWriteMessage.descriptor.protocolPath === PermissionsProtocol.grantPath) {
       validateJsonSchema('PermissionGrantData', dataObject);
 

--- a/src/protocols/permissions.ts
+++ b/src/protocols/permissions.ts
@@ -164,6 +164,14 @@ export class PermissionsProtocol {
     permissionRequestData: PermissionRequestData,
     permissionRequestBytes: Uint8Array
   }> {
+
+    if (this.isRecordPermissionScope(options.scope) && options.scope.protocol === undefined) {
+      throw new DwnError(
+        DwnErrorCode.PermissionsProtocolCreateRequestRecordsScopeMissingProtocol,
+        'Permission revokes for Records must have a scope with a `protocol` property'
+      );
+    }
+
     const scope = PermissionsProtocol.normalizePermissionScope(options.scope);
 
     const permissionRequestData: PermissionRequestData = {
@@ -173,6 +181,13 @@ export class PermissionsProtocol {
       conditions  : options.conditions,
     };
 
+    let permissionTags = undefined;
+    if (this.isRecordPermissionScope(scope)) {
+      permissionTags = {
+        protocol: scope.protocol
+      };
+    }
+
     const permissionRequestBytes = Encoder.objectToBytes(permissionRequestData);
     const recordsWrite = await RecordsWrite.create({
       signer           : options.signer,
@@ -181,6 +196,7 @@ export class PermissionsProtocol {
       protocolPath     : PermissionsProtocol.requestPath,
       dataFormat       : 'application/json',
       data             : permissionRequestBytes,
+      tags             : permissionTags,
     });
 
     return {

--- a/src/protocols/permissions.ts
+++ b/src/protocols/permissions.ts
@@ -303,8 +303,9 @@ export class PermissionsProtocol {
     const dataString = Encoder.bytesToString(dataBytes);
     const dataObject = JSON.parse(dataString);
     if (recordsWriteMessage.descriptor.protocolPath === PermissionsProtocol.requestPath) {
-      validateJsonSchema('PermissionRequestData', dataObject);
-      PermissionsProtocol.validateScope(dataObject.scope, recordsWriteMessage);
+      const permissionRequestData = dataObject as PermissionRequestData;
+      validateJsonSchema('PermissionRequestData', permissionRequestData);
+      PermissionsProtocol.validateScope(permissionRequestData.scope, recordsWriteMessage);
     } else if (recordsWriteMessage.descriptor.protocolPath === PermissionsProtocol.grantPath) {
       validateJsonSchema('PermissionGrantData', dataObject);
 

--- a/src/protocols/permissions.ts
+++ b/src/protocols/permissions.ts
@@ -168,7 +168,7 @@ export class PermissionsProtocol {
     if (this.isRecordPermissionScope(options.scope) && options.scope.protocol === undefined) {
       throw new DwnError(
         DwnErrorCode.PermissionsProtocolCreateRequestRecordsScopeMissingProtocol,
-        'Permission revokes for Records must have a scope with a `protocol` property'
+        'Permission request for Records must have a scope with a `protocol` property'
       );
     }
 

--- a/tests/features/permissions.spec.ts
+++ b/tests/features/permissions.spec.ts
@@ -81,6 +81,7 @@ export function testPermissions(): void {
         method    : DwnMethodName.Write,
         protocol  : `any-protocol`
       };
+
       const requestToAlice = await PermissionsProtocol.createRequest({
         signer      : Jws.createSigner(bob),
         description : `Requesting to write to Alice's DWN`,
@@ -208,7 +209,25 @@ export function testPermissions(): void {
       expect(revocationReadReply2.record?.recordId).to.equal(revokeWrite.recordsWrite.message.recordId);
     });
 
-    it('should fail if a RecordsPermissionScope is provided without a protocol', async () => {
+    it('should fail if a RecordsPermissionScope request is created without a protocol', async () => {
+      const bob = await TestDataGenerator.generateDidKeyPersona();
+
+      const permissionScope = {
+        interface : DwnInterfaceName.Records,
+        method    : DwnMethodName.Write
+      };
+
+      const grantWrite = PermissionsProtocol.createRequest({
+        signer      : Jws.createSigner(bob),
+        description : `Requesting to write to Alice's DWN`,
+        delegated   : false,
+        scope       : permissionScope as any // explicity as any to test the validation
+      });
+
+      expect(grantWrite).to.eventually.be.rejectedWith(DwnErrorCode.PermissionsProtocolCreateGrantRecordsScopeMissingProtocol);
+    });
+
+    it('should fail if a RecordsPermissionScope grant is created without a protocol', async () => {
       const alice = await TestDataGenerator.generateDidKeyPersona();
       const bob = await TestDataGenerator.generateDidKeyPersona();
 

--- a/tests/features/permissions.spec.ts
+++ b/tests/features/permissions.spec.ts
@@ -224,7 +224,7 @@ export function testPermissions(): void {
         delegated   : false,
         scope       : permissionScope as any // explicity as any to test the validation
       });
-      expect(requestWrite).to.eventually.be.rejectedWith(DwnErrorCode.PermissionsProtocolCreateGrantRecordsScopeMissingProtocol);
+      await expect(requestWrite).to.eventually.be.rejectedWith(DwnErrorCode.PermissionsProtocolCreateRequestRecordsScopeMissingProtocol);
 
 
       const grantWrite = PermissionsProtocol.createGrant({
@@ -234,7 +234,7 @@ export function testPermissions(): void {
         grantedTo   : bob.did,
         scope       : permissionScope as any // explicity as any to test the validation
       });
-      expect(grantWrite).to.eventually.be.rejectedWith(DwnErrorCode.PermissionsProtocolCreateGrantRecordsScopeMissingProtocol);
+      await expect(grantWrite).to.eventually.be.rejectedWith(DwnErrorCode.PermissionsProtocolCreateGrantRecordsScopeMissingProtocol);
     });
 
     it('should fail if an invalid protocolPath is used during Permissions schema validation', async () => {
@@ -316,7 +316,7 @@ export function testPermissions(): void {
           data         : Encoder.stringToBytes(JSON.stringify({})),
           tags         : { someTag: 'someValue' } // not a protocol tag
         });
-        
+
         expect(
           () => PermissionsProtocol['validateScope'](permissionScope, requestWrite.message)
         ).to.throw(DwnErrorCode.PermissionsProtocolValidateScopeMissingProtocolTag);

--- a/tests/features/permissions.spec.ts
+++ b/tests/features/permissions.spec.ts
@@ -247,13 +247,9 @@ export function testPermissions(): void {
         data         : Encoder.stringToBytes(JSON.stringify({}))
       });
 
-      try {
-        PermissionsProtocol.validateSchema(message, dataBytes!);
-        expect.fail('Expected to throw');
-      } catch (error:any) {
-        expect(error.message).to.include(DwnErrorCode.PermissionsProtocolValidateSchemaUnexpectedRecord);
-        expect(error.message).to.include('invalid/path');
-      }
+      expect(
+        () => PermissionsProtocol.validateSchema(message, dataBytes!)
+      ).to.throw(DwnErrorCode.PermissionsProtocolValidateSchemaUnexpectedRecord);
     });
 
     describe('validateScope', async () => {
@@ -320,13 +316,10 @@ export function testPermissions(): void {
           data         : Encoder.stringToBytes(JSON.stringify({})),
           tags         : { someTag: 'someValue' } // not a protocol tag
         });
-
-        try {
-          PermissionsProtocol['validateScope'](permissionScope, requestWrite.message);
-          expect.fail('Expected to throw');
-        } catch (error:any) {
-          expect(error.message).to.include(DwnErrorCode.PermissionsProtocolValidateScopeMissingProtocolTag);
-        }
+        
+        expect(
+          () => PermissionsProtocol['validateScope'](permissionScope, requestWrite.message)
+        ).to.throw(DwnErrorCode.PermissionsProtocolValidateScopeMissingProtocolTag);
 
         // create a permission grant without a protocol tag
         const grantRecordsWrite = await TestDataGenerator.generateRecordsWrite({
@@ -359,12 +352,9 @@ export function testPermissions(): void {
           data         : Encoder.stringToBytes(JSON.stringify({}))
         });
 
-        try {
-          PermissionsProtocol['validateScope'](permissionScope, requestWrite.message);
-          expect.fail('Expected to throw');
-        } catch (error:any) {
-          expect(error.message).to.include(DwnErrorCode.PermissionsProtocolValidateScopeMissingProtocolTag);
-        }
+        expect(
+          () => PermissionsProtocol['validateScope'](permissionScope, requestWrite.message)
+        ).to.throw(DwnErrorCode.PermissionsProtocolValidateScopeMissingProtocolTag);
 
         // create a permission grant without a protocol tag
         const grantRecordsWrite = await TestDataGenerator.generateRecordsWrite({
@@ -398,12 +388,9 @@ export function testPermissions(): void {
           tags         : { protocol: 'https://example.com/protocol/invalid' }
         });
 
-        try {
-          PermissionsProtocol['validateScope'](permissionScope, requestWrite.message);
-          expect.fail('Expected to throw');
-        } catch (error:any) {
-          expect(error.message).to.include(DwnErrorCode.PermissionsProtocolValidateScopeProtocolMismatch);
-        }
+        expect(
+          () => PermissionsProtocol['validateScope'](permissionScope, requestWrite.message)
+        ).to.throw(DwnErrorCode.PermissionsProtocolValidateScopeProtocolMismatch);
 
         // create a permission grant with a protocol tag that does not match the scope
         const grantRecordsWrite = await TestDataGenerator.generateRecordsWrite({
@@ -439,12 +426,9 @@ export function testPermissions(): void {
           tags         : { protocol: 'https://example.com/protocol/test' }
         });
 
-        try {
-          PermissionsProtocol['validateScope'](permissionScope, requestRecordsWrite.message);
-          expect.fail('Expected to throw');
-        } catch (error:any) {
-          expect(error.message).to.include(DwnErrorCode.PermissionsProtocolValidateScopeContextIdProhibitedProperties);
-        }
+        expect(
+          () => PermissionsProtocol['validateScope'](permissionScope, requestRecordsWrite.message)
+        ).to.throw(DwnErrorCode.PermissionsProtocolValidateScopeContextIdProhibitedProperties);
 
         // create a permission grant with a scope that has both protocolPath and contextId
         const grantRecordsWrite = await TestDataGenerator.generateRecordsWrite({

--- a/tests/features/records-tags.spec.ts
+++ b/tests/features/records-tags.spec.ts
@@ -155,7 +155,7 @@ export function testRecordsTags(): void {
               protocolDefinition : invalidSchemaProtocol,
             });
 
-            expect(protocolConfigure).to.eventually.be.rejectedWith(DwnErrorCode.ProtocolsConfigureInvalidTagSchema);
+            await expect(protocolConfigure).to.eventually.be.rejectedWith(DwnErrorCode.ProtocolsConfigureInvalidTagSchema);
           });
 
           it('should reject tags that have invalid schema definitions during process', async () => {


### PR DESCRIPTION
Enforce `RecordsPermissionScope` validation on `createGrant`