### PR TITLE
Changed timer type in clearTimeoutExtensionTimer to be node.js independent

### DIFF
--- a/src/core/resumable-task-manager.ts
+++ b/src/core/resumable-task-manager.ts
@@ -66,8 +66,9 @@ export class ResumableTaskManager {
   /**
    * Removes the specified timeout extension loop timer.
    * NOTE: created mainly for testing purposes so we can spy on this specific method without needing to filter out other `clearInterval` calls.
+   * NOTE: using `ReturnType` utility type to avoid using node.js specific type, because `setInterval` returns a `number` in browser environments.
    */
-  public static clearTimeoutExtensionTimer(timer: NodeJS.Timer): void {
+  public static clearTimeoutExtensionTimer(timer: ReturnType<typeof setInterval>): void {
     clearInterval(timer);
   }
 


### PR DESCRIPTION
Not sure why document generator github action fails while the PR merge flow and local machine have no issue compiling:

https://github.com/TBD54566975/dwn-sdk-js/actions/runs/9473485488/job/26150552015

Regardless this should fix it.