### PR TITLE
construction of grants and requests are not async

### DIFF
--- a/src/interfaces/records-delete.ts
+++ b/src/interfaces/records-delete.ts
@@ -108,7 +108,7 @@ export class RecordsDelete extends AbstractMessage<RecordsDeleteMessage> {
    * @param messageStore Used to check if the grant has been revoked.
    */
   public async authorizeDelegate(recordsWriteToDelete: RecordsWriteMessage, messageStore: MessageStore): Promise<void> {
-    const delegatedGrant = await PermissionGrant.parse(this.message.authorization!.authorDelegatedGrant!);
+    const delegatedGrant = new PermissionGrant(this.message.authorization!.authorDelegatedGrant!);
     await RecordsGrantAuthorization.authorizeDelete({
       recordsDeleteMessage : this.message,
       recordsWriteToDelete,

--- a/src/interfaces/records-query.ts
+++ b/src/interfaces/records-query.ts
@@ -119,7 +119,7 @@ export class RecordsQuery extends AbstractMessage<RecordsQueryMessage> {
    * @param messageStore Used to check if the grant has been revoked.
    */
   public async authorizeDelegate(messageStore: MessageStore): Promise<void> {
-    const delegatedGrant = await PermissionGrant.parse(this.message.authorization!.authorDelegatedGrant!);
+    const delegatedGrant = new PermissionGrant(this.message.authorization!.authorDelegatedGrant!);
     await RecordsGrantAuthorization.authorizeQueryOrSubscribe({
       incomingMessage : this.message,
       expectedGrantee : this.signer!,

--- a/src/interfaces/records-read.ts
+++ b/src/interfaces/records-read.ts
@@ -87,7 +87,7 @@ export class RecordsRead extends AbstractMessage<RecordsReadMessage> {
    * @param messageStore Used to check if the grant has been revoked.
    */
   public async authorizeDelegate(matchedRecordsWrite: RecordsWriteMessage, messageStore: MessageStore): Promise<void> {
-    const delegatedGrant = await PermissionGrant.parse(this.message.authorization!.authorDelegatedGrant!);
+    const delegatedGrant = new PermissionGrant(this.message.authorization!.authorDelegatedGrant!);
     await RecordsGrantAuthorization.authorizeRead({
       recordsReadMessage          : this.message,
       recordsWriteMessageToBeRead : matchedRecordsWrite,

--- a/src/interfaces/records-subscribe.ts
+++ b/src/interfaces/records-subscribe.ts
@@ -92,7 +92,7 @@ export class RecordsSubscribe extends AbstractMessage<RecordsSubscribeMessage> {
  * @param messageStore Used to check if the grant has been revoked.
  */
   public async authorizeDelegate(messageStore: MessageStore): Promise<void> {
-    const delegatedGrant = await PermissionGrant.parse(this.message.authorization!.authorDelegatedGrant!);
+    const delegatedGrant = new PermissionGrant(this.message.authorization!.authorDelegatedGrant!);
     await RecordsGrantAuthorization.authorizeQueryOrSubscribe({
       incomingMessage : this.message,
       expectedGrantor : this.author!,

--- a/src/interfaces/records-write.ts
+++ b/src/interfaces/records-write.ts
@@ -795,7 +795,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
    * @param messageStore Used to check if the grant has been revoked.
    */
   public async authorizeAuthorDelegate(messageStore: MessageStore): Promise<void> {
-    const delegatedGrant = await PermissionGrant.parse(this.message.authorization.authorDelegatedGrant!);
+    const delegatedGrant = new PermissionGrant(this.message.authorization.authorDelegatedGrant!);
     await RecordsGrantAuthorization.authorizeWrite({
       recordsWriteMessage : this.message,
       expectedGrantor     : this.author!,
@@ -810,7 +810,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
    * @param messageStore Used to check if the grant has been revoked.
    */
   public async authorizeOwnerDelegate(messageStore: MessageStore): Promise<void> {
-    const delegatedGrant = await PermissionGrant.parse(this.message.authorization.ownerDelegatedGrant!);
+    const delegatedGrant = new PermissionGrant(this.message.authorization.ownerDelegatedGrant!);
     await RecordsGrantAuthorization.authorizeWrite({
       recordsWriteMessage : this.message,
       expectedGrantor     : this.owner!,

--- a/src/protocols/permission-grant.ts
+++ b/src/protocols/permission-grant.ts
@@ -60,12 +60,7 @@ export class PermissionGrant {
    */
   public readonly conditions?: PermissionConditions;
 
-  public static async parse(message: DataEncodedRecordsWriteMessage): Promise<PermissionGrant> {
-    const permissionGrant = new PermissionGrant(message);
-    return permissionGrant;
-  }
-
-  private constructor(message: DataEncodedRecordsWriteMessage) {
+  constructor(message: DataEncodedRecordsWriteMessage) {
     // properties derived from the generic DWN message properties
     this.id = message.recordId;
     this.grantor = Message.getSigner(message)!;

--- a/src/protocols/permission-request.ts
+++ b/src/protocols/permission-request.ts
@@ -41,12 +41,7 @@ export class PermissionRequest {
    */
   public readonly conditions?: PermissionConditions;
 
-  public static async parse(message: DataEncodedRecordsWriteMessage): Promise<PermissionRequest> {
-    const permissionRequest = new PermissionRequest(message);
-    return permissionRequest;
-  }
-
-  private constructor(message: DataEncodedRecordsWriteMessage) {
+  constructor(message: DataEncodedRecordsWriteMessage) {
     // properties derived from the generic DWN message properties
     this.id = message.recordId;
     this.requester = Message.getSigner(message)!;

--- a/src/protocols/permissions.ts
+++ b/src/protocols/permissions.ts
@@ -394,7 +394,7 @@ export class PermissionsProtocol {
     }
 
     const permissionGrantMessage = possibleGrantMessage as DataEncodedRecordsWriteMessage;
-    const permissionGrant = await PermissionGrant.parse(permissionGrantMessage);
+    const permissionGrant = new PermissionGrant(permissionGrantMessage);
 
     return permissionGrant;
   }
@@ -421,11 +421,11 @@ export class PermissionsProtocol {
       const grant = await PermissionsProtocol.fetchGrant(tenant, messageStore, incomingMessage.descriptor.parentId!);
       return grant.scope;
     } else if (incomingMessage.descriptor.protocolPath === PermissionsProtocol.grantPath) {
-      const grant = await PermissionGrant.parse(incomingMessage);
+      const grant = new PermissionGrant(incomingMessage);
       return grant.scope;
     } else {
       // if the record is not a grant or revocation, it must be a request
-      const request = await PermissionRequest.parse(incomingMessage);
+      const request = new PermissionRequest(incomingMessage);
       return request.scope;
     }
   }

--- a/src/utils/records.ts
+++ b/src/utils/records.ts
@@ -412,7 +412,7 @@ export class Records {
     if (authorDelegatedGrantDefined) {
       const delegatedGrant = message.authorization!.authorDelegatedGrant!;
 
-      const permissionGrant = await PermissionGrant.parse(delegatedGrant);
+      const permissionGrant = new PermissionGrant(delegatedGrant);
       if (permissionGrant.delegated !== true) {
         throw new DwnError(
           DwnErrorCode.RecordsAuthorDelegatedGrantNotADelegatedGrant,
@@ -455,7 +455,7 @@ export class Records {
 
     if (ownerDelegatedGrantDefined) {
       const delegatedGrant = message.authorization!.ownerDelegatedGrant!;
-      const permissionGrant = await PermissionGrant.parse(delegatedGrant);
+      const permissionGrant = new PermissionGrant(delegatedGrant);
 
       if (permissionGrant.delegated !== true) {
         throw new DwnError(

--- a/tests/features/author-delegated-grant.spec.ts
+++ b/tests/features/author-delegated-grant.spec.ts
@@ -1221,7 +1221,7 @@ export function testAuthorDelegatedGrant(): void {
       // 3. Alice revokes the grant
       const permissionRevoke = await PermissionsProtocol.createRevocation({
         signer : Jws.createSigner(alice),
-        grant  : await PermissionGrant.parse(deviceXGrant.dataEncodedMessage),
+        grant  : new PermissionGrant(deviceXGrant.dataEncodedMessage),
       });
       const revocationDataStream = DataStream.fromBytes(permissionRevoke.permissionRevocationBytes);
       const permissionRevokeReply = await dwn.processMessage(alice.did, permissionRevoke.recordsWrite.message, { dataStream: revocationDataStream });

--- a/tests/features/owner-delegated-grant.spec.ts
+++ b/tests/features/owner-delegated-grant.spec.ts
@@ -603,7 +603,7 @@ export function testOwnerDelegatedGrant(): void {
       // 3. Alice revokes the grant
       const permissionRevoke = await PermissionsProtocol.createRevocation({
         signer : Jws.createSigner(alice),
-        grant  : await PermissionGrant.parse(appXGrant.dataEncodedMessage),
+        grant  : new PermissionGrant(appXGrant.dataEncodedMessage),
       });
       const revocationDataStream = DataStream.fromBytes(permissionRevoke.permissionRevocationBytes);
       const permissionRevokeReply = await dwn.processMessage(

--- a/tests/features/permissions.spec.ts
+++ b/tests/features/permissions.spec.ts
@@ -97,7 +97,7 @@ export function testPermissions(): void {
       // createRevocation with a protocol derived from the grant
       const revokeWrite = await PermissionsProtocol.createRevocation({
         signer      : Jws.createSigner(alice),
-        grant       : await PermissionGrant.parse(grantWrite.dataEncodedMessage),
+        grant       : new PermissionGrant(grantWrite.dataEncodedMessage),
         dateRevoked : Time.getCurrentTimestamp()
       });
       expect(revokeWrite.recordsWrite.message.descriptor.tags).to.deep.equal({ protocol: testProtocol });
@@ -188,7 +188,7 @@ export function testPermissions(): void {
       // derive the grantId and protocol from the grant record
       const revokeWrite = await PermissionsProtocol.createRevocation({
         signer      : Jws.createSigner(alice),
-        grant       : await PermissionGrant.parse(grantWrite.dataEncodedMessage),
+        grant       : new PermissionGrant(grantWrite.dataEncodedMessage),
         dateRevoked : Time.getCurrentTimestamp()
       });
 
@@ -316,7 +316,7 @@ export function testPermissions(): void {
       // 7. Verify that non-owner cannot revoke the grant
       const unauthorizedRevokeWrite = await PermissionsProtocol.createRevocation({
         signer      : Jws.createSigner(bob),
-        grant       : await PermissionGrant.parse(grantWrite.dataEncodedMessage),
+        grant       : new PermissionGrant(grantWrite.dataEncodedMessage),
         dateRevoked : Time.getCurrentTimestamp(),
       });
 
@@ -331,7 +331,7 @@ export function testPermissions(): void {
       // 8. Alice revokes the permission grant for Bob
       const revokeWrite = await PermissionsProtocol.createRevocation({
         signer      : Jws.createSigner(alice),
-        grant       : await PermissionGrant.parse(grantWrite.dataEncodedMessage),
+        grant       : new PermissionGrant(grantWrite.dataEncodedMessage),
         dateRevoked : Time.getCurrentTimestamp(),
       });
 

--- a/tests/handlers/messages-read.spec.ts
+++ b/tests/handlers/messages-read.spec.ts
@@ -530,7 +530,7 @@ export function testMessagesReadHandler(): void {
           // Alice revokes Carol's grant
           const permissionRevocationCarol = await PermissionsProtocol.createRevocation({
             signer : Jws.createSigner(alice),
-            grant  : await PermissionGrant.parse(permissionGrantCarol.dataEncodedMessage),
+            grant  : new PermissionGrant(permissionGrantCarol.dataEncodedMessage),
           });
           const permissionRevocationCarolDataStream = DataStream.fromBytes(permissionRevocationCarol.permissionRevocationBytes);
           const permissionRevocationCarolReply = await dwn.processMessage(

--- a/tests/handlers/protocols-query.spec.ts
+++ b/tests/handlers/protocols-query.spec.ts
@@ -272,7 +272,7 @@ export function testProtocolsQueryHandler(): void {
           // 4. Alice revokes Bob's grant
           const revokeWrite = await PermissionsProtocol.createRevocation({
             signer      : Jws.createSigner(alice),
-            grant       : await PermissionGrant.parse(permissionGrant.dataEncodedMessage),
+            grant       : new PermissionGrant(permissionGrant.dataEncodedMessage),
             dateRevoked : Time.getCurrentTimestamp()
           });
 

--- a/tests/protocols/permission-request.spec.ts
+++ b/tests/protocols/permission-request.spec.ts
@@ -30,7 +30,7 @@ describe('PermissionRequest', () => {
       scope
     });
 
-    const parsedPermissionRequest = await PermissionRequest.parse(permissionRequest.dataEncodedMessage);
+    const parsedPermissionRequest = new PermissionRequest(permissionRequest.dataEncodedMessage);
     expect (parsedPermissionRequest.id).to.equal(permissionRequest.dataEncodedMessage.recordId);
     expect (parsedPermissionRequest.delegated).to.equal(true);
     expect (parsedPermissionRequest.scope).to.deep.equal(scope);

--- a/tests/protocols/permissions.spec.ts
+++ b/tests/protocols/permissions.spec.ts
@@ -51,7 +51,7 @@ describe('PermissionsProtocol', () => {
         }
       });
 
-      const request = await PermissionRequest.parse(permissionRequest.dataEncodedMessage);
+      const request = new PermissionRequest(permissionRequest.dataEncodedMessage);
 
       const scope = await PermissionsProtocol.getScopeFromPermissionRecord(
         alice.did,
@@ -77,7 +77,7 @@ describe('PermissionsProtocol', () => {
         dateExpires : Time.createOffsetTimestamp({ seconds: 100 })
       });
 
-      const grant = await PermissionGrant.parse(grantMessage);
+      const grant = new PermissionGrant(grantMessage);
 
       const scope = await PermissionsProtocol.getScopeFromPermissionRecord(
         alice.did,
@@ -107,7 +107,7 @@ describe('PermissionsProtocol', () => {
       const indexes = await grantRecordsWrite.constructIndexes(true);
       await messageStore.put(alice.did, grantMessage, indexes);
 
-      const grant = await PermissionGrant.parse(grantMessage);
+      const grant = new PermissionGrant(grantMessage);
 
       const revocation = await PermissionsProtocol.createRevocation({
         signer : Jws.createSigner(alice),
@@ -139,7 +139,7 @@ describe('PermissionsProtocol', () => {
       });
 
       // notice the grant is not stored in the message store
-      const grant = await PermissionGrant.parse(grantMessage);
+      const grant = new PermissionGrant(grantMessage);
 
       const revocation = await PermissionsProtocol.createRevocation({
         signer : Jws.createSigner(alice),

--- a/tests/scenarios/messages-query.spec.ts
+++ b/tests/scenarios/messages-query.spec.ts
@@ -400,7 +400,7 @@ export function testMessagesQueryScenarios(): void {
       // revoke permissions for proto1
       const revokeProto1 = await PermissionsProtocol.createRevocation({
         signer : Jws.createSigner(alice),
-        grant  : await PermissionGrant.parse(grantProto1.dataEncodedMessage),
+        grant  : new PermissionGrant(grantProto1.dataEncodedMessage),
       });
       const revokeProto1Response = await dwn.processMessage(
         alice.did,
@@ -412,7 +412,7 @@ export function testMessagesQueryScenarios(): void {
       // revoke permissions for proto2
       const revokeProto2 = await PermissionsProtocol.createRevocation({
         signer : Jws.createSigner(alice),
-        grant  : await PermissionGrant.parse(grantProto2.dataEncodedMessage),
+        grant  : new PermissionGrant(grantProto2.dataEncodedMessage),
       });
       const revokeProto2Response = await dwn.processMessage(
         alice.did,

--- a/tests/scenarios/subscriptions.spec.ts
+++ b/tests/scenarios/subscriptions.spec.ts
@@ -483,7 +483,7 @@ export function testSubscriptionScenarios(): void {
         // revoke permissions for proto1
         const revokeProto1 = await PermissionsProtocol.createRevocation({
           signer : Jws.createSigner(alice),
-          grant  : await PermissionGrant.parse(grantProto1.dataEncodedMessage),
+          grant  : new PermissionGrant(grantProto1.dataEncodedMessage),
         });
         const revokeProto1Response = await dwn.processMessage(
           alice.did,
@@ -495,7 +495,7 @@ export function testSubscriptionScenarios(): void {
         // revoke permissions for proto2
         const revokeProto2 = await PermissionsProtocol.createRevocation({
           signer : Jws.createSigner(alice),
-          grant  : await PermissionGrant.parse(grantProto2.dataEncodedMessage),
+          grant  : new PermissionGrant(grantProto2.dataEncodedMessage),
         });
         const revokeProto2Response = await dwn.processMessage(
           alice.did,


### PR DESCRIPTION
Currently `PermissionGrant` and `PermissionRequest` have an async `parse()` method to instantiate them with a private constructor.

However there is **currently** no async action needed to parse the grant/request. Any objection to removing the `parse()` method in favor of just using the constructor?