### PR TITLE
RecordsPermissionScope Revocation must be scoped to a protocol

### DIFF
--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -53,6 +53,7 @@ export enum DwnErrorCode {
   PermissionsProtocolValidateScopeContextIdProhibitedProperties = 'PermissionsProtocolValidateScopeContextIdProhibitedProperties',
   PermissionsProtocolValidateScopeProtocolMismatch = 'PermissionsProtocolValidateScopeProtocolMismatch',
   PermissionsProtocolValidateScopeMissingProtocolTag = 'PermissionsProtocolValidateScopeMissingProtocolTag',
+  PermissionsProtocolValidateRevocationProtocolTagMismatch = 'PermissionsProtocolValidateRevocationProtocolTagMismatch',
   PrivateKeySignerUnableToDeduceAlgorithm = 'PrivateKeySignerUnableToDeduceAlgorithm',
   PrivateKeySignerUnableToDeduceKeyId = 'PrivateKeySignerUnableToDeduceKeyId',
   PrivateKeySignerUnsupportedCurve = 'PrivateKeySignerUnsupportedCurve',

--- a/src/core/records-grant-authorization.ts
+++ b/src/core/records-grant-authorization.ts
@@ -31,7 +31,7 @@ export class RecordsGrantAuthorization {
     });
 
     // NOTE: validated the invoked permission is for Records in GrantAuthorization.performBaseValidation()
-    RecordsGrantAuthorization.verifyScope(recordsWriteMessage, permissionGrant.scope as RecordsPermissionScope);
+    RecordsGrantAuthorization.verifyProtocolRecordScope(recordsWriteMessage, permissionGrant.scope as RecordsPermissionScope);
 
     RecordsGrantAuthorization.verifyConditions(recordsWriteMessage, permissionGrant.conditions);
   }
@@ -61,7 +61,7 @@ export class RecordsGrantAuthorization {
     });
 
     // NOTE: validated the invoked permission is for Records in GrantAuthorization.performBaseValidation()
-    RecordsGrantAuthorization.verifyScope(recordsWriteMessageToBeRead, permissionGrant.scope as RecordsPermissionScope);
+    RecordsGrantAuthorization.verifyProtocolRecordScope(recordsWriteMessageToBeRead, permissionGrant.scope as RecordsPermissionScope);
   }
 
   /**
@@ -138,9 +138,9 @@ export class RecordsGrantAuthorization {
   }
 
   /**
-   * Verifies a record against the scope of the given grant.
+   * Verifies a protocol record against the scope of the given grant.
    */
-  private static verifyScope(
+  private static verifyProtocolRecordScope(
     recordsWriteMessage: RecordsWriteMessage,
     grantScope: RecordsPermissionScope
   ): void {

--- a/src/core/records-grant-authorization.ts
+++ b/src/core/records-grant-authorization.ts
@@ -31,7 +31,7 @@ export class RecordsGrantAuthorization {
     });
 
     // NOTE: validated the invoked permission is for Records in GrantAuthorization.performBaseValidation()
-    RecordsGrantAuthorization.verifyProtocolRecordScope(recordsWriteMessage, permissionGrant.scope as RecordsPermissionScope);
+    RecordsGrantAuthorization.verifyScope(recordsWriteMessage, permissionGrant.scope as RecordsPermissionScope);
 
     RecordsGrantAuthorization.verifyConditions(recordsWriteMessage, permissionGrant.conditions);
   }
@@ -61,7 +61,7 @@ export class RecordsGrantAuthorization {
     });
 
     // NOTE: validated the invoked permission is for Records in GrantAuthorization.performBaseValidation()
-    RecordsGrantAuthorization.verifyProtocolRecordScope(recordsWriteMessageToBeRead, permissionGrant.scope as RecordsPermissionScope);
+    RecordsGrantAuthorization.verifyScope(recordsWriteMessageToBeRead, permissionGrant.scope as RecordsPermissionScope);
   }
 
   /**
@@ -138,9 +138,9 @@ export class RecordsGrantAuthorization {
   }
 
   /**
-   * Verifies a protocol record against the scope of the given grant.
+   * Verifies a record against the scope of the given grant.
    */
