### PR TITLE
Enforce requiring all read actions (`read`, `query`, `subscribe`)  to exist in a protocol role rule.

### DIFF
--- a/src/core/dwn-error.ts
+++ b/src/core/dwn-error.ts
@@ -91,6 +91,7 @@ export enum DwnErrorCode {
   ProtocolsConfigureInvalidTagSchema = 'ProtocolsConfigureInvalidTagSchema',
   ProtocolsConfigureRecordNestingDepthExceeded = 'ProtocolsConfigureRecordNestingDepthExceeded',
   ProtocolsConfigureRoleDoesNotExistAtGivenPath = 'ProtocolsConfigureRoleDoesNotExistAtGivenPath',
+  ProtocolsConfigureRoleReadActionMissing = 'ProtocolsConfigureRoleReadActionMissing',
   ProtocolsGrantAuthorizationQueryProtocolScopeMismatch = 'ProtocolsGrantAuthorizationQueryProtocolScopeMismatch',
   ProtocolsGrantAuthorizationScopeProtocolMismatch = 'ProtocolsGrantAuthorizationScopeProtocolMismatch',
   ProtocolsQueryUnauthorized = 'ProtocolsQueryUnauthorized',

--- a/src/interfaces/protocols-configure.ts
+++ b/src/interfaces/protocols-configure.ts
@@ -196,6 +196,16 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
             DwnErrorCode.ProtocolsConfigureRoleDoesNotExistAtGivenPath,
             `Role in action ${JSON.stringify(actionRule)} for rule set ${ruleSetProtocolPath} does not exist.`
           );
+        } else {
+          // it is a role record, we ensure that if any of the `can` actions are 'read' type of actions ('read', 'query', 'subscribe'),
+          // that they are all present.
+          const readActions = [ProtocolAction.Read, ProtocolAction.Query, ProtocolAction.Subscribe];
+          if (readActions.find( action => actionRule.can.includes(action)) && !readActions.every(action => actionRule.can.includes(action))) {
+            throw new DwnError(
+              DwnErrorCode.ProtocolsConfigureRoleReadActionMissing,
+              `Role in action ${JSON.stringify(actionRule)} for rule set ${ruleSetProtocolPath} must contain all read actions (${readActions.join(', ')}).`
+            );
+          }
         }
       }
 

--- a/tests/vectors/protocol-definitions/friend-role.json
+++ b/tests/vectors/protocol-definitions/friend-role.json
@@ -22,7 +22,7 @@
         {
           "role": "fan",
           "can": [
-            "read"
+            "read", "query", "subscribe"
           ]
         },
         {

--- a/tests/vectors/protocol-definitions/slack.json
+++ b/tests/vectors/protocol-definitions/slack.json
@@ -57,7 +57,7 @@
         {
           "role": "community/admin",
           "can": [
-            "read"
+            "read", "query", "subscribe"
           ]
         }
       ],
@@ -156,14 +156,16 @@
             "can": [
               "create",
               "update",
+              "read",
               "query",
+              "subscribe",
               "co-delete"
             ]
           },
           {
             "role": "community/gatedChannel/participant",
             "can": [
-              "read"
+              "read", "query", "subscribe"
             ]
           }
         ],
@@ -203,6 +205,8 @@
                 "create",
                 "update",
                 "query",
+                "read",
+                "subscribe",
                 "co-delete"
               ]
             }

--- a/tests/vectors/protocol-definitions/thread-role.json
+++ b/tests/vectors/protocol-definitions/thread-role.json
@@ -17,7 +17,7 @@
         {
           "role": "thread/participant",
           "can": [
-            "read"
+            "read", "query", "subscribe"
           ]
         }
       ],
@@ -31,6 +31,8 @@
             "role": "thread/participant",
             "can": [
               "read",
+              "query",
+              "subscribe",
               "create"
             ]
           }


### PR DESCRIPTION
Currently there are some inconsistencies being able to fetch record data. If a user can only query for something, they are able to get the data if it is under the encodedData size limit, however if it is not they are unable to issue a `RecordsRead` for that record.

This change forces the user to include all 3 "read" actions (read, subscribe, query) when using any one of them in a protocol role-based action rule.