### PR TITLE
Refactor `MessagesRead` response

### DIFF
--- a/src/core/message-reply.ts
+++ b/src/core/message-reply.ts
@@ -21,7 +21,13 @@ export type UnionMessageReply = GenericMessageReply & {
    * e.g. the resulting messages from a RecordsQuery, or array of messageCid strings for MessagesQuery
    * Mutually exclusive with `record`.
    */
-  entries?: QueryResultEntry[] | ProtocolsConfigureMessage[] | MessagesReadReplyEntry[] | string[];
+  entries?: QueryResultEntry[] | ProtocolsConfigureMessage[] | string[];
+
+  /**
+   * A single message entry if applicable (e.g. MessagesRead).
+   * Mutually exclusive with `record`, `entries` and `cursor`.
+   */
+  entry?: MessagesReadReplyEntry;
 
   /**
    * Record corresponding to the message received if applicable (e.g. RecordsRead).

--- a/src/handlers/messages-read.ts
+++ b/src/handlers/messages-read.ts
@@ -55,13 +55,13 @@ export class MessagesReadHandler implements MethodHandler {
       // we store `encodedData` along with the message if the data is below a certain threshold.
       if (recordsWrite.encodedData !== undefined) {
         const dataBytes = Encoder.base64UrlToBytes(recordsWrite.encodedData);
-        entry.message.data = DataStream.fromBytes(dataBytes);
+        entry.data = DataStream.fromBytes(dataBytes);
         delete recordsWrite.encodedData;
       } else {
         // otherwise check the data store for the associated data
         const result = await this.dataStore.get(tenant, recordsWrite.recordId, recordsWrite.descriptor.dataCid);
         if (result?.dataStream !== undefined) {
-          entry.message.data = result.dataStream;
+          entry.data = result.dataStream;
         }
       }
     }

--- a/src/types/messages-types.ts
+++ b/src/types/messages-types.ts
@@ -28,7 +28,8 @@ export type MessagesReadMessage = GenericMessage & {
 
 export type MessagesReadReplyEntry = {
   messageCid: string;
-  message: (GenericMessage & { data?: Readable });
+  message: GenericMessage;
+  data?: Readable;
 };
 
 export type MessagesReadReply = GenericMessageReply & {

--- a/tests/handlers/messages-read.spec.ts
+++ b/tests/handlers/messages-read.spec.ts
@@ -176,8 +176,8 @@ export function testMessagesReadHandler(): void {
             expect(messageReply.messageCid).to.equal(recordsWriteMessageCid);
 
             expect(messageReply.message).to.exist.and.not.be.undefined;
-            expect(messageReply.message?.data).to.exist.and.not.be.undefined;
-            const messageData = await DataStream.toBytes(messageReply.message!.data!);
+            expect(messageReply.data).to.exist.and.not.be.undefined;
+            const messageData = await DataStream.toBytes(messageReply.data!);
             expect(messageData).to.eql(dataBytes);
           });
 
@@ -207,8 +207,8 @@ export function testMessagesReadHandler(): void {
             expect(messageReply.messageCid).to.equal(recordsWriteMessageCid);
 
             expect(messageReply.message).to.exist.and.not.be.undefined;
-            expect(messageReply.message?.data).to.exist.and.not.be.undefined;
-            const messageData = await DataStream.toBytes(messageReply.message!.data!);
+            expect(messageReply.data).to.exist.and.not.be.undefined;
+            const messageData = await DataStream.toBytes(messageReply.data!);
             expect(messageData).to.eql(dataBytes);
           });
 
@@ -249,7 +249,7 @@ export function testMessagesReadHandler(): void {
             expect(messageReply.messageCid).to.equal(initialMessageCid);
 
             expect(messageReply.message).to.exist.and.not.be.undefined;
-            expect(messageReply.message?.data).to.be.undefined;
+            expect(messageReply.data).to.be.undefined;
           });
         });
       });
@@ -598,8 +598,6 @@ export function testMessagesReadHandler(): void {
           const messagesReadWithGrantReply = await dwn.processMessage(alice.did, messagesReadWithGrant.message);
           expect(messagesReadWithGrantReply.status.code).to.equal(200);
           expect(messagesReadWithGrantReply.entry).to.exist;
-          // delete the data field from the message for comparison of the message
-          delete messagesReadWithGrantReply.entry!.message.data;
           expect(messagesReadWithGrantReply.entry!.message).to.deep.equal(recordsWrite.message);
 
           // alice RecordsDelete
@@ -622,8 +620,6 @@ export function testMessagesReadHandler(): void {
           const messagesReadCarolRequestReply = await dwn.processMessage(alice.did, messagesReadCarolRequest.message);
           expect(messagesReadCarolRequestReply.status.code).to.equal(200);
           expect(messagesReadCarolRequestReply.entry).to.exist;
-          // delete the data field from the message for comparison of the message
-          delete messagesReadCarolRequestReply.entry!.message.data;
           expect(messagesReadCarolRequestReply.entry!.message).to.deep.equal(permissionRequestCarol.recordsWrite.message);
 
           // carol's Permission Grant
@@ -635,8 +631,6 @@ export function testMessagesReadHandler(): void {
           const messagesReadCarolGrantReply = await dwn.processMessage(alice.did, messagesReadCarolGrant.message);
           expect(messagesReadCarolGrantReply.status.code).to.equal(200);
           expect(messagesReadCarolGrantReply.entry).to.exist;
-          // delete the data field from the message for comparison of the message
-          delete messagesReadCarolGrantReply.entry!.message.data;
           expect(messagesReadCarolGrantReply.entry!.message).to.deep.equal(permissionGrantCarol.recordsWrite.message);
 
           // carol's RecordsWrite
@@ -648,8 +642,6 @@ export function testMessagesReadHandler(): void {
           const messagesReadCarolRecordReply = await dwn.processMessage(alice.did, messagesReadCarolRecord.message);
           expect(messagesReadCarolRecordReply.status.code).to.equal(200);
           expect(messagesReadCarolRecordReply.entry).to.exist;
-          // delete the data field from the message for comparison of the message
-          delete messagesReadCarolRecordReply.entry!.message.data;
           expect(messagesReadCarolRecordReply.entry!.message).to.deep.equal(recordsWriteCarol.message);
 
           // carol's Grant Revocation
@@ -661,8 +653,6 @@ export function testMessagesReadHandler(): void {
           const messagesReadCarolGrantRevocationReply = await dwn.processMessage(alice.did, messagesReadCarolGrantRevocation.message);
           expect(messagesReadCarolGrantRevocationReply.status.code).to.equal(200);
           expect(messagesReadCarolGrantRevocationReply.entry).to.exist;
-          // delete the data field from the message for comparison of the message
-          delete messagesReadCarolGrantRevocationReply.entry!.message.data;
           expect(messagesReadCarolGrantRevocationReply.entry!.message).to.deep.equal(permissionRevocationCarol.recordsWrite.message);
 
           // CONTROL: Alice writes a record not associated with the protocol


### PR DESCRIPTION
- Added `entry` to `UnionMessageReply` that represents response from `MessagesRead`.
- Modified `MessagesReadReplyEntry` to include `data` as a sibling property to `message`