### PR TITLE
Add `did:jwk` to default resolvers, remove `did:ion`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2725,9 +2725,9 @@
       "dev": true
     },
     "node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
       "dev": true,
       "dependencies": {
         "bn.js": "^4.11.9",

--- a/src/dwn.ts
+++ b/src/dwn.ts
@@ -29,7 +29,7 @@ import { RecordsSubscribeHandler } from './handlers/records-subscribe.js';
 import { RecordsWriteHandler } from './handlers/records-write.js';
 import { ResumableTaskManager } from './core/resumable-task-manager.js';
 import { StorageController } from './store/storage-controller.js';
-import { DidDht, DidIon, DidKey, DidResolverCacheLevel, UniversalResolver } from '@web5/dids';
+import { DidDht, DidJwk, DidKey, DidResolverCacheLevel, UniversalResolver } from '@web5/dids';
 import { DwnInterfaceName, DwnMethodName } from './enums/dwn-interface-method.js';
 
 export class Dwn {
@@ -126,7 +126,7 @@ export class Dwn {
    */
   public static async create(config: DwnConfig): Promise<Dwn> {
     config.didResolver ??= new UniversalResolver({
-      didResolvers : [DidDht, DidIon, DidKey],
+      didResolvers : [DidDht, DidJwk, DidKey ],
       cache        : new DidResolverCacheLevel({ location: 'RESOLVERCACHE' }),
     });
     config.tenantGate ??= new AllowAllTenantGate();


### PR DESCRIPTION
- Adding `did:jwk` to the default resolvers list
- Removing `did:ion` from the default resolvers list as the TBD `did:ion` gateway is no longer active
- npm audit fix elliptic ECDSA vulns. CVE-2024-42459, CVE-2024-42460, CVE-2024-42461