-  private static verifyProtocolRecordScope(
+  private static verifyScope(
     recordsWriteMessage: RecordsWriteMessage,
     grantScope: RecordsPermissionScope
   ): void {

--- a/src/handlers/records-write.ts
+++ b/src/handlers/records-write.ts
@@ -182,7 +182,7 @@ export class RecordsWriteHandler implements MethodHandler {
       const permissionGrantId = recordsWriteMessage.descriptor.parentId!;
       const grant = await PermissionsProtocol.fetchGrant(tenant, this.messageStore, permissionGrantId);
       const revokeTagProtocol = recordsWriteMessage.descriptor.tags?.protocol;
-      const grantProtocol = PermissionsProtocol.isRecordPermissionScope(grant.scope) ? grant.scope.protocol : undefined;
+      const grantProtocol = 'protocol' in grant.scope ? grant.scope.protocol : undefined;
       if (grantProtocol !== revokeTagProtocol) {
         throw new DwnError(
           DwnErrorCode.PermissionsProtocolValidateRevocationProtocolTagMismatch,

--- a/src/handlers/records-write.ts
+++ b/src/handlers/records-write.ts
@@ -181,8 +181,18 @@ export class RecordsWriteHandler implements MethodHandler {
   private async preProcessingForCoreRecordsWrite(tenant: string, recordsWriteMessage: RecordsWriteMessage): Promise<void> {
     if (recordsWriteMessage.descriptor.protocol === PermissionsProtocol.uri &&
       recordsWriteMessage.descriptor.protocolPath === PermissionsProtocol.revocationPath) {
+
+      // we validate the protocol tag of the revocation message against the grant's scoped protocol
+      // to do this we will fetch the grant, and compare the the scoped protocol value to the protocol tag of the revocation message
+
+      // get the parentId of the revocation message, which is the permissionGrantId
+      // fetch the grant in order to get the grant's protocol
       const permissionGrantId = recordsWriteMessage.descriptor.parentId!;
       const grant = await PermissionsProtocol.fetchGrant(tenant, this.messageStore, permissionGrantId);
+
+      // get the protocol of the revocation message from the protocol tag if it is defined
+      // get the protocol from the grant scope if it is defined
+      // compare the two ensuring they must match
       const revokeTagProtocol = recordsWriteMessage.descriptor.tags?.protocol;
       const grantProtocol = 'protocol' in grant.scope ? grant.scope.protocol : undefined;
       if (grantProtocol !== revokeTagProtocol) {

--- a/src/handlers/records-write.ts
+++ b/src/handlers/records-write.ts
@@ -96,7 +96,9 @@ export class RecordsWriteHandler implements MethodHandler {
     }
 
     try {
-      await this.validateUserlandRulesForCoreRecordsWrite(tenant, message);
+      // Preform any necessary validation for a core RecordsWrite
+      // For instance: a Permission revocation RecordsWrite.
+      await this.preProcessingForCoreRecordsWrite(tenant, message);
 
       // NOTE: We allow isLatestBaseState to be true ONLY if the incoming message comes with data, or if the incoming message is NOT an initial write
       // This would allow an initial write to be written to the DB without data, but having it not queryable,
@@ -176,7 +178,7 @@ export class RecordsWriteHandler implements MethodHandler {
    * Performs additional necessary validation if the RecordsWrite handled is a core DWN RecordsWrite that need additional processing.
    * For instance: a Permission revocation RecordsWrite.
    */
-  private async validateUserlandRulesForCoreRecordsWrite(tenant: string, recordsWriteMessage: RecordsWriteMessage): Promise<void> {
+  private async preProcessingForCoreRecordsWrite(tenant: string, recordsWriteMessage: RecordsWriteMessage): Promise<void> {
     if (recordsWriteMessage.descriptor.protocol === PermissionsProtocol.uri &&
       recordsWriteMessage.descriptor.protocolPath === PermissionsProtocol.revocationPath) {
       const permissionGrantId = recordsWriteMessage.descriptor.parentId!;

--- a/src/protocols/permissions.ts
+++ b/src/protocols/permissions.ts
@@ -390,7 +390,7 @@ export class PermissionsProtocol {
   /**
    * Type guard to determine if the scope is a record permission scope.
    */
-  public static isRecordPermissionScope(scope: PermissionScope): scope is RecordsPermissionScope {
+  private static isRecordPermissionScope(scope: PermissionScope): scope is RecordsPermissionScope {
     return scope.interface === 'Records';
   }
 

--- a/src/protocols/permissions.ts
+++ b/src/protocols/permissions.ts
@@ -66,6 +66,10 @@ export type PermissionRevocationCreateOptions = {
    */
   signer?: Signer;
   grantId: string;
+  /**
+   * If the grant was scoped toa protocol, the protocol must be included in the revocation.
+   */
+  protocol?: string;
   dateRevoked?: string;
 
   // remaining properties are contained within the data payload of the record
@@ -279,6 +283,12 @@ export class PermissionsProtocol {
       description: options.description,
     };
 
+    let permissionTags = undefined;
+    if (options.protocol !== undefined) {
+      const protocol = normalizeProtocolUrl(options.protocol);
+      permissionTags = { protocol };
+    }
+
     const permissionRevocationBytes = Encoder.objectToBytes(permissionRevocationData);
     const recordsWrite = await RecordsWrite.create({
       signer          : options.signer,
@@ -287,6 +297,7 @@ export class PermissionsProtocol {
       protocolPath    : PermissionsProtocol.revocationPath,
       dataFormat      : 'application/json',
       data            : permissionRevocationBytes,
+      tags            : permissionTags,
     });
 
     return {
@@ -379,7 +390,7 @@ export class PermissionsProtocol {
   /**
    * Type guard to determine if the scope is a record permission scope.
    */
-  private static isRecordPermissionScope(scope: PermissionScope): scope is RecordsPermissionScope {
+  public static isRecordPermissionScope(scope: PermissionScope): scope is RecordsPermissionScope {
     return scope.interface === 'Records';
   }
 

--- a/src/protocols/permissions.ts
+++ b/src/protocols/permissions.ts
@@ -67,7 +67,7 @@ export type PermissionRevocationCreateOptions = {
   signer?: Signer;
   grantId: string;
   /**
-   * If the grant was scoped to a protocol, the protocol must be included in the revocation.
+   * If the grant being revoked was scoped to a protocol, the protocol must be included in the revocation.
    */
   protocol?: string;
   dateRevoked?: string;
@@ -186,7 +186,7 @@ export class PermissionsProtocol {
     };
 
     // If the request is scoped to a protocol, the protocol tag must be included with the record.
-    // This is done in order to do a subset message query that includes the requests tied to a specific protocol
+    // This is done in order to ensure a subset message query filtered to a protocol includes the permission requests associated with it.
     let permissionTags = undefined;
     if (this.isRecordPermissionScope(scope)) {
       permissionTags = {
@@ -241,7 +241,7 @@ export class PermissionsProtocol {
     };
 
     // If the grant is scoped to a protocol, the protocol tag must be included with the record.
-    // This is done in order to do a subset message query that includes grants tied to a specific protocol
+    // This is done in order to ensure a subset message query filtered to a protocol includes the permission grants associated with it.
     let permissionTags = undefined;
     if (this.isRecordPermissionScope(scope)) {
       permissionTags = {
@@ -288,9 +288,9 @@ export class PermissionsProtocol {
     };
 
     // if the grant was scoped to a protocol, the protocol tag must be included in the revocation
-    // this is done in order to do a subset message query that includes the grant revocations tied to a specific protocol
+    // This is done in order to ensure a subset message query filtered to a protocol includes the permission revocations associated with it.
     //
-    // the tag is validated against the original grant when the revocation is processed.
+    // NOTE: the added tag is validated against the original grant when the revocation is processed by the DWN.
     let permissionTags = undefined;
     if (options.protocol !== undefined) {
       const protocol = normalizeProtocolUrl(options.protocol);

--- a/src/protocols/permissions.ts
+++ b/src/protocols/permissions.ts
@@ -65,11 +65,10 @@ export type PermissionRevocationCreateOptions = {
    * The signer of the grant.
    */
   signer?: Signer;
-  grantId: string;
   /**
-   * If the grant being revoked was scoped to a protocol, the protocol must be included in the revocation.
+   * The PermissionGrant this revocation is for.
    */
-  protocol?: string;
+  grant: PermissionGrant;
   dateRevoked?: string;
 
   // remaining properties are contained within the data payload of the record
@@ -287,20 +286,23 @@ export class PermissionsProtocol {
       description: options.description,
     };
 
+    const grantId = options.grant.id;
+    const grantScopedProtocol = this.isRecordPermissionScope(options.grant.scope) ? options.grant.scope.protocol : undefined;
+
     // if the grant was scoped to a protocol, the protocol tag must be included in the revocation
     // This is done in order to ensure a subset message query filtered to a protocol includes the permission revocations associated with it.
     //
     // NOTE: the added tag is validated against the original grant when the revocation is processed by the DWN.
     let permissionTags = undefined;
-    if (options.protocol !== undefined) {
-      const protocol = normalizeProtocolUrl(options.protocol);
+    if (grantScopedProtocol !== undefined) {
+      const protocol = normalizeProtocolUrl(grantScopedProtocol);
       permissionTags = { protocol };
     }
 
     const permissionRevocationBytes = Encoder.objectToBytes(permissionRevocationData);
     const recordsWrite = await RecordsWrite.create({
       signer          : options.signer,
-      parentContextId : options.grantId, // NOTE: since the grant is the root record, its record ID is also the context ID
+      parentContextId : grantId, // NOTE: since the grant is the root record, its record ID is also the context ID
       protocol        : PermissionsProtocol.uri,
       protocolPath    : PermissionsProtocol.revocationPath,
       dataFormat      : 'application/json',

--- a/src/protocols/permissions.ts
+++ b/src/protocols/permissions.ts
@@ -67,7 +67,7 @@ export type PermissionRevocationCreateOptions = {
   signer?: Signer;
   grantId: string;
   /**
-   * If the grant was scoped toa protocol, the protocol must be included in the revocation.
+   * If the grant was scoped to a protocol, the protocol must be included in the revocation.
    */
   protocol?: string;
   dateRevoked?: string;
@@ -185,6 +185,8 @@ export class PermissionsProtocol {
       conditions  : options.conditions,
     };
 
+    // If the request is scoped to a protocol, the protocol tag must be included with the record.
+    // This is done in order to do a subset message query that includes the requests tied to a specific protocol
     let permissionTags = undefined;
     if (this.isRecordPermissionScope(scope)) {
       permissionTags = {
@@ -238,6 +240,8 @@ export class PermissionsProtocol {
       conditions  : options.conditions,
     };
 
+    // If the grant is scoped to a protocol, the protocol tag must be included with the record.
+    // This is done in order to do a subset message query that includes grants tied to a specific protocol
     let permissionTags = undefined;
     if (this.isRecordPermissionScope(scope)) {
       permissionTags = {
@@ -283,6 +287,10 @@ export class PermissionsProtocol {
       description: options.description,
     };
 
+    // if the grant was scoped to a protocol, the protocol tag must be included in the revocation
+    // this is done in order to do a subset message query that includes the grant revocations tied to a specific protocol
+    //
+    // the tag is validated against the original grant when the revocation is processed.
     let permissionTags = undefined;
     if (options.protocol !== undefined) {
       const protocol = normalizeProtocolUrl(options.protocol);

--- a/tests/features/author-delegated-grant.spec.ts
+++ b/tests/features/author-delegated-grant.spec.ts
@@ -16,6 +16,7 @@ import { DataStream } from '../../src/utils/data-stream.js';
 import { Dwn } from '../../src/dwn.js';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
 import { Jws } from '../../src/utils/jws.js';
+import { PermissionGrant } from '../../src/protocols/permission-grant.js';
 import { RecordsWrite } from '../../src/interfaces/records-write.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestEventStream } from '../test-event-stream.js';
@@ -1189,9 +1190,8 @@ export function testAuthorDelegatedGrant(): void {
 
       // 3. Alice revokes the grant
       const permissionRevoke = await PermissionsProtocol.createRevocation({
-        signer   : Jws.createSigner(alice),
-        grantId  : deviceXGrant.recordsWrite.message.recordId,
-        protocol : scope.protocol,
+        signer : Jws.createSigner(alice),
+        grant  : await PermissionGrant.parse(deviceXGrant.dataEncodedMessage),
       });
       const revocationDataStream = DataStream.fromBytes(permissionRevoke.permissionRevocationBytes);
       const permissionRevokeReply = await dwn.processMessage(alice.did, permissionRevoke.recordsWrite.message, { dataStream: revocationDataStream });

--- a/tests/features/author-delegated-grant.spec.ts
+++ b/tests/features/author-delegated-grant.spec.ts
@@ -1189,8 +1189,9 @@ export function testAuthorDelegatedGrant(): void {
 
       // 3. Alice revokes the grant
       const permissionRevoke = await PermissionsProtocol.createRevocation({
-        signer  : Jws.createSigner(alice),
-        grantId : deviceXGrant.recordsWrite.message.recordId
+        signer   : Jws.createSigner(alice),
+        grantId  : deviceXGrant.recordsWrite.message.recordId,
+        protocol : scope.protocol,
       });
       const revocationDataStream = DataStream.fromBytes(permissionRevoke.permissionRevocationBytes);
       const permissionRevokeReply = await dwn.processMessage(alice.did, permissionRevoke.recordsWrite.message, { dataStream: revocationDataStream });

--- a/tests/features/owner-delegated-grant.spec.ts
+++ b/tests/features/owner-delegated-grant.spec.ts
@@ -601,8 +601,9 @@ export function testOwnerDelegatedGrant(): void {
 
       // 3. Alice revokes the grant
       const permissionRevoke = await PermissionsProtocol.createRevocation({
-        signer  : Jws.createSigner(alice),
-        grantId : appXGrant.recordsWrite.message.recordId
+        signer   : Jws.createSigner(alice),
+        grantId  : appXGrant.recordsWrite.message.recordId,
+        protocol : scope.protocol,
       });
       const revocationDataStream = DataStream.fromBytes(permissionRevoke.permissionRevocationBytes);
       const permissionRevokeReply = await dwn.processMessage(

--- a/tests/features/owner-delegated-grant.spec.ts
+++ b/tests/features/owner-delegated-grant.spec.ts
@@ -12,6 +12,7 @@ import { DataStream } from '../../src/utils/data-stream.js';
 import { Dwn } from '../../src/dwn.js';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
 import { Jws } from '../../src/utils/jws.js';
+import { PermissionGrant } from '../../src/protocols/permission-grant.js';
 import { RecordsWrite } from '../../src/interfaces/records-write.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestEventStream } from '../test-event-stream.js';
@@ -601,9 +602,8 @@ export function testOwnerDelegatedGrant(): void {
 
       // 3. Alice revokes the grant
       const permissionRevoke = await PermissionsProtocol.createRevocation({
-        signer   : Jws.createSigner(alice),
-        grantId  : appXGrant.recordsWrite.message.recordId,
-        protocol : scope.protocol,
+        signer : Jws.createSigner(alice),
+        grant  : await PermissionGrant.parse(appXGrant.dataEncodedMessage),
       });
       const revocationDataStream = DataStream.fromBytes(permissionRevoke.permissionRevocationBytes);
       const permissionRevokeReply = await dwn.processMessage(

--- a/tests/features/permissions.spec.ts
+++ b/tests/features/permissions.spec.ts
@@ -209,25 +209,7 @@ export function testPermissions(): void {
       expect(revocationReadReply2.record?.recordId).to.equal(revokeWrite.recordsWrite.message.recordId);
     });
 
-    it('should fail if a RecordsPermissionScope request is created without a protocol', async () => {
-      const bob = await TestDataGenerator.generateDidKeyPersona();
-
-      const permissionScope = {
-        interface : DwnInterfaceName.Records,
-        method    : DwnMethodName.Write
-      };
-
-      const grantWrite = PermissionsProtocol.createRequest({
-        signer      : Jws.createSigner(bob),
-        description : `Requesting to write to Alice's DWN`,
-        delegated   : false,
-        scope       : permissionScope as any // explicity as any to test the validation
-      });
-
-      expect(grantWrite).to.eventually.be.rejectedWith(DwnErrorCode.PermissionsProtocolCreateGrantRecordsScopeMissingProtocol);
-    });
-
-    it('should fail if a RecordsPermissionScope grant is created without a protocol', async () => {
+    it('should fail if a RecordsPermissionScope in a Request or Grant record is created without a protocol', async () => {
       const alice = await TestDataGenerator.generateDidKeyPersona();
       const bob = await TestDataGenerator.generateDidKeyPersona();
 

--- a/tests/features/permissions.spec.ts
+++ b/tests/features/permissions.spec.ts
@@ -196,7 +196,7 @@ export function testPermissions(): void {
       const permissionScope: PermissionScope = {
         interface : DwnInterfaceName.Records,
         method    : DwnMethodName.Write,
-        protocol  : `any-protocol` // URL will normalize to `http://any-protocol`
+        protocol  : `any-protocol`
       };
 
       const requestToAlice = await PermissionsProtocol.createRequest({
@@ -371,7 +371,7 @@ export function testPermissions(): void {
       ).to.throw(DwnErrorCode.PermissionsProtocolValidateSchemaUnexpectedRecord);
     });
 
-    it('performs additional validation to tagged protocol in a Revocation message matches the Grant it is revoking', async () => {
+    it('performs additional validation to the tagged protocol in a Revocation message ensuring it matches the Grant it is revoking', async () => {
       const alice = await TestDataGenerator.generateDidKeyPersona();
       const bob = await TestDataGenerator.generateDidKeyPersona();
 

--- a/tests/features/permissions.spec.ts
+++ b/tests/features/permissions.spec.ts
@@ -372,6 +372,12 @@ export function testPermissions(): void {
     });
 
     it('performs additional validation to the tagged protocol in a Revocation message ensuring it matches the Grant it is revoking', async () => {
+      // scenario:
+      //  Alice creates a grant scoped to a protocol.
+      //  Alice then tries to revoke the grant without a protocol set, it should fail.
+      //  Alice then tries to revoke the grant with an invalid protocol, it should fail.
+      //  Alice finally tries to revoke the grant with a valid protocol, it should succeed.
+
       const alice = await TestDataGenerator.generateDidKeyPersona();
       const bob = await TestDataGenerator.generateDidKeyPersona();
 

--- a/tests/features/permissions.spec.ts
+++ b/tests/features/permissions.spec.ts
@@ -209,7 +209,25 @@ export function testPermissions(): void {
       expect(revocationReadReply2.record?.recordId).to.equal(revokeWrite.recordsWrite.message.recordId);
     });
 
-    it('should fail if a RecordsPermissionScope in a Request or Grant record is created without a protocol', async () => {
+    it('should fail if a RecordsPermissionScope request is created without a protocol', async () => {
+      const bob = await TestDataGenerator.generateDidKeyPersona();
+
+      const permissionScope = {
+        interface : DwnInterfaceName.Records,
+        method    : DwnMethodName.Write
+      };
+
+      const grantWrite = PermissionsProtocol.createRequest({
+        signer      : Jws.createSigner(bob),
+        description : `Requesting to write to Alice's DWN`,
+        delegated   : false,
+        scope       : permissionScope as any // explicity as any to test the validation
+      });
+
+      expect(grantWrite).to.eventually.be.rejectedWith(DwnErrorCode.PermissionsProtocolCreateGrantRecordsScopeMissingProtocol);
+    });
+
+    it('should fail if a RecordsPermissionScope grant is created without a protocol', async () => {
       const alice = await TestDataGenerator.generateDidKeyPersona();
       const bob = await TestDataGenerator.generateDidKeyPersona();
 

--- a/tests/handlers/protocols-query.spec.ts
+++ b/tests/handlers/protocols-query.spec.ts
@@ -14,6 +14,7 @@ import chai, { expect } from 'chai';
 
 import { GeneralJwsBuilder } from '../../src/jose/jws/general/builder.js';
 import { Message } from '../../src/core/message.js';
+import { PermissionGrant } from '../../src/protocols/permission-grant.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestEventStream } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
@@ -271,7 +272,7 @@ export function testProtocolsQueryHandler(): void {
           // 4. Alice revokes Bob's grant
           const revokeWrite = await PermissionsProtocol.createRevocation({
             signer      : Jws.createSigner(alice),
-            grantId     : permissionGrantId,
+            grant       : await PermissionGrant.parse(permissionGrant.dataEncodedMessage),
             dateRevoked : Time.getCurrentTimestamp()
           });
 

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -91,6 +91,19 @@ export function testRecordsWriteHandler(): void {
         await dwn.close();
       });
 
+      it('should call preProcessingForCoreRecordsWrite after authorization', async () => {
+        // create a records write message
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice });
+        const preProcessingForCoreRecordsWriteSpy = sinon.spy(RecordsWriteHandler.prototype as any, 'preProcessingForCoreRecordsWrite');
+
+        const reply = await dwn.processMessage(alice.did, message, { dataStream });
+        expect(reply.status.code).to.equal(202);
+
+        // confirm that the preProcessingForCoreRecordsWrite method was called
+        expect(preProcessingForCoreRecordsWriteSpy.calledOnce).to.be.true;
+      });
+
       it('should only be able to overwrite existing record if new record has a later `messageTimestamp` value', async () => {
       // write a message into DB
         const author = await TestDataGenerator.generateDidKeyPersona();

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -92,7 +92,7 @@ export function testRecordsWriteHandler(): void {
       });
 
       it('should call preProcessingForCoreRecordsWrite after authorization and before storage', async () => {
-        // We create spy and stub the authorization, preProcessingForCoreRecordsWrite and processMessageWithDataStream methods
+        // We create spy or stub for authorization, preProcessingForCoreRecordsWrite and processMessageWithDataStream methods
         // When we trigger a failure for `preProcessingForCoreRecordsWrite`, we expect the `processMessageWithDataStream` method to not be called
 
         const authorizationSpy = sinon.spy(RecordsWriteHandler as any, 'authorizeRecordsWrite');

--- a/tests/handlers/records-write.spec.ts
+++ b/tests/handlers/records-write.spec.ts
@@ -28,7 +28,6 @@ import { base64url } from 'multiformats/bases/base64';
 import { Cid } from '../../src/utils/cid.js';
 import { DataStream } from '../../src/utils/data-stream.js';
 import { Dwn } from '../../src/dwn.js';
-import { DwnError, DwnErrorCode } from '../../src/core/dwn-error.js';
 import { Encoder } from '../../src/utils/encoder.js';
 import { GeneralJwsBuilder } from '../../src/jose/jws/general/builder.js';
 import { Jws } from '../../src/utils/jws.js';
@@ -43,6 +42,7 @@ import { TestEventStream } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
 import { Time } from '../../src/utils/time.js';
+import { DwnError, DwnErrorCode } from '../../src/core/dwn-error.js';
 
 import { DidKey, UniversalResolver } from '@web5/dids';
 import { DwnConstant, DwnInterfaceName, DwnMethodName, KeyDerivationScheme, PermissionsProtocol, RecordsDelete, RecordsQuery } from '../../src/index.js';


### PR DESCRIPTION
In order to get Permission Revocation messages associated with a specific protocol from the `MessageStore` it is necessary for the revocation messages to be tagged with the `protocol` from the grant scope.

In this PR:
- added an optional `protocol` property to the `PermissionRevocationCreateOptions` which normalizes and adds the provided protocol as a tag.
- added a `preProcessingForCoreRecordsWrite` method to the `RecordsWriteHandler` where if the incoming message is a revocation message, the original grant will be fetched and the protocol tag from the revocation will be compared to the grant scope protocol.

