### PR TITLE
Missing JSON Schema properties for Permission Scopes

### DIFF
--- a/json-schemas/permissions/scopes.json
+++ b/json-schemas/permissions/scopes.json
@@ -165,6 +165,9 @@
         "method": {
           "const": "Query"
         },
+        "protocol": {
+          "type": "string"
+        },
         "contextId": {
           "type": "string"
         },
@@ -186,6 +189,9 @@
         },
         "method": {
           "const": "Subscribe"
+        },
+        "protocol": {
+          "type": "string"
         },
         "contextId": {
           "type": "string"

--- a/json-schemas/permissions/scopes.json
+++ b/json-schemas/permissions/scopes.json
@@ -92,6 +92,12 @@
         },
         "protocol": {
           "type": "string"
+        },
+        "contextId": {
+          "type": "string"
+        },
+        "protocolPath": {
+          "type": "string"
         }
       }
     },
@@ -156,7 +162,13 @@
         "interface": {
           "const": "Records"
         },
-        "protocol": {
+        "method": {
+          "const": "Query"
+        },
+        "contextId": {
+          "type": "string"
+        },
+        "protocolPath": {
           "type": "string"
         }
       }
@@ -175,7 +187,10 @@
         "method": {
           "const": "Subscribe"
         },
-        "protocol": {
+        "contextId": {
+          "type": "string"
+        },
+        "protocolPath": {
           "type": "string"
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export type { GenericMessage, GenericMessageReply, MessageSort, MessageSubscript
 export type { MessagesFilter, MessagesReadMessage as MessagesReadMessage, MessagesReadReply as MessagesReadReply, MessagesReadReplyEntry as MessagesReadReplyEntry, MessagesQueryMessage, MessagesQueryReply, MessagesSubscribeDescriptor, MessagesSubscribeMessage, MessagesSubscribeReply, MessageSubscriptionHandler } from './types/messages-types.js';
 export type { Filter, EqualFilter, OneOfFilter, RangeFilter, RangeCriterion, PaginationCursor, QueryOptions } from './types/query-types.js';
 export type { ProtocolsConfigureDescriptor, ProtocolDefinition, ProtocolTypes, ProtocolRuleSet, ProtocolsQueryFilter, ProtocolsConfigureMessage, ProtocolsQueryMessage, ProtocolsQueryReply } from './types/protocols-types.js';
-export type { EncryptionProperty, RecordsDeleteMessage, RecordsQueryMessage, RecordsQueryReply, RecordsQueryReplyEntry, RecordsReadMessage, RecordsReadReply, RecordsSubscribeDescriptor, RecordsSubscribeMessage, RecordsSubscribeReply, RecordSubscriptionHandler, RecordsWriteDescriptor, RecordsWriteTags, RecordsWriteTagValue, RecordsWriteMessage } from './types/records-types.js';
+export type { DataEncodedRecordsWriteMessage, EncryptionProperty, RecordsDeleteMessage, RecordsQueryMessage, RecordsQueryReply, RecordsQueryReplyEntry, RecordsReadMessage, RecordsReadReply, RecordsSubscribeDescriptor, RecordsSubscribeMessage, RecordsSubscribeReply, RecordSubscriptionHandler, RecordsWriteDescriptor, RecordsWriteTags, RecordsWriteTagValue, RecordsWriteMessage } from './types/records-types.js';
 export { authenticate } from './core/auth.js';
 export { ActiveTenantCheckResult, AllowAllTenantGate, TenantGate } from './core/tenant-gate.js';
 export { Cid } from './utils/cid.js';


### PR DESCRIPTION
This PR adds some missing schema properties expected in the various protocol scopes.

I wrote tests that validate that the messages are processed, but I think there need to be some additional testing regarding the functionality of various scopes in a subsequent PR/Issue